### PR TITLE
plugins: use std::dynamic_pointer_cast rather than boost

### DIFF
--- a/src/gazebo_lidar_plugin.cpp
+++ b/src/gazebo_lidar_plugin.cpp
@@ -60,7 +60,7 @@ void RayPlugin::Load(sensors::SensorPtr _parent, sdf::ElementPtr _sdf)
 {
   // Get then name of the parent sensor
   this->parentSensor =
-    boost::dynamic_pointer_cast<sensors::RaySensor>(_parent);
+    std::dynamic_pointer_cast<sensors::RaySensor>(_parent);
 
   if (!this->parentSensor)
     gzthrow("RayPlugin requires a Ray Sensor as its parent");

--- a/src/gazebo_opticalFlow_plugin.cpp
+++ b/src/gazebo_opticalFlow_plugin.cpp
@@ -56,12 +56,12 @@ void CameraPlugin::Load(sensors::SensorPtr _sensor, sdf::ElementPtr _sdf)
     gzerr << "Invalid sensor pointer.\n";
 
   this->parentSensor =
-    boost::dynamic_pointer_cast<sensors::CameraSensor>(_sensor);
+    std::dynamic_pointer_cast<sensors::CameraSensor>(_sensor);
 
   if (!this->parentSensor)
   {
     gzerr << "CameraPlugin requires a CameraSensor.\n";
-    if (boost::dynamic_pointer_cast<sensors::DepthCameraSensor>(_sensor))
+    if (std::dynamic_pointer_cast<sensors::DepthCameraSensor>(_sensor))
       gzmsg << "It is a depth camera sensor\n";
   }
 


### PR DESCRIPTION
prevents compilation failures like:

```
/Users/liam/code/3dr/px4upstream/Firmware/Tools/sitl_gazebo/src/gazebo_opticalFlow_plugin.cpp:59:5: error: no matching function for call to 'dynamic_pointer_cast'
    boost::dynamic_pointer_cast<sensors::CameraSensor>(_sensor);
    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/local/include/boost/smart_ptr/shared_ptr.hpp:848:42: note: candidate template ignored: could not match 'boost::shared_ptr' against 'std::__1::shared_ptr'
template<class T, class U> shared_ptr<T> dynamic_pointer_cast( shared_ptr<U> const & r ) BOOST_NOEXCEPT
                                         ^
```

which suggests boost::shared_ptr cannot be converted to std::shared_ptr in this case

Compiler is

```
liam@drungus sitl_gazebo (master *)$ c++ --version
Apple LLVM version 7.0.2 (clang-700.1.81)
Target: x86_64-apple-darwin15.3.0
Thread model: posix
```

and boost version is 1.59.0
