### PR TITLE
patched OGRE Paging compile error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ include_directories(
   ${Boost_INCLUDE_DIR}/eigen3
   # Hack to work around pkg_check_modules not setting the OGRE dirs correctly
   /usr/local/include/OGRE
+  /usr/local/include/OGRE/Paging
   )
 
 set(enable_mavlink_interface "true")


### PR DESCRIPTION
fixes the following compile error:

/usr/local/include/OGRE/Terrain/OgreTerrainPaging.h:33:10: fatal error: 
      'OgrePagedWorldSection.h' file not found
# include "OgrePagedWorldSection.h"

```
     ^
```

1 error generated.
