### PR TITLE
cmake: don't show deprecated warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,12 @@ endif()
 pkg_check_modules( protobuf REQUIRED protobuf )
 
 FIND_PACKAGE( Boost 1.40 COMPONENTS system thread REQUIRED )
-add_definitions(-std=c++11)
+
+add_definitions(
+	-std=c++11
+	# Shut up warnings about std::binder1st, std::binder2nd.
+	-Wno-deprecated-declarations
+)
 
 set(GAZEBO_MSG_INCLUDE_DIRS)
 foreach(ITR ${GAZEBO_INCLUDE_DIRS})


### PR DESCRIPTION
This gets rid of the compile warnings for me on Ubuntu 15.10.

```
[ 95%] Linking CXX shared library librotors_gazebo_motor_model.so
[ 95%] Built target rotors_gazebo_motor_model
In file included from /usr/include/eigen3/Eigen/Core:276:0,
                 from /usr/include/eigen3/Eigen/Dense:1,
                 from /home/julianoes/src/Firmware/Tools/sitl_gazebo/include/common.h:22,
                 from /home/julianoes/src/Firmware/Tools/sitl_gazebo/include/gazebo_multirotor_base_plugin.h:29,
                 from /home/julianoes/src/Firmware/Tools/sitl_gazebo/src/gazebo_multirotor_base_plugin.cpp:21:
/usr/include/eigen3/Eigen/src/Core/Functors.h:973:28: warning: ‘template<class _Operation> class std::binder2nd’ is deprecated [-Wdeprecated-declarations]
 struct functor_traits<std::binder2nd<T> >
```
