### PR TITLE
add support for testing multiple autopilots simultaneously in SITL

### DIFF
--- a/include/gazebo_mavlink_interface.h
+++ b/include/gazebo_mavlink_interface.h
@@ -52,6 +52,7 @@
 static const uint8_t mavlink_message_lengths[256] = MAVLINK_MESSAGE_LENGTHS;
 static const uint8_t mavlink_message_crcs[256] = MAVLINK_MESSAGE_CRCS;
 
+static const uint32_t kDefaultMavlinkUdpPort = 14560;
 
 namespace gazebo {
 
@@ -98,7 +99,8 @@ class GazeboMavlinkInterface : public ModelPlugin {
         zero_position_armed{},
         input_index{},
         lat_rad(0.0),
-        lon_rad(0.0)
+        lon_rad(0.0),
+        mavlink_udp_port_(kDefaultMavlinkUdpPort)
         {}
   ~GazeboMavlinkInterface();
 
@@ -195,6 +197,9 @@ class GazeboMavlinkInterface : public ModelPlugin {
   double optflow_ygyro;
   double optflow_zgyro;
   double optflow_distance;
+
+  //mavlink udp port
+  int mavlink_udp_port_;
 
   };
 }

--- a/src/gazebo_controller_interface.cpp
+++ b/src/gazebo_controller_interface.cpp
@@ -53,11 +53,11 @@ void GazeboControllerInterface::Load(physics::ModelPtr _model, sdf::ElementPtr _
   updateConnection_ = event::Events::ConnectWorldUpdateBegin(
       boost::bind(&GazeboControllerInterface::OnUpdate, this, _1));
 
-  cmd_motor_sub_ = node_handle_->Subscribe<mav_msgs::msgs::CommandMotorSpeed>(command_motor_speed_sub_topic_,
+  cmd_motor_sub_ = node_handle_->Subscribe<mav_msgs::msgs::CommandMotorSpeed>("~/" + model_->GetName() + command_motor_speed_sub_topic_,
                                            &GazeboControllerInterface::CommandMotorCallback,
                                            this);
 
-  motor_velocity_reference_pub_ = node_handle_->Advertise<mav_msgs::msgs::CommandMotorSpeed>(motor_velocity_reference_pub_topic_, 1);
+  motor_velocity_reference_pub_ = node_handle_->Advertise<mav_msgs::msgs::CommandMotorSpeed>("~/" + model_->GetName() + motor_velocity_reference_pub_topic_, 1);
 }
 
 // This gets called by the world update start event.

--- a/src/gazebo_imu_plugin.cpp
+++ b/src/gazebo_imu_plugin.cpp
@@ -102,7 +102,7 @@ void GazeboImuPlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf) {
       event::Events::ConnectWorldUpdateBegin(
           boost::bind(&GazeboImuPlugin::OnUpdate, this, _1));
 
-  imu_pub_ = node_handle_->Advertise<sensor_msgs::msgs::Imu>(imu_topic_, 1);
+  imu_pub_ = node_handle_->Advertise<sensor_msgs::msgs::Imu>("~/" + model_->GetName() + imu_topic_, 1);
 
   // Fill imu message.
   // imu_message_.header.frame_id = frame_id_; TODO Add header

--- a/src/gazebo_lidar_plugin.cpp
+++ b/src/gazebo_lidar_plugin.cpp
@@ -96,6 +96,7 @@ void RayPlugin::Load(sensors::SensorPtr _parent, sdf::ElementPtr _sdf)
   node_handle_ = transport::NodePtr(new transport::Node());
   node_handle_->Init(namespace_);
 
+  // TODO(tfoote) Find a way to namespace this within the model to allow multiple models
   lidar_pub_ = node_handle_->Advertise<lidar_msgs::msgs::lidar>("/lidar", 10);
 }
 
@@ -115,4 +116,3 @@ void RayPlugin::OnNewLaserScans()
 
   lidar_pub_->Publish(lidar_message);
 }
-

--- a/src/gazebo_mavlink_interface.cpp
+++ b/src/gazebo_mavlink_interface.cpp
@@ -158,12 +158,12 @@ void GazeboMavlinkInterface::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf
       boost::bind(&GazeboMavlinkInterface::OnUpdate, this, _1));
 
   // Subscriber to IMU sensor_msgs::Imu Message and SITL message
-  imu_sub_ = node_handle_->Subscribe(imu_sub_topic_, &GazeboMavlinkInterface::ImuCallback, this);
-  lidar_sub_ = node_handle_->Subscribe(lidar_sub_topic_, &GazeboMavlinkInterface::LidarCallback, this);
-  opticalFlow_sub_ = node_handle_->Subscribe(opticalFlow_sub_topic_, &GazeboMavlinkInterface::OpticalFlowCallback, this);
+  imu_sub_ = node_handle_->Subscribe("~/" + model_->GetName() + imu_sub_topic_, &GazeboMavlinkInterface::ImuCallback, this);
+  lidar_sub_ = node_handle_->Subscribe("~/" + model_->GetName() + lidar_sub_topic_, &GazeboMavlinkInterface::LidarCallback, this);
+  opticalFlow_sub_ = node_handle_->Subscribe("~/" + model_->GetName() + opticalFlow_sub_topic_, &GazeboMavlinkInterface::OpticalFlowCallback, this);
   
   // Publish gazebo's motor_speed message
-  motor_velocity_reference_pub_ = node_handle_->Advertise<mav_msgs::msgs::CommandMotorSpeed>(motor_velocity_reference_pub_topic_, 1);
+  motor_velocity_reference_pub_ = node_handle_->Advertise<mav_msgs::msgs::CommandMotorSpeed>("~/" + model_->GetName() + motor_velocity_reference_pub_topic_, 1);
 
   _rotor_count = 5;
   last_time_ = world_->GetSimTime();

--- a/src/gazebo_mavlink_interface.cpp
+++ b/src/gazebo_mavlink_interface.cpp
@@ -22,8 +22,6 @@
 #include "gazebo_mavlink_interface.h"
 #include "geo_mag_declination.h"
 
-#define UDP_PORT 14560
-
 namespace gazebo {
 
 GZ_REGISTER_MODEL_PLUGIN(GazeboMavlinkInterface);
@@ -186,7 +184,9 @@ void GazeboMavlinkInterface::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf
 
   //Create socket
   // udp socket data
-  const int _port = UDP_PORT;
+  if (_sdf->HasElement("mavlink_udp_port")) {
+    mavlink_udp_port_ = _sdf->GetElement("mavlink_udp_port")->Get<int>();
+  }
 
   // try to setup udp socket for communcation with simulator
   if ((_fd = socket(AF_INET, SOCK_DGRAM, 0)) < 0) {
@@ -207,8 +207,7 @@ void GazeboMavlinkInterface::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf
 
   _srcaddr.sin_family = AF_INET;
   _srcaddr.sin_addr.s_addr = htonl(INADDR_ANY);
-  _srcaddr.sin_port = htons(UDP_PORT);
-
+  _srcaddr.sin_port = htons(mavlink_udp_port_);
   _addrlen = sizeof(_srcaddr);
 
   fds[0].fd = _fd;

--- a/src/gazebo_motor_model.cpp
+++ b/src/gazebo_motor_model.cpp
@@ -99,7 +99,7 @@ void GazeboMotorModel::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf) {
 
   /*
   std::cout << "Subscribing to: " << motor_test_sub_topic_ << std::endl;
-  motor_sub_ = node_handle_->Subscribe<mav_msgs::msgs::MotorSpeed>(motor_test_sub_topic_, &GazeboMotorModel::testProto, this);
+  motor_sub_ = node_handle_->Subscribe<mav_msgs::msgs::MotorSpeed>("~/" + model_->GetName() + motor_test_sub_topic_, &GazeboMotorModel::testProto, this);
   */
 
   // Set the maximumForce on the joint. This is deprecated from V5 on, and the joint won't move.
@@ -110,8 +110,8 @@ void GazeboMotorModel::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf) {
   // simulation iteration.
   updateConnection_ = event::Events::ConnectWorldUpdateBegin(boost::bind(&GazeboMotorModel::OnUpdate, this, _1));
 
-  command_sub_ = node_handle_->Subscribe<mav_msgs::msgs::CommandMotorSpeed>(command_sub_topic_, &GazeboMotorModel::VelocityCallback, this);
-  motor_velocity_pub_ = node_handle_->Advertise<std_msgs::msgs::Float>(motor_speed_pub_topic_, 1);
+  command_sub_ = node_handle_->Subscribe<mav_msgs::msgs::CommandMotorSpeed>("~/" + model_->GetName() + command_sub_topic_, &GazeboMotorModel::VelocityCallback, this);
+  motor_velocity_pub_ = node_handle_->Advertise<std_msgs::msgs::Float>("~/" + model_->GetName() + motor_speed_pub_topic_, 1);
 
   // Create the first order filter.
   rotor_velocity_filter_.reset(new FirstOrderFilter<double>(time_constant_up_, time_constant_down_, ref_motor_rot_vel_));
@@ -193,4 +193,3 @@ void GazeboMotorModel::UpdateForcesAndMoments() {
 
 GZ_REGISTER_MODEL_PLUGIN(GazeboMotorModel);
 }
-

--- a/src/gazebo_multirotor_base_plugin.cpp
+++ b/src/gazebo_multirotor_base_plugin.cpp
@@ -42,7 +42,7 @@ void GazeboMultirotorBasePlugin::Load(physics::ModelPtr _model, sdf::ElementPtr 
 
   node_handle_ = transport::NodePtr(new transport::Node());
   node_handle_->Init(namespace_);
-  motor_pub_ = node_handle_->Advertise<mav_msgs::msgs::MotorSpeed>(motor_pub_topic_, 1);
+  motor_pub_ = node_handle_->Advertise<mav_msgs::msgs::MotorSpeed>("~/" + model_->GetName() + motor_pub_topic_, 1);
 
 
   frame_id_ = link_name_;

--- a/src/gazebo_opticalFlow_plugin.cpp
+++ b/src/gazebo_opticalFlow_plugin.cpp
@@ -106,6 +106,7 @@ void OpticalFlowPlugin::Load(sensors::SensorPtr _sensor, sdf::ElementPtr _sdf)
 
   node_handle_ = transport::NodePtr(new transport::Node());
   node_handle_->Init(namespace_);
+  // TODO(tfoote) Find a way to namespace this within the model to allow multiple models
   opticalFlow_pub_ = node_handle_->Advertise<opticalFlow_msgs::msgs::opticalFlow>(topicName, 10);
 
 


### PR DESCRIPTION
This changes the mavlink udp port to be optionally parameterized in the sdf. This allows for multiple instances of the plugin to be loaded and not be on the same channel.

To use this, the models need this added to their sdf in the `<plugin name='mavlink_interface' filename='librotors_gazebo_mavlink_interface.so'>` section:

```
<mavlink_udp_port>14660</mavlink_udp_port>
<mavlink_udp_port_2>14656</mavlink_udp_port_2>
```

For anyone not setting those parameters it should have no effect. The default values are moved to static constants defined in the header instead of `#define` in the source. 
