### PR TITLE
GStreamer camera plugin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ include(GNUInstallDirs)
 
 # Add search directory for CMake on OS X
 list(APPEND CMAKE_MODULE_PATH /usr/local/share/cmake/Modules)
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 
 ## System dependencies are found with CMake's conventions
 find_package(PkgConfig REQUIRED)
@@ -24,6 +25,7 @@ find_package(gazebo REQUIRED)
 find_program(px4 REQUIRED)
 find_package(OpenCV REQUIRED)
 find_package(Boost REQUIRED COMPONENTS system thread timer)
+find_package(GStreamer)
 
 # see if catkin was invoked to build this
 if (CATKIN_DEVEL_PREFIX)
@@ -109,6 +111,7 @@ include_directories(
   # Workaround for OGRE include dirs on Mac OS
   /usr/local/include/OGRE
   /usr/local/include/OGRE/Paging
+  ${GSTREAMER_INCLUDE_DIRS}
   )
 
 link_libraries(
@@ -118,6 +121,7 @@ link_libraries(
   ${Boost_SYSTEM_LIBRARY_RELEASE}
   ${Boost_THREAD_LIBRARY_RELEASE}
   ${Boost_TIMER_LIBRARY_RELEASE}
+  ${GSTREAMER_LIBRARIES}
   )
 
 link_directories(
@@ -188,6 +192,15 @@ set(plugins
   gazebo_lidar_plugin
   rotors_gazebo_mavlink_interface
   )
+
+if (GSTREAMER_FOUND)
+  add_library(gazebo_gst_camera_plugin SHARED src/gazebo_gst_camera_plugin.cpp)
+  set(plugins
+    ${plugins}
+    gazebo_gst_camera_plugin
+  )
+  message(STATUS "Found GStreamer: adding gst_camera_plugin")
+endif()
 
 # Linux is not consistent with plugin availability, even on Gazebo 7
 #if("${GAZEBO_VERSION}" VERSION_LESS "7.0")

--- a/README.md
+++ b/README.md
@@ -74,6 +74,13 @@ Now build the gazebo plugins by typing:
 make
 ```
 
+### GStreamer Support
+If you want support for the GStreamer camera plugin, make sure to install
+GStreamer before running `cmake`. Eg. on Ubuntu with:
+```
+sudo apt-get install gstreamer1.0-* libgstreamer1.0-*
+```
+
 ## Install
 
 If you wish the libraries and models to be usable anywhere on your system without

--- a/cmake/FindGStreamer.cmake
+++ b/cmake/FindGStreamer.cmake
@@ -1,0 +1,131 @@
+# - Try to find GStreamer and its plugins
+# Once done, this will define
+#
+#  GSTREAMER_FOUND - system has GStreamer
+#  GSTREAMER_INCLUDE_DIRS - the GStreamer include directories
+#  GSTREAMER_LIBRARIES - link these to use GStreamer
+#
+# Additionally, gstreamer-base is always looked for and required, and
+# the following related variables are defined:
+#
+#  GSTREAMER_BASE_INCLUDE_DIRS - gstreamer-base's include directory
+#  GSTREAMER_BASE_LIBRARIES - link to these to use gstreamer-base
+#
+# Optionally, the COMPONENTS keyword can be passed to find_package()
+# and GStreamer plugins can be looked for.  Currently, the following
+# plugins can be searched, and they define the following variables if
+# found:
+#
+#  gstreamer-app:        GSTREAMER_APP_INCLUDE_DIRS and GSTREAMER_APP_LIBRARIES
+#  gstreamer-audio:      GSTREAMER_AUDIO_INCLUDE_DIRS and GSTREAMER_AUDIO_LIBRARIES
+#  gstreamer-fft:        GSTREAMER_FFT_INCLUDE_DIRS and GSTREAMER_FFT_LIBRARIES
+#  gstreamer-gl:         GSTREAMER_GL_INCLUDE_DIRS and GSTREAMER_GL_LIBRARIES
+#  gstreamer-mpegts:     GSTREAMER_MPEGTS_INCLUDE_DIRS and GSTREAMER_MPEGTS_LIBRARIES
+#  gstreamer-pbutils:    GSTREAMER_PBUTILS_INCLUDE_DIRS and GSTREAMER_PBUTILS_LIBRARIES
+#  gstreamer-tag:        GSTREAMER_TAG_INCLUDE_DIRS and GSTREAMER_TAG_LIBRARIES
+#  gstreamer-video:      GSTREAMER_VIDEO_INCLUDE_DIRS and GSTREAMER_VIDEO_LIBRARIES
+#
+# Copyright (C) 2012 Raphael Kubo da Costa <rakuco@webkit.org>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER AND ITS CONTRIBUTORS ``AS
+# IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR ITS
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+# OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+# OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+find_package(PkgConfig)
+
+# Helper macro to find a GStreamer plugin (or GStreamer itself)
+#   _component_prefix is prepended to the _INCLUDE_DIRS and _LIBRARIES variables (eg. "GSTREAMER_AUDIO")
+#   _pkgconfig_name is the component's pkg-config name (eg. "gstreamer-1.0", or "gstreamer-video-1.0").
+#   _library is the component's library name (eg. "gstreamer-1.0" or "gstvideo-1.0")
+macro(FIND_GSTREAMER_COMPONENT _component_prefix _pkgconfig_name _library)
+
+    string(REGEX MATCH "(.*)>=(.*)" _dummy "${_pkgconfig_name}")
+    if ("${CMAKE_MATCH_2}" STREQUAL "")
+        pkg_check_modules(PC_${_component_prefix} "${_pkgconfig_name} >= ${GStreamer_FIND_VERSION}")
+    else ()
+        pkg_check_modules(PC_${_component_prefix} ${_pkgconfig_name})
+    endif ()
+    set(${_component_prefix}_INCLUDE_DIRS ${PC_${_component_prefix}_INCLUDE_DIRS})
+
+    find_library(${_component_prefix}_LIBRARIES
+        NAMES ${_library}
+        HINTS ${PC_${_component_prefix}_LIBRARY_DIRS} ${PC_${_component_prefix}_LIBDIR}
+    )
+endmacro()
+
+# ------------------------
+# 1. Find GStreamer itself
+# ------------------------
+
+# 1.1. Find headers and libraries
+FIND_GSTREAMER_COMPONENT(GSTREAMER gstreamer-1.0 gstreamer-1.0)
+FIND_GSTREAMER_COMPONENT(GSTREAMER_BASE gstreamer-base-1.0 gstbase-1.0)
+
+# -------------------------
+# 2. Find GStreamer plugins
+# -------------------------
+
+#FIND_GSTREAMER_COMPONENT(GSTREAMER_APP gstreamer-app-1.0 gstapp-1.0)
+#FIND_GSTREAMER_COMPONENT(GSTREAMER_AUDIO gstreamer-audio-1.0 gstaudio-1.0)
+#FIND_GSTREAMER_COMPONENT(GSTREAMER_FFT gstreamer-fft-1.0 gstfft-1.0)
+#FIND_GSTREAMER_COMPONENT(GSTREAMER_GL gstreamer-gl-1.0>=1.8.0 gstgl-1.0)
+#FIND_GSTREAMER_COMPONENT(GSTREAMER_MPEGTS gstreamer-mpegts-1.0>=1.4.0 gstmpegts-1.0)
+#FIND_GSTREAMER_COMPONENT(GSTREAMER_PBUTILS gstreamer-pbutils-1.0 gstpbutils-1.0)
+#FIND_GSTREAMER_COMPONENT(GSTREAMER_TAG gstreamer-tag-1.0 gsttag-1.0)
+#FIND_GSTREAMER_COMPONENT(GSTREAMER_VIDEO gstreamer-video-1.0 gstvideo-1.0)
+
+# ------------------------------------------------
+# 3. Process the COMPONENTS passed to FIND_PACKAGE
+# ------------------------------------------------
+set(_GSTREAMER_REQUIRED_VARS GSTREAMER_INCLUDE_DIRS GSTREAMER_LIBRARIES GSTREAMER_VERSION GSTREAMER_BASE_INCLUDE_DIRS GSTREAMER_BASE_LIBRARIES)
+
+foreach (_component ${GStreamer_FIND_COMPONENTS})
+    set(_gst_component "GSTREAMER_${_component}")
+    string(TOUPPER ${_gst_component} _UPPER_NAME)
+
+    list(APPEND _GSTREAMER_REQUIRED_VARS ${_UPPER_NAME}_INCLUDE_DIRS ${_UPPER_NAME}_LIBRARIES)
+endforeach ()
+
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(GStreamer REQUIRED_VARS _GSTREAMER_REQUIRED_VARS
+                                            VERSION_VAR   GSTREAMER_VERSION)
+
+mark_as_advanced(
+    GSTREAMER_APP_INCLUDE_DIRS
+    GSTREAMER_APP_LIBRARIES
+    GSTREAMER_AUDIO_INCLUDE_DIRS
+    GSTREAMER_AUDIO_LIBRARIES
+    GSTREAMER_BASE_INCLUDE_DIRS
+    GSTREAMER_BASE_LIBRARIES
+    GSTREAMER_FFT_INCLUDE_DIRS
+    GSTREAMER_FFT_LIBRARIES
+    GSTREAMER_GL_INCLUDE_DIRS
+    GSTREAMER_GL_LIBRARIES
+    GSTREAMER_INCLUDE_DIRS
+    GSTREAMER_LIBRARIES
+    GSTREAMER_MPEGTS_INCLUDE_DIRS
+    GSTREAMER_MPEGTS_LIBRARIES
+    GSTREAMER_PBUTILS_INCLUDE_DIRS
+    GSTREAMER_PBUTILS_LIBRARIES
+    GSTREAMER_TAG_INCLUDE_DIRS
+    GSTREAMER_TAG_LIBRARIES
+    GSTREAMER_VIDEO_INCLUDE_DIRS
+    GSTREAMER_VIDEO_LIBRARIES
+)

--- a/include/gazebo_gst_camera_plugin.h
+++ b/include/gazebo_gst_camera_plugin.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2012-2016 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+#pragma once
+
+#include <string>
+#include <mutex>
+
+#include "gazebo/common/Plugin.hh"
+#include "gazebo/sensors/CameraSensor.hh"
+#include "gazebo/gazebo.hh"
+#include "gazebo/common/common.hh"
+#include "gazebo/rendering/Camera.hh"
+#include "gazebo/util/system.hh"
+#include "gazebo/transport/transport.hh"
+#include "gazebo/msgs/msgs.hh"
+
+#include <gst/gst.h>
+
+namespace gazebo
+{
+/**
+ * @class GstCameraPlugin
+ * A Gazebo plugin that can be attached to a camera and then streams the video data using gstreamer.
+ * It streams to a configurable UDP port, default is 5600.
+ *
+ * Connect to the stream via command line with:
+ * gst-launch-1.0  -v udpsrc port=5600 caps='application/x-rtp, media=(string)video, clock-rate=(int)90000, encoding-name=(string)H264' \
+ *  ! rtph264depay ! avdec_h264 ! videoconvert ! autovideosink fps-update-interval=1000 sync=false
+ */
+class GAZEBO_VISIBLE GstCameraPlugin : public SensorPlugin
+{
+  public: GstCameraPlugin();
+
+  public: virtual ~GstCameraPlugin();
+
+  public: virtual void Load(sensors::SensorPtr sensor, sdf::ElementPtr sdf);
+
+  public: virtual void OnNewFrame(const unsigned char *image,
+		unsigned int width, unsigned int height,
+		unsigned int depth, const std::string &format);
+
+  public: void startGstThread();
+  public: void gstCallback(GstElement *appsrc);
+
+  protected: unsigned int width, height, depth;
+  float rate;
+  protected: std::string format;
+
+  protected: int udpPort;
+
+  protected: sensors::CameraSensorPtr parentSensor;
+  protected: rendering::CameraPtr camera;
+
+  private: event::ConnectionPtr newFrameConnection;
+
+  private: transport::NodePtr node_handle_;
+  private: std::string namespace_;
+  private: const std::string topicName = "gst_video";
+
+  GstBuffer *frameBuffer;
+  std::mutex frameBufferMutex;
+  GMainLoop *mainLoop;
+  GstClockTime gstTimestamp;
+
+};
+
+} /* namespace gazebo */

--- a/models/typhoon_h480/typhoon_h480.sdf
+++ b/models/typhoon_h480/typhoon_h480.sdf
@@ -388,6 +388,7 @@
         <camera>
           <horizontal_fov>2.0</horizontal_fov>
           <image>
+            <format>R8G8B8</format>
             <width>640</width>
             <height>480</height>
           </image>
@@ -413,6 +414,14 @@
           <distortionK3>0.0</distortionK3>
           <distortionT1>0.0</distortionT1>
           <distortionT2>0.0</distortionT2>
+        </plugin>
+        -->
+        <!-- GStreamer camera plugin (needs a lot of CPU! Consider lowering the
+             camera image size when enabling) -->
+        <!--
+        <plugin name="GstCameraPlugin" filename="libgazebo_gst_camera_plugin.so">
+            <robotNamespace></robotNamespace>
+            <udpPort>5600</udpPort>
         </plugin>
         -->
       </sensor>

--- a/src/gazebo_gst_camera_plugin.cpp
+++ b/src/gazebo_gst_camera_plugin.cpp
@@ -1,0 +1,291 @@
+/*
+ * Copyright (C) 2012-2016 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+#ifdef _WIN32
+  // Ensure that Winsock2.h is included before Windows.h, which can get
+  // pulled in by anybody (e.g., Boost).
+#include <Winsock2.h>
+#endif
+
+#include "gazebo/sensors/DepthCameraSensor.hh"
+#include "gazebo_gst_camera_plugin.h"
+
+#include <math.h>
+#include <string>
+#include <iostream>
+#include <thread>
+#include <time.h>
+
+using namespace std;
+using namespace gazebo;
+
+GZ_REGISTER_SENSOR_PLUGIN(GstCameraPlugin)
+
+
+static void cb_need_data(GstElement *appsrc, guint unused_size, gpointer user_data) {
+  GstCameraPlugin *plugin = (GstCameraPlugin*)user_data;
+  plugin->gstCallback(appsrc);
+}
+
+void GstCameraPlugin::gstCallback(GstElement *appsrc) {
+
+  frameBufferMutex.lock();
+
+  while (!frameBuffer) {
+	/* can happen if not initialized yet */
+    frameBufferMutex.unlock();
+    usleep(10000);
+    frameBufferMutex.lock();
+  }
+
+  GST_BUFFER_PTS(frameBuffer) = gstTimestamp;
+  GST_BUFFER_DURATION(frameBuffer) = gst_util_uint64_scale_int (1, GST_SECOND, (int)rate);
+  gstTimestamp += GST_BUFFER_DURATION(frameBuffer);
+
+  GstFlowReturn ret;
+  g_signal_emit_by_name(appsrc, "push-buffer", frameBuffer, &ret);
+
+  frameBufferMutex.unlock();
+
+  if (ret != GST_FLOW_OK) {
+    /* something wrong, stop pushing */
+	gzerr << "g_signal_emit_by_name failed" << endl;
+    g_main_loop_quit(mainLoop);
+  }
+}
+
+static void* start_thread(void* param) {
+  GstCameraPlugin* plugin = (GstCameraPlugin*)param;
+  plugin->startGstThread();
+  return nullptr;
+}
+
+void GstCameraPlugin::startGstThread() {
+
+  gst_init(0, 0);
+
+  mainLoop = g_main_loop_new(NULL, FALSE);
+  if (!mainLoop) {
+    gzerr << "Create loop failed. \n";
+    return;
+  }
+
+  GstElement* pipeline = gst_pipeline_new("sender");
+  if (!pipeline) {
+    gzerr << "ERR: Create pipeline failed. \n";
+    return;
+  }
+
+  GstElement* dataSrc = gst_element_factory_make("appsrc", "AppSrc");
+  GstElement* testSrc = gst_element_factory_make("videotestsrc", "FileSrc");
+  GstElement* conv  = gst_element_factory_make("videoconvert", "Convert");
+  GstElement* encoder = gst_element_factory_make("x264enc", "AvcEncoder");
+  GstElement* parser  = gst_element_factory_make("h264parse", "Parser");
+  GstElement* payload = gst_element_factory_make("rtph264pay", "PayLoad");
+  GstElement* sink  = gst_element_factory_make("udpsink", "UdpSink");
+  if (!dataSrc || !testSrc || !conv || !encoder || !parser || !payload || !sink) {
+    gzerr << "ERR: Create elements failed. \n";
+    return;
+  }
+
+// gzerr <<"width"<< this->width<<"\n";
+// gzerr <<"height"<< this->height<<"\n";
+// gzerr <<"rate"<< this->rate<<"\n";
+
+  // Config src
+  g_object_set(G_OBJECT(dataSrc), "caps",
+      gst_caps_new_simple ("video/x-raw",
+      "format", G_TYPE_STRING, "RGB",
+      "width", G_TYPE_INT, this->width,
+      "height", G_TYPE_INT, this->height,
+      "framerate", GST_TYPE_FRACTION, (unsigned int)this->rate, 1,
+      NULL),
+      "is-live", TRUE,
+      NULL);
+
+  // Config encoder
+  g_object_set(G_OBJECT(encoder), "bitrate", 800, NULL);
+  g_object_set(G_OBJECT(encoder), "speed-preset", 2, NULL); //lower = faster, 6=medium
+  //g_object_set(G_OBJECT(encoder), "tune", "zerolatency", NULL);
+  //g_object_set(G_OBJECT(encoder), "low-latency", 1, NULL);
+  //g_object_set(G_OBJECT(encoder), "control-rate", 2, NULL);
+
+  // Config payload
+  g_object_set(G_OBJECT(payload), "config-interval", 1, NULL);
+
+  // Config udpsink
+  g_object_set(G_OBJECT(sink), "host", "127.0.0.1", NULL);
+  g_object_set(G_OBJECT(sink), "port", this->udpPort, NULL);
+  //g_object_set(G_OBJECT(sink), "sync", false, NULL);
+  //g_object_set(G_OBJECT(sink), "async", false, NULL);
+
+  // Connect all elements to pipeline
+  gst_bin_add_many(GST_BIN(pipeline), dataSrc, conv, encoder, parser, payload, sink, NULL);
+
+  // Link all elements
+  if (gst_element_link_many(dataSrc, conv, encoder, parser, payload, sink, NULL) != TRUE) {
+    gzerr << "ERR: Link all the elements failed. \n";
+    return;
+  }
+
+  // Set up appsrc
+  g_object_set(G_OBJECT(dataSrc), "stream-type", 0, "format", GST_FORMAT_TIME, NULL);
+  g_signal_connect(dataSrc, "need-data", G_CALLBACK(cb_need_data), this);
+
+  // Start
+  gst_element_set_state(pipeline, GST_STATE_PLAYING);
+  g_main_loop_run(mainLoop);
+
+  // Clean up
+  gst_element_set_state(pipeline, GST_STATE_NULL);
+  gst_object_unref(GST_OBJECT(pipeline));
+  g_main_loop_unref(mainLoop);
+  mainLoop = nullptr;
+
+}
+
+/////////////////////////////////////////////////
+GstCameraPlugin::GstCameraPlugin()
+: SensorPlugin(), width(0), height(0), depth(0), frameBuffer(nullptr), mainLoop(nullptr),
+  gstTimestamp(0)
+{
+}
+
+/////////////////////////////////////////////////
+GstCameraPlugin::~GstCameraPlugin()
+{
+  this->parentSensor.reset();
+  this->camera.reset();
+  if (mainLoop) {
+    g_main_loop_quit(mainLoop);
+  }
+  std::lock_guard<std::mutex> guard(frameBufferMutex);
+  if (frameBuffer) {
+	  gst_buffer_unref(frameBuffer);
+	  frameBuffer = nullptr;
+  }
+}
+
+/////////////////////////////////////////////////
+void GstCameraPlugin::Load(sensors::SensorPtr sensor, sdf::ElementPtr sdf)
+{
+  if (!sensor)
+    gzerr << "Invalid sensor pointer.\n";
+
+  this->parentSensor =
+#if GAZEBO_MAJOR_VERSION >= 7
+    std::dynamic_pointer_cast<sensors::CameraSensor>(sensor);
+#else
+    boost::dynamic_pointer_cast<sensors::CameraSensor>(sensor);
+#endif
+
+  if (!this->parentSensor)
+  {
+    gzerr << "GstCameraPlugin requires a CameraSensor.\n";
+#if GAZEBO_MAJOR_VERSION >= 7
+    if (std::dynamic_pointer_cast<sensors::DepthCameraSensor>(sensor))
+#else
+    if (boost::dynamic_pointer_cast<sensors::DepthCameraSensor>(sensor))
+#endif
+      gzmsg << "It is a depth camera sensor\n";
+  }
+
+#if GAZEBO_MAJOR_VERSION >= 7
+  this->camera = this->parentSensor->Camera();
+#else
+  this->camera = this->parentSensor->GetCamera();
+#endif
+
+  if (!this->parentSensor)
+  {
+    gzerr << "GstCameraPlugin not attached to a camera sensor\n";
+    return;
+  }
+
+#if GAZEBO_MAJOR_VERSION >= 7
+  this->width = this->camera->ImageWidth();
+  this->height = this->camera->ImageHeight();
+  this->depth = this->camera->ImageDepth();
+  this->format = this->camera->ImageFormat();
+  this->rate = this->camera->RenderRate();
+#else
+  this->width = this->camera->GetImageWidth();
+  this->height = this->camera->GetImageHeight();
+  this->depth = this->camera->GetImageDepth();
+  this->format = this->camera->GetImageFormat();
+  this->rate = this->camera->GetRenderRate();
+#endif
+
+ if (!isfinite(this->rate)) {
+   this->rate =  60.0;
+ }
+
+  if (sdf->HasElement("robotNamespace"))
+    namespace_ = sdf->GetElement("robotNamespace")->Get<std::string>();
+  else
+    gzwarn << "[gazebo_gst_camera_plugin] Please specify a robotNamespace.\n";
+
+  this->udpPort = 5600;
+  if (sdf->HasElement("udpPort")) {
+	this->udpPort = sdf->GetElement("udpPort")->Get<int>();
+  }
+
+  node_handle_ = transport::NodePtr(new transport::Node());
+  node_handle_->Init(namespace_);
+
+
+  this->newFrameConnection = this->camera->ConnectNewImageFrame(
+      boost::bind(&GstCameraPlugin::OnNewFrame, this, _1, this->width, this->height, this->depth, this->format));
+
+  this->parentSensor->SetActive(true);
+
+  /* start the gstreamer event loop */
+  pthread_t threadId;
+  pthread_create(&threadId, NULL, start_thread, this);
+}
+
+/////////////////////////////////////////////////
+void GstCameraPlugin::OnNewFrame(const unsigned char * image,
+                              unsigned int width,
+                              unsigned int height,
+                              unsigned int depth,
+                              const std::string &format)
+{
+
+#if GAZEBO_MAJOR_VERSION >= 7
+  image = this->camera->ImageData(0);
+#else
+  image = this->camera->GetImageData(0);
+#endif
+
+  std::lock_guard<std::mutex> guard(frameBufferMutex);
+
+  if (frameBuffer) {
+	gst_buffer_unref(frameBuffer);
+  }
+
+  // Alloc buffer
+  guint size = width * height * 3;
+  frameBuffer = gst_buffer_new_allocate(NULL, size, NULL);
+
+  GstMapInfo mapInfo;
+  if (gst_buffer_map(frameBuffer, &mapInfo, GST_MAP_WRITE)) {
+    memcpy(mapInfo.data, image, size);
+    gst_buffer_unmap(frameBuffer, &mapInfo);
+  } else {
+	  gzerr << "gst_buffer_map failed"<<endl;
+  }
+}


### PR DESCRIPTION
This adds a GStreamer camera plugin, so that for example the gimbal camera can be viewed with QGC.
Some remarks:
- gstreamer is optional, if not found, the plugin will not be built
- I added the plugin to the typhoon, but commented it, because it needs a lot of CPU and I don't think we need it enabled all the time (especially since gazebo also has a topic viewer)
