### PR TITLE
Readme update for Mac OS, Linux install

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is a flight simulator for multirotors, VTOL and fixed wing. It uses the mot
 
 ## Install Gazebo Simulator
 
-Follow instructions on the [official site](http://gazebosim.org/tutorials?cat=install) to install Gazebo. Mac OS users should install Gazebo 7, Linux users PGazebo 6. Failing to install the right version can render the simulation inoperational.
+Follow instructions on the [official site](http://gazebosim.org/tutorials?cat=install) to install Gazebo. Mac OS and Linux users should install Gazebo 7.
 
 
 ## Protobuf
@@ -16,7 +16,7 @@ Install the protobuf library, which is used as interface to Gazebo.
 ### Ubuntu Linux
 
 ```bash
-sudo apt-get install libprotobuf-dev libprotoc-dev protobuf-compiler libeigen3-dev libgazebo6-dev
+sudo apt-get install libprotobuf-dev libprotoc-dev protobuf-compiler libeigen3-dev gazebo7 libgazebo7-dev
 ```
 
 ### Mac OS

--- a/README.md
+++ b/README.md
@@ -22,8 +22,15 @@ sudo apt-get install libprotobuf-dev libprotoc-dev protobuf-compiler libeigen3-d
 ### Mac OS
 
 ```bash
-brew install graphviz sdformat3 protobuf eigen opencv
+brew install graphviz sdformat3 eigen opencv
 brew install gazebo7
+```
+
+An older version of protobuf (`< 3.0.0`) is required on Mac OS:
+
+```bash
+brew tap homebrew/versions
+brew install homebrew/versions/protobuf260
 ```
 
 ## Build Gazebo Plugins (all operating systems)


### PR DESCRIPTION
This contains two changes for the README:
- Linux has been set on Gazebo7 for a while now, see https://github.com/PX4/Devguide/pull/17.
- An older protobuf version is needed on Mac, see https://github.com/PX4/Devguide/pull/45.
