### PR TITLE
Fix Mac build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,10 @@ endforeach()
 find_package(Protobuf REQUIRED)
 pkg_check_modules(PROTOBUF protobuf)
 
+if ("${PROTOBUF_VERSION}" VERSION_LESS "2.5.0")
+  message(FATAL_ERROR "protobuf version: ${PROTOBUF_VERSION} not compatible, must be >= 2.5.0")
+endif()
+
 if("${GAZEBO_VERSION}" VERSION_LESS "6.0")
   message(FATAL_ERROR "You need at least Gazebo 6.0. Your version: ${GAZEBO_VERSION}")
 else()
@@ -75,10 +79,7 @@ if(NOT EIGEN3_FOUND)
 else()
   set(EIGEN3_INCLUDE_DIRS ${EIGEN3_INCLUDE_DIR})
 endif()
-if (NOT "${PROTOBUF_VERSION}" VERSION_LESS "3.0.0" OR
-  "${PROTOBUF_VERSION}" VERSION_LESS "2.5.0")
-  message(FATAL_ERROR "protobuf version: ${PROTOBUF_VERSION} not compatible, must be >= 2.5.0 and < 3.0.0")
-endif()
+
 find_package(Boost 1.40 COMPONENTS system thread timer REQUIRED )
 
 ###########

--- a/src/flow_settings.c
+++ b/src/flow_settings.c
@@ -38,8 +38,6 @@
 enum global_param_id_t global_param_id;
 struct global_struct global_data;
 
-// FIXME: this lead to linking errors
-//extern uint8_t debug_int_message_buffer(const char* string, int32_t num);
 
 /**
  * @brief reset all parameters to default
@@ -230,12 +228,8 @@ void set_sensor_position_settings(uint8_t sensor_position)
 			break;
 
 		default:
-			// FIXME: this lead to linking errors
-			//debug_int_message_buffer("Unused sensor position:", sensor_position);
 			return;
 	}
 
-	// FIXME: this lead to linking errors
-	//debug_int_message_buffer("Set sensor position:", sensor_position);
 	return;
 }

--- a/src/flow_settings.c
+++ b/src/flow_settings.c
@@ -38,7 +38,8 @@
 enum global_param_id_t global_param_id;
 struct global_struct global_data;
 
-extern uint8_t debug_int_message_buffer(const char* string, int32_t num);
+// FIXME: this lead to linking errors
+//extern uint8_t debug_int_message_buffer(const char* string, int32_t num);
 
 /**
  * @brief reset all parameters to default
@@ -229,10 +230,12 @@ void set_sensor_position_settings(uint8_t sensor_position)
 			break;
 
 		default:
-			debug_int_message_buffer("Unused sensor position:", sensor_position);
+			// FIXME: this lead to linking errors
+			//debug_int_message_buffer("Unused sensor position:", sensor_position);
 			return;
 	}
 
-	debug_int_message_buffer("Set sensor position:", sensor_position);
+	// FIXME: this lead to linking errors
+	//debug_int_message_buffer("Set sensor position:", sensor_position);
 	return;
 }


### PR DESCRIPTION
This fixes to issues:
- Any protobuf above 2.5.0 seems ok: The protobuf > 3.0.0 seem to be defaulting to "proto", so things stay compatible.
- fix undefined reference on Mac: Somehow the symbol is not found on Mac. Commenting the calls out fixes the Mac build.

@jgoppert are you ok with this?
