### PR TITLE
Use multirotor inputs from 0 to 1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,12 +137,16 @@ set(enable_logging "false")
 set(enable_camera "false")
 set(rotors_description_dir "${CMAKE_CURRENT_SOURCE_DIR}/models/rotors_description")
 set(scripts_dir "${CMAKE_CURRENT_SOURCE_DIR}/scripts")
+
 add_custom_command(OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/models/iris/iris.sdf
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   COMMAND rm -f ${CMAKE_CURRENT_SOURCE_DIR}/models/iris/iris.sdf
-  COMMAND python ${scripts_dir}/xacro.py -o  ${rotors_description_dir}/urdf/iris_base.urdf  ${rotors_description_dir}/urdf/iris_base.xacro enable_mavlink_interface:=${enable_mavlink_interface} enable_ground_truth:=${enable_ground_truth} enable_logging:=${enable_logging} rotors_description_dir:=${rotors_description_dir} 
+  COMMAND python ${scripts_dir}/xacro.py -o  ${rotors_description_dir}/urdf/iris_base.urdf  ${rotors_description_dir}/urdf/iris_base.xacro enable_mavlink_interface:=${enable_mavlink_interface} enable_ground_truth:=${enable_ground_truth} enable_logging:=${enable_logging} rotors_description_dir:=${rotors_description_dir}
   COMMAND gz sdf -p  ${rotors_description_dir}/urdf/iris_base.urdf >> ${CMAKE_CURRENT_SOURCE_DIR}/models/iris/iris.sdf
   COMMAND rm -f ${rotors_description_dir}/urdf/iris_base.urdf
+  DEPENDS ${rotors_description_dir}/urdf/iris.xacro
+  DEPENDS ${rotors_description_dir}/urdf/iris_base.xacro
+  DEPENDS ${rotors_description_dir}/urdf/component_snippets.xacro
   )
 add_custom_target(sdf ALL DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/models/iris/iris.sdf)
 

--- a/models/rotors_description/urdf/component_snippets.xacro
+++ b/models/rotors_description/urdf/component_snippets.xacro
@@ -136,32 +136,32 @@
         <control_channels>
           <channel name="rotor1">
             <input_index>0</input_index>
-            <input_offset>1</input_offset>
-            <input_scaling>550</input_scaling>
+            <input_offset>0</input_offset>
+            <input_scaling>1000</input_scaling>
             <zero_position_disarmed>0</zero_position_disarmed>
             <zero_position_armed>100</zero_position_armed>
             <joint_control_type>velocity</joint_control_type>
           </channel>
           <channel name="rotor2">
             <input_index>1</input_index>
-            <input_offset>1</input_offset>
-            <input_scaling>550</input_scaling>
+            <input_offset>0</input_offset>
+            <input_scaling>1000</input_scaling>
             <zero_position_disarmed>0</zero_position_disarmed>
             <zero_position_armed>100</zero_position_armed>
             <joint_control_type>velocity</joint_control_type>
           </channel>
           <channel name="rotor3">
             <input_index>2</input_index>
-            <input_offset>1</input_offset>
-            <input_scaling>550</input_scaling>
+            <input_offset>0</input_offset>
+            <input_scaling>1000</input_scaling>
             <zero_position_disarmed>0</zero_position_disarmed>
             <zero_position_armed>100</zero_position_armed>
             <joint_control_type>velocity</joint_control_type>
           </channel>
           <channel name="rotor4">
             <input_index>3</input_index>
-            <input_offset>1</input_offset>
-            <input_scaling>550</input_scaling>
+            <input_offset>0</input_offset>
+            <input_scaling>1000</input_scaling>
             <zero_position_disarmed>0</zero_position_disarmed>
             <zero_position_armed>100</zero_position_armed>
             <joint_control_type>velocity</joint_control_type>

--- a/models/standard_vtol/standard_vtol.sdf
+++ b/models/standard_vtol/standard_vtol.sdf
@@ -759,7 +759,7 @@
       <turningDirection>ccw</turningDirection>
       <timeConstantUp>0.0125</timeConstantUp>
       <timeConstantDown>0.025</timeConstantDown>
-      <maxRotVelocity>1100</maxRotVelocity>
+      <maxRotVelocity>1000</maxRotVelocity>
       <motorConstant>8.54858e-06</motorConstant>
       <momentConstant>0.06</momentConstant>
       <commandSubTopic>/gazebo/command/motor_speed</commandSubTopic>
@@ -776,7 +776,7 @@
       <turningDirection>ccw</turningDirection>
       <timeConstantUp>0.0125</timeConstantUp>
       <timeConstantDown>0.025</timeConstantDown>
-      <maxRotVelocity>1100</maxRotVelocity>
+      <maxRotVelocity>1000</maxRotVelocity>
       <motorConstant>8.54858e-06</motorConstant>
       <momentConstant>0.06</momentConstant>
       <commandSubTopic>/gazebo/command/motor_speed</commandSubTopic>
@@ -793,7 +793,7 @@
       <turningDirection>cw</turningDirection>
       <timeConstantUp>0.0125</timeConstantUp>
       <timeConstantDown>0.025</timeConstantDown>
-      <maxRotVelocity>1100</maxRotVelocity>
+      <maxRotVelocity>1000</maxRotVelocity>
       <motorConstant>8.54858e-06</motorConstant>
       <momentConstant>0.06</momentConstant>
       <commandSubTopic>/gazebo/command/motor_speed</commandSubTopic>
@@ -810,7 +810,7 @@
       <turningDirection>cw</turningDirection>
       <timeConstantUp>0.0125</timeConstantUp>
       <timeConstantDown>0.025</timeConstantDown>
-      <maxRotVelocity>1100</maxRotVelocity>
+      <maxRotVelocity>1000</maxRotVelocity>
       <motorConstant>8.54858e-06</motorConstant>
       <momentConstant>0.06</momentConstant>
       <commandSubTopic>/gazebo/command/motor_speed</commandSubTopic>
@@ -827,7 +827,7 @@
       <turningDirection>cw</turningDirection>
       <timeConstantUp>0.0125</timeConstantUp>
       <timeConstantDown>0.025</timeConstantDown>
-      <maxRotVelocity>3100</maxRotVelocity>
+      <maxRotVelocity>3000</maxRotVelocity>
       <motorConstant>8.54858e-06</motorConstant>
       <momentConstant>0.01</momentConstant>
       <commandSubTopic>/gazebo/command/motor_speed</commandSubTopic>
@@ -857,8 +857,8 @@
       <control_channels>
         <channel name="rotor0">
           <input_index>0</input_index>
-          <input_offset>1</input_offset>
-          <input_scaling>550</input_scaling>
+          <input_offset>0</input_offset>
+          <input_scaling>1000</input_scaling>
           <zero_position_disarmed>0</zero_position_disarmed>
           <zero_position_armed>0</zero_position_armed>
           <joint_control_type>velocity</joint_control_type>
@@ -866,8 +866,8 @@
         </channel>
         <channel name="rotor1">
           <input_index>1</input_index>
-          <input_offset>1</input_offset>
-          <input_scaling>550</input_scaling>
+          <input_offset>0</input_offset>
+          <input_scaling>1000</input_scaling>
           <zero_position_disarmed>0</zero_position_disarmed>
           <zero_position_armed>0</zero_position_armed>
           <joint_control_type>velocity</joint_control_type>
@@ -875,8 +875,8 @@
         </channel>
         <channel name="rotor2">
           <input_index>2</input_index>
-          <input_offset>1</input_offset>
-          <input_scaling>550</input_scaling>
+          <input_offset>0</input_offset>
+          <input_scaling>1000</input_scaling>
           <zero_position_disarmed>0</zero_position_disarmed>
           <zero_position_armed>0</zero_position_armed>
           <joint_control_type>velocity</joint_control_type>
@@ -884,8 +884,8 @@
         </channel>
         <channel name="rotor3">
           <input_index>3</input_index>
-          <input_offset>1</input_offset>
-          <input_scaling>550</input_scaling>
+          <input_offset>0</input_offset>
+          <input_scaling>1000</input_scaling>
           <zero_position_disarmed>0</zero_position_disarmed>
           <zero_position_armed>0</zero_position_armed>
           <joint_control_type>velocity</joint_control_type>
@@ -893,8 +893,8 @@
         </channel>
         <channel name="rotor4">
           <input_index>4</input_index>
-          <input_offset>1</input_offset>
-          <input_scaling>1600</input_scaling>
+          <input_offset>0</input_offset>
+          <input_scaling>3000</input_scaling>
           <zero_position_disarmed>0</zero_position_disarmed>
           <zero_position_armed>0</zero_position_armed>
           <joint_control_type>velocity</joint_control_type>

--- a/models/typhoon_h480/typhoon_h480.sdf
+++ b/models/typhoon_h480/typhoon_h480.sdf
@@ -398,7 +398,7 @@
         </camera>
         <always_on>1</always_on>
         <update_rate>10</update_rate>
-        <visualize>true</visualize>
+        <visualize>false</visualize>
         <!-- how to make this work without using urdf?
         <plugin name="cgo3_camera_controller" filename="libgazebo_ros_camera.so">
           <alwaysOn>true</alwaysOn>
@@ -1138,7 +1138,7 @@
       <turningDirection>ccw</turningDirection>
       <timeConstantUp>0.0125</timeConstantUp>
       <timeConstantDown>0.025</timeConstantDown>
-      <maxRotVelocity>1100</maxRotVelocity>
+      <maxRotVelocity>1000</maxRotVelocity>
       <motorConstant>8.54858e-06</motorConstant>
       <momentConstant>0.06</momentConstant>
       <commandSubTopic>/gazebo/command/motor_speed</commandSubTopic>
@@ -1166,7 +1166,7 @@
       <turningDirection>cw</turningDirection>
       <timeConstantUp>0.0125</timeConstantUp>
       <timeConstantDown>0.025</timeConstantDown>
-      <maxRotVelocity>1100</maxRotVelocity>
+      <maxRotVelocity>1000</maxRotVelocity>
       <motorConstant>8.54858e-06</motorConstant>
       <momentConstant>0.06</momentConstant>
       <commandSubTopic>/gazebo/command/motor_speed</commandSubTopic>
@@ -1194,7 +1194,7 @@
       <turningDirection>cw</turningDirection>
       <timeConstantUp>0.0125</timeConstantUp>
       <timeConstantDown>0.025</timeConstantDown>
-      <maxRotVelocity>1100</maxRotVelocity>
+      <maxRotVelocity>1000</maxRotVelocity>
       <motorConstant>8.54858e-06</motorConstant>
       <momentConstant>0.06</momentConstant>
       <commandSubTopic>/gazebo/command/motor_speed</commandSubTopic>
@@ -1222,7 +1222,7 @@
       <turningDirection>ccw</turningDirection>
       <timeConstantUp>0.0125</timeConstantUp>
       <timeConstantDown>0.025</timeConstantDown>
-      <maxRotVelocity>1100</maxRotVelocity>
+      <maxRotVelocity>1000</maxRotVelocity>
       <motorConstant>8.54858e-06</motorConstant>
       <momentConstant>0.06</momentConstant>
       <commandSubTopic>/gazebo/command/motor_speed</commandSubTopic>
@@ -1250,7 +1250,7 @@
       <turningDirection>cw</turningDirection>
       <timeConstantUp>0.0125</timeConstantUp>
       <timeConstantDown>0.025</timeConstantDown>
-      <maxRotVelocity>1100</maxRotVelocity>
+      <maxRotVelocity>1000</maxRotVelocity>
       <motorConstant>8.54858e-06</motorConstant>
       <momentConstant>0.06</momentConstant>
       <commandSubTopic>/gazebo/command/motor_speed</commandSubTopic>
@@ -1278,7 +1278,7 @@
       <turningDirection>ccw</turningDirection>
       <timeConstantUp>0.0125</timeConstantUp>
       <timeConstantDown>0.025</timeConstantDown>
-      <maxRotVelocity>1100</maxRotVelocity>
+      <maxRotVelocity>1000</maxRotVelocity>
       <motorConstant>8.54858e-06</motorConstant>
       <momentConstant>0.06</momentConstant>
       <commandSubTopic>/gazebo/command/motor_speed</commandSubTopic>
@@ -1307,8 +1307,8 @@
       <control_channels>
         <channel name="rotor0">
           <input_index>0</input_index>
-          <input_offset>1</input_offset>
-          <input_scaling>450</input_scaling>
+          <input_offset>0</input_offset>
+          <input_scaling>1000</input_scaling>
           <zero_position_disarmed>0</zero_position_disarmed>
           <zero_position_armed>100</zero_position_armed>
           <joint_control_type>velocity</joint_control_type>
@@ -1327,8 +1327,8 @@
         </channel>
         <channel name="rotor1">
           <input_index>1</input_index>
-          <input_offset>1</input_offset>
-          <input_scaling>450</input_scaling>
+          <input_offset>0</input_offset>
+          <input_scaling>1000</input_scaling>
           <zero_position_disarmed>0</zero_position_disarmed>
           <zero_position_armed>100</zero_position_armed>
           <joint_control_type>velocity</joint_control_type>
@@ -1347,8 +1347,8 @@
         </channel>
         <channel name="rotor2">
           <input_index>2</input_index>
-          <input_offset>1</input_offset>
-          <input_scaling>450</input_scaling>
+          <input_offset>0</input_offset>
+          <input_scaling>1000</input_scaling>
           <zero_position_disarmed>0</zero_position_disarmed>
           <zero_position_armed>100</zero_position_armed>
           <joint_control_type>velocity</joint_control_type>
@@ -1367,8 +1367,8 @@
         </channel>
         <channel name="rotor3">
           <input_index>3</input_index>
-          <input_offset>1</input_offset>
-          <input_scaling>450</input_scaling>
+          <input_offset>0</input_offset>
+          <input_scaling>1000</input_scaling>
           <zero_position_disarmed>0</zero_position_disarmed>
           <zero_position_armed>100</zero_position_armed>
           <joint_control_type>velocity</joint_control_type>
@@ -1387,8 +1387,8 @@
         </channel>
         <channel name="rotor4">
           <input_index>4</input_index>
-          <input_offset>1</input_offset>
-          <input_scaling>450</input_scaling>
+          <input_offset>0</input_offset>
+          <input_scaling>1000</input_scaling>
           <zero_position_disarmed>0</zero_position_disarmed>
           <zero_position_armed>100</zero_position_armed>
           <joint_control_type>velocity</joint_control_type>
@@ -1407,8 +1407,8 @@
         </channel>
         <channel name="rotor5">
           <input_index>5</input_index>
-          <input_offset>1</input_offset>
-          <input_scaling>450</input_scaling>
+          <input_offset>0</input_offset>
+          <input_scaling>1000</input_scaling>
           <zero_position_disarmed>0</zero_position_disarmed>
           <zero_position_armed>100</zero_position_armed>
           <joint_control_type>velocity</joint_control_type>
@@ -1458,7 +1458,7 @@
         <channel name="left_leg">
           <input_index>9</input_index>
           <input_offset>1</input_offset>
-          <input_scaling>1</input_scaling>
+          <input_scaling>0.5</input_scaling>
           <zero_position_disarmed>0</zero_position_disarmed>
           <zero_position_armed>0</zero_position_armed>
           <joint_control_type>position</joint_control_type>
@@ -1476,7 +1476,7 @@
         <channel name="right_leg">
           <input_index>10</input_index>
           <input_offset>1</input_offset>
-          <input_scaling>1</input_scaling>
+          <input_scaling>0.5</input_scaling>
           <zero_position_disarmed>0</zero_position_disarmed>
           <zero_position_armed>0</zero_position_armed>
           <joint_control_type>position</joint_control_type>


### PR DESCRIPTION
Previously, the throttle sent from PX4 was in the range -1..1, however
the positive range is now 0..1 which would allow for negative throttle
levels e.g. for pusher motors or variable pitch.

This goes together with https://github.com/PX4/Firmware/pull/5716.
