### PR TITLE
Fix warning on Mac

### DIFF
--- a/include/flow_settings.h
+++ b/include/flow_settings.h
@@ -94,11 +94,11 @@ typedef enum
   * ALL SETTINGS VARIABLES
   */
 
-typedef struct
-{
-	/* nothing here until now */
-
-} SysState_TypeDef;
+//typedef struct
+//{
+//	/* nothing here until now */
+//
+//} SysState_TypeDef;
 
 enum global_param_id_t
 {


### PR DESCRIPTION
Clang doesn't seem to like an empty struct as much as gcc does.