### PR TITLE
Fix for ground truth

### DIFF
--- a/include/gazebo_mavlink_interface.h
+++ b/include/gazebo_mavlink_interface.h
@@ -187,7 +187,7 @@ class GazeboMavlinkInterface : public ModelPlugin {
 
   math::Vector3 gravity_W_;
   math::Vector3 velocity_prev_W_;
-  math::Vector3 mag_W_;
+  math::Vector3 mag_d_;
 
   std::default_random_engine random_generator_;
   std::normal_distribution<float> standard_normal_distribution_;


### PR DESCRIPTION
This is a hardcore rewrite of the the simulated attitude for sensors and ground truth to be very explicit about which fame vectors are in and follow common conventions used in the firmware. I have verified all of the ground truths match via plots with px4tools and have flown this in SITL.

![image](https://cloud.githubusercontent.com/assets/473772/20822664/a84ebc00-b81a-11e6-80ad-7a16beb2204a.png)
