### PR TITLE
Fix typo in discrete random-walk noise for imu.

### DIFF
--- a/src/gazebo_imu_plugin.cpp
+++ b/src/gazebo_imu_plugin.cpp
@@ -197,7 +197,7 @@ void GazeboImuPlugin::addNoise(Eigen::Vector3d* linear_acceleration,
   double sigma_b_g = imu_parameters_.gyroscope_random_walk;
   // Compute exact covariance of the process after dt [Maybeck 4-114].
   double sigma_b_g_d =
-      sqrt( - sigma_b_g * sigma_b_g * tau_g / 2.0 *
+      sqrt( - sigma_b_g * sigma_b_g / tau_g / 2.0 *
       (exp(-2.0 * dt / tau_g) - 1.0));
   // Compute state-transition.
   double phi_g_d = exp(-1.0 / tau_g * dt);
@@ -219,7 +219,7 @@ void GazeboImuPlugin::addNoise(Eigen::Vector3d* linear_acceleration,
   double sigma_b_a = imu_parameters_.accelerometer_random_walk;
   // Compute exact covariance of the process after dt [Maybeck 4-114].
   double sigma_b_a_d =
-      sqrt( - sigma_b_a * sigma_b_a * tau_a / 2.0 *
+      sqrt( - sigma_b_a * sigma_b_a / tau_a / 2.0 *
       (exp(-2.0 * dt / tau_a) - 1.0));
   // Compute state-transition.
   double phi_a_d = exp(-1.0 / tau_a * dt);

--- a/src/gazebo_imu_plugin.cpp
+++ b/src/gazebo_imu_plugin.cpp
@@ -70,7 +70,7 @@ void GazeboImuPlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf) {
   getSdfParam<double>(_sdf, "gyroscopeNoiseDensity",
                       imu_parameters_.gyroscope_noise_density,
                       imu_parameters_.gyroscope_noise_density);
-  getSdfParam<double>(_sdf, "gyroscopeBiasRandomWalk",
+  getSdfParam<double>(_sdf, "gyroscopeRandomWalk",
                       imu_parameters_.gyroscope_random_walk,
                       imu_parameters_.gyroscope_random_walk);
   getSdfParam<double>(_sdf, "gyroscopeBiasCorrelationTime",


### PR DESCRIPTION
I believe there is a typo, you can confirm by comparing to Maybeck (vol. 1 pg 173)

```
* Maybeck: Qd = Q*/(2*T) * [ 1 - e^(-2*dt/T)]
* Our equation: Qd = Q*T/2 * [ 1 - e^(-2*dt/T)]
```

I discovered this through Allan Variance plots and the original plots were highly impacted by random walk. We were effectively multiplying the random walk standard deviation by the correlation time constant (300).

You can see plots of the comparison here from running each for 10 minutes:

https://github.com/jgoppert/iekf_analysis/blob/master/Noise%20Fix.ipynb

@Stifael please check me here.