### PR TITLE
Fixed typo in gyro bias random walk name.

### DIFF
--- a/src/gazebo_imu_plugin.cpp
+++ b/src/gazebo_imu_plugin.cpp
@@ -70,7 +70,7 @@ void GazeboImuPlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf) {
   getSdfParam<double>(_sdf, "gyroscopeNoiseDensity",
                       imu_parameters_.gyroscope_noise_density,
                       imu_parameters_.gyroscope_noise_density);
-  getSdfParam<double>(_sdf, "gyroscopeBiasRandomWalk",
+  getSdfParam<double>(_sdf, "gyroscopeRandomWalk",
                       imu_parameters_.gyroscope_random_walk,
                       imu_parameters_.gyroscope_random_walk);
   getSdfParam<double>(_sdf, "gyroscopeBiasCorrelationTime",


### PR DESCRIPTION
This fixes a gazebo param name issue. All of the gyro bias random walk values were being set to default and the existing statements had no effect.