### PR TITLE
define an initial camera position for iris and iris_opt_flow

### DIFF
--- a/worlds/iris.world
+++ b/worlds/iris.world
@@ -36,5 +36,10 @@
       <real_time_update_rate>500</real_time_update_rate>
       <magnetic_field>6e-06 2.3e-05 -4.2e-05</magnetic_field>
     </physics>
+    <gui>
+      <camera name="user_camera">
+        <pose>-15 0 10 0 0.45 0</pose>
+      </camera>
+    </gui>
   </world>
 </sdf>

--- a/worlds/iris_opt_flow.world
+++ b/worlds/iris_opt_flow.world
@@ -36,5 +36,10 @@
       <real_time_update_rate>500</real_time_update_rate>
       <magnetic_field>6e-06 2.3e-05 -4.2e-05</magnetic_field>
     </physics>
+    <gui>
+      <camera name="user_camera">
+        <pose>-15 0 10 0 0.45 0</pose>
+      </camera>
+    </gui>
   </world>
 </sdf>


### PR DESCRIPTION
I added a default camera position for iris.world and iris_opt_flow.world. If someone prefers a different position I suggest to change it locally and put it in .gitignore.
I haven't changed all the other worlds since I never use them and don't know the preferred positions...