### PR TITLE
MAVLINK_HIL_GPS: fixed CoG [0,360] angle wrap bug

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -1,3 +1,5 @@
+#ifndef SITL_GAZEBO_COMMON_H_
+#define SITL_GAZEBO_COMMON_H_
 /*
  * Copyright 2015 Fadri Furrer, ASL, ETH Zurich, Switzerland
  * Copyright 2015 Michael Burri, ASL, ETH Zurich, Switzerland
@@ -47,9 +49,18 @@ bool getSdfParam(sdf::ElementPtr sdf, const std::string& name, T& param, const T
   return false;
 }
 
+/**
+ * \brief Get a math::Angle as an angle from [0, 360)
+ */
+double GetDegrees360(const math::Angle& angle) {
+  double degrees = angle.Degree();
+  while (degrees < 0.) degrees += 360.0;
+  while (degrees >= 360.0) degrees -= 360.0;
+  return degrees;
 }
 
 
+}  // namespace gazebo
 
 template <typename T>
 class FirstOrderFilter {
@@ -126,3 +137,5 @@ void copyPosition(const In& in, Out* out) {
   out->y = in.y;
   out->z = in.z;
 }
+
+#endif  // SITL_GAZEBO_COMMON_H_


### PR DESCRIPTION
The MAVLINK_HIL_GPS Course-over-Ground (cog) field
is a uint16_t expressed in hundredth's of degrees in
the range [0, 360).

The previous code was using the output of std::atan2
to populate the field, which outputs angles from [-pi, pi],
and it was not accounting for the necessary shift in
the interval to an unsigned representation.

The new code
* adds a helper function to common.h to
output a gazebo::math::Angle in degrees from 0-360, and
* makes use of the helper function when packing the
MAVLINK_HIL_GPS message in gazebo_mavlink_interface.cpp.

An include header is also added to common.h.
