### PR TITLE
Fix inverted magnetic declination

### DIFF
--- a/src/gazebo_mavlink_interface.cpp
+++ b/src/gazebo_mavlink_interface.cpp
@@ -642,7 +642,7 @@ void GazeboMavlinkInterface::ImuCallback(ImuPtr& imu_message) {
   float declination = get_mag_declination(lat_rad, lon_rad);
 
   math::Quaternion q_dn(0.0, 0.0, declination);
-  math::Vector3 mag_n = q_dn.RotateVectorReverse(mag_d_);
+  math::Vector3 mag_n = q_dn.RotateVector(mag_d_);
 
   math::Vector3 vel_b = q_br.RotateVector(model_->GetRelativeLinearVel());
   math::Vector3 vel_n = q_ng.RotateVector(model_->GetWorldLinearVel());


### PR DESCRIPTION
Fixes PX4/Firmware#6843

Another possible fix is simply flipping the sign on the `declination` on the previous line. They both accomplish the same thing, so I'm not sure which fix is technically *correct*.

I also believe that `mag_d_.z`'s [sign](https://github.com/mcgill-robotics/sitl_gazebo/blob/cc57c7ed5d8a97a56c010a0b31799de5c0554b59/src/gazebo_mavlink_interface.cpp#L450) should be flipped according to WMM2015, but I would like someone else to verify that is indeed the case first. My tests seem to have shown that that number is irrelevant though.

FYI @matanhavi