### PR TITLE
Add undefined args in iris xacro:  Helps in running multi uav in sitl px4

### DIFF
--- a/models/rotors_description/urdf/iris_base.xacro
+++ b/models/rotors_description/urdf/iris_base.xacro
@@ -4,9 +4,16 @@
   <!-- Properties that can be assigned at build time as arguments.
   Is there a reason not to make all properties arguments?
   -->
+  <xacro:arg name='name' default='iris' />
   <xacro:arg name='mavlink_addr' default='INADDR_ANY' />
   <xacro:arg name='mavlink_udp_port' default='14560' />
   <xacro:arg name='visual_material' default='DarkGrey' />
+  <xacro:arg name='enable_mavlink_interface' default='true' />
+  <xacro:arg name='enable_wind' default='false' />
+  <!-- The following causes segfault with multiple vehicles if defaults to true!!! -->
+  <xacro:arg name='enable_ground_truth' default='false' />
+  <xacro:arg name='enable_logging' default='false' />
+  <xacro:arg name='log_file' default='iris' />
 
   <!-- macros for gazebo plugins, sensors -->
   <xacro:include filename="$(arg rotors_description_dir)/urdf/component_snippets.xacro" />


### PR DESCRIPTION
This PR is modified in order to allow multi-uav support in SITL in PX4 stack.
* the ```xacro``` file is used to auto-generate SDF file that has specific parameters. Namely the ```mavlink_udp_port```. I could not find a way to pass argument to SDF file in a lunch file. However, I am able to pass arguments to ```$(find xacro)/xacro.py``` in a launch file. Then I can change the```xacro``` file to SDF in the same launch file. This is why ```.xacro``` file is needed.

* With previous ```iris_base.xacro```, undefined args in top of the file was causing issues 
* default ground truth plugin to false. This was causing segfault when trying to run multi uav in SITL, if default=true.