### PR TITLE
Fix compilation for gazebo 8.

### DIFF
--- a/src/gazebo_geotagged_images_plugin.cpp
+++ b/src/gazebo_geotagged_images_plugin.cpp
@@ -74,7 +74,11 @@ void GeotaggedImagesPlugin::Load(sensors::SensorPtr sensor, sdf::ElementPtr sdf)
     return;
   }
   scene_ = camera_->GetScene();
+#if GAZEBO_MAJOR_VERSION >= 8
+  lastImageTime_ = scene_->SimTime();
+#else
   lastImageTime_ = scene_->GetSimTime();
+#endif
 
 #if GAZEBO_MAJOR_VERSION >= 7
   this->width_ = this->camera_->ImageWidth();
@@ -146,7 +150,11 @@ void GeotaggedImagesPlugin::OnNewFrame(const unsigned char * image)
   image = this->camera_->GetImageData(0);
 #endif
 
+#if GAZEBO_MAJOR_VERSION >= 8
+  common::Time currentTime = scene_->SimTime();
+#else
   common::Time currentTime = scene_->GetSimTime();
+#endif
   if (currentTime.Double() - lastImageTime_.Double() < storeIntervalSec_) {
     return;
   }

--- a/src/gazebo_gimbal_controller_plugin.cpp
+++ b/src/gazebo_gimbal_controller_plugin.cpp
@@ -306,10 +306,8 @@ void GimbalControllerPlugin::OnUpdate()
 
     /// currentAngleYPRVariable is defined in roll-pitch-yaw-fixed-axis
     /// and gimbal is constructed using yaw-roll-pitch-variable-axis
-    ignition::math::Vector3d currentAngleYPRVariable(
-      this->imuSensor->Orientation().Euler());
     ignition::math::Vector3d currentAnglePRYVariable(
-      this->QtoZXY(currentAngleYPRVariable));
+      this->QtoZXY(this->imuSensor->Orientation()));
 
     /// get joint limits (in sensor frame)
     /// TODO: move to Load() if limits do not change


### PR DESCRIPTION
Minor fixes for gazebo 8. Might want to double check I handled the gimbal correctly. No need to transform a quaternion to euler then to quaternion and then back to euler. Also this api is no loner supported in gazebo 8.