### PR TITLE
Adding support for Gazebo 9 and onwards

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -23,6 +23,7 @@
 
 #include <Eigen/Dense>
 #include <gazebo/gazebo.hh>
+#include <ignition/math.hh>
 
 namespace gazebo {
 
@@ -52,7 +53,7 @@ bool getSdfParam(sdf::ElementPtr sdf, const std::string& name, T& param, const T
 /**
  * \brief Get a math::Angle as an angle from [0, 360)
  */
-double GetDegrees360(const math::Angle& angle) {
+double GetDegrees360(const ignition::math::Angle& angle) {
   double degrees = angle.Degree();
   while (degrees < 0.) degrees += 360.0;
   while (degrees >= 360.0) degrees -= 360.0;

--- a/include/gazebo_imu_plugin.h
+++ b/include/gazebo_imu_plugin.h
@@ -26,8 +26,10 @@
 #include <gazebo/common/Plugin.hh>
 #include <gazebo/gazebo.hh>
 #include <gazebo/physics/physics.hh>
+#include <gazebo/physics/World.hh>
 #include "gazebo/transport/transport.hh"
 #include "gazebo/msgs/msgs.hh"
+#include <ignition/math.hh>
 
 #include "common.h"
 
@@ -137,8 +139,8 @@ class GazeboImuPlugin : public ModelPlugin {
 
   sensor_msgs::msgs::Imu imu_message_;
 
-  math::Vector3 gravity_W_;
-  math::Vector3 velocity_prev_W_;
+  ignition::math::Vector3d gravity_W_;
+  ignition::math::Vector3d velocity_prev_W_;
 
   Eigen::Vector3d gyroscope_bias_;
   Eigen::Vector3d accelerometer_bias_;

--- a/include/gazebo_mavlink_interface.h
+++ b/include/gazebo_mavlink_interface.h
@@ -38,6 +38,7 @@
 #include "sonarSens.pb.h"
 #include <boost/bind.hpp>
 
+#include <ignition/math.hh>
 #include <iostream>
 #include <math.h>
 #include <deque>
@@ -46,7 +47,7 @@
 
 #include "mavlink/v1.0/common/mavlink.h"
 
-#include "gazebo/math/Vector3.hh"
+
 #include <sys/socket.h>
 #include <netinet/in.h>
 
@@ -192,9 +193,9 @@ class GazeboMavlinkInterface : public ModelPlugin {
   double lon_rad;
   void handle_control(double _dt);
 
-  math::Vector3 gravity_W_;
-  math::Vector3 velocity_prev_W_;
-  math::Vector3 mag_d_;
+  ignition::math::Vector3d gravity_W_;
+  ignition::math::Vector3d velocity_prev_W_;
+  ignition::math::Vector3d mag_d_;
 
   std::default_random_engine random_generator_;
   std::normal_distribution<float> standard_normal_distribution_;

--- a/include/gazebo_motor_model.h
+++ b/include/gazebo_motor_model.h
@@ -30,7 +30,6 @@
 #include <gazebo/common/Plugin.hh>
 #include <rotors_model/motor_model.hpp>
 #include "CommandMotorSpeed.pb.h"
-#include "gazebo/math/Vector3.hh"
 #include "gazebo/transport/transport.hh"
 #include "gazebo/msgs/msgs.hh"
 #include "MotorSpeed.pb.h"

--- a/include/gazebo_multirotor_base_plugin.h
+++ b/include/gazebo_multirotor_base_plugin.h
@@ -28,7 +28,6 @@
 
 #include "common.h"
 
-#include "gazebo/math/Vector3.hh"
 #include "gazebo/transport/transport.hh"
 #include "gazebo/msgs/msgs.hh"
 #include "MotorSpeed.pb.h"

--- a/include/liftdrag_plugin/liftdrag_plugin.h
+++ b/include/liftdrag_plugin/liftdrag_plugin.h
@@ -19,6 +19,7 @@
 
 #include <string>
 #include <vector>
+#include <ignition/math.hh>
 
 #include "gazebo/common/Plugin.hh"
 #include "gazebo/physics/physics.hh"
@@ -107,19 +108,19 @@ namespace gazebo
     protected: double alpha;
 
     /// \brief center of pressure in link local coordinates
-    protected: math::Vector3 cp;
+    protected: ignition::math::Vector3d cp;
 
     /// \brief Normally, this is taken as a direction parallel to the chord
     /// of the airfoil in zero angle of attack forward flight.
-    protected: math::Vector3 forward;
+    protected: ignition::math::Vector3d forward;
 
     /// \brief A vector in the lift/drag plane, perpendicular to the forward
     /// vector. Inflow velocity orthogonal to forward and upward vectors
     /// is considered flow in the wing sweep direction.
-    protected: math::Vector3 upward;
+    protected: ignition::math::Vector3d upward;
 
     /// \brief Smoothed velocity
-    protected: math::Vector3 velSmooth;
+    protected: ignition::math::Vector3d velSmooth;
 
     /// \brief Pointer to link currently targeted by mud joint.
     protected: physics::LinkPtr link;

--- a/package.xml
+++ b/package.xml
@@ -28,7 +28,7 @@
   <!-- Example: -->
   <author email="lorenz@px4.io">Lorenz Meier</author>
   <author email="james.goppert@gmail.com">James Goppert</author> 
-  <author email="develop707@gmail.com">William Peale</author
+  <author email="develop707@gmail.com">William Peale</author>
 
   <!-- The *_depend tags are used to specify dependencies -->
   <!-- Dependencies can be catkin packages or system dependencies -->

--- a/package.xml
+++ b/package.xml
@@ -28,7 +28,7 @@
   <!-- Example: -->
   <author email="lorenz@px4.io">Lorenz Meier</author>
   <author email="james.goppert@gmail.com">James Goppert</author> 
-
+  <author email="develop707@gmail.com">William Peale</author
 
   <!-- The *_depend tags are used to specify dependencies -->
   <!-- Dependencies can be catkin packages or system dependencies -->

--- a/src/gazebo_controller_interface.cpp
+++ b/src/gazebo_controller_interface.cpp
@@ -20,11 +20,13 @@
 
 
 #include "gazebo_controller_interface.h"
+#include <ignition/math.hh>
 
 namespace gazebo {
 
 GazeboControllerInterface::~GazeboControllerInterface() {
-  event::Events::DisconnectWorldUpdateBegin(updateConnection_);
+  //event::Event::DisconnectWorldUpdateBegin(updateConnection_);
+  updateConnection_->~Connection();
 }
 
 void GazeboControllerInterface::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf) {
@@ -66,7 +68,7 @@ void GazeboControllerInterface::OnUpdate(const common::UpdateInfo& /*_info*/) {
   if(!received_first_referenc_)
     return;
 
-  common::Time now = world_->GetSimTime();
+  common::Time now = world_->SimTime();
 
   mav_msgs::msgs::CommandMotorSpeed turning_velocities_msg;
 

--- a/src/gazebo_gimbal_controller_plugin.cpp
+++ b/src/gazebo_gimbal_controller_plugin.cpp
@@ -135,9 +135,9 @@ void GimbalControllerPlugin::Load(physics::ModelPtr _model,
 void GimbalControllerPlugin::Init()
 {
   this->node = transport::NodePtr(new transport::Node());
-  this->node->Init(this->model->GetWorld()->GetName());
+  this->node->Init(this->model->GetWorld()->Name());
 
-  this->lastUpdateTime = this->model->GetWorld()->GetSimTime();
+  this->lastUpdateTime = this->model->GetWorld()->SimTime();
 
   // receive pitch command via gz transport
   std::string pitchTopic = std::string("~/") +  this->model->GetName() +
@@ -269,7 +269,7 @@ void GimbalControllerPlugin::OnUpdate()
   if (!this->pitchJoint || !this->rollJoint || !this->yawJoint)
     return;
 
-  common::Time time = this->model->GetWorld()->GetSimTime();
+  common::Time time = this->model->GetWorld()->SimTime();
   if (time < this->lastUpdateTime)
   {
     gzerr << "time reset event\n";
@@ -289,14 +289,14 @@ void GimbalControllerPlugin::OnUpdate()
 
     // truncate command inside joint angle limits
     double rollLimited = ignition::math::clamp(this->rollCommand,
-      rDir*this->rollJoint->GetUpperLimit(0).Radian(),
-	  rDir*this->rollJoint->GetLowerLimit(0).Radian());
+      rDir*this->rollJoint->UpperLimit(0),
+	  rDir*this->rollJoint->LowerLimit(0));
     double pitchLimited = ignition::math::clamp(this->pitchCommand,
-      pDir*this->pitchJoint->GetUpperLimit(0).Radian(),
-      pDir*this->pitchJoint->GetLowerLimit(0).Radian());
+      pDir*this->pitchJoint->UpperLimit(0),
+      pDir*this->pitchJoint->LowerLimit(0));
     double yawLimited = ignition::math::clamp(this->yawCommand,
-      yDir*this->yawJoint->GetLowerLimit(0).Radian(),
-	  yDir*this->yawJoint->GetUpperLimit(0).Radian());
+      yDir*this->yawJoint->LowerLimit(0),
+	  yDir*this->yawJoint->UpperLimit(0));
 
     ignition::math::Quaterniond commandRPY(
       rollLimited, pitchLimited, yawLimited);
@@ -319,13 +319,13 @@ void GimbalControllerPlugin::OnUpdate()
     /// get joint limits (in sensor frame)
     /// TODO: move to Load() if limits do not change
     ignition::math::Vector3d lowerLimitsPRY
-      (pDir*this->pitchJoint->GetLowerLimit(0).Radian(),
-       rDir*this->rollJoint->GetLowerLimit(0).Radian(),
-       yDir*this->yawJoint->GetLowerLimit(0).Radian());
+      (pDir*this->pitchJoint->LowerLimit(0),
+       rDir*this->rollJoint->LowerLimit(0),
+       yDir*this->yawJoint->LowerLimit(0));
     ignition::math::Vector3d upperLimitsPRY
-      (pDir*this->pitchJoint->GetUpperLimit(0).Radian(),
-       rDir*this->rollJoint->GetUpperLimit(0).Radian(),
-       yDir*this->yawJoint->GetUpperLimit(0).Radian());
+      (pDir*this->pitchJoint->UpperLimit(0),
+       rDir*this->rollJoint->UpperLimit(0),
+       yDir*this->yawJoint->UpperLimit(0));
 
     // normalize errors
     double pitchError = this->ShortestAngularDistance(
@@ -412,27 +412,27 @@ void GimbalControllerPlugin::OnUpdate()
     gazebo::msgs::Any m;
     m.set_type(gazebo::msgs::Any_ValueType_DOUBLE);
 
-    m.set_double_value(this->pitchJoint->GetAngle(0).Radian());
+    m.set_double_value(this->pitchJoint->Position(0));
     this->pitchPub->Publish(m);
 
-    m.set_double_value(this->rollJoint->GetAngle(0).Radian());
+    m.set_double_value(this->rollJoint->Position(0));
     this->rollPub->Publish(m);
 
-    m.set_double_value(this->yawJoint->GetAngle(0).Radian());
+    m.set_double_value(this->yawJoint->Position(0));
     this->yawPub->Publish(m);
 #else
     std::stringstream ss;
     gazebo::msgs::GzString m;
 
-    ss << this->pitchJoint->GetAngle(0).Radian();
+    ss << this->pitchJoint->Position(0);
     m.set_data(ss.str());
     this->pitchPub->Publish(m);
 
-    ss << this->rollJoint->GetAngle(0).Radian();
+    ss << this->rollJoint->Position(0);
     m.set_data(ss.str());
     this->rollPub->Publish(m);
 
-    ss << this->yawJoint->GetAngle(0).Radian();
+    ss << this->yawJoint->Position(0);
     m.set_data(ss.str());
     this->yawPub->Publish(m);
 #endif

--- a/src/gazebo_lidar_plugin.cpp
+++ b/src/gazebo_lidar_plugin.cpp
@@ -50,12 +50,9 @@ RayPlugin::RayPlugin()
 /////////////////////////////////////////////////
 RayPlugin::~RayPlugin()
 {
-#if GAZEBO_MAJOR_VERSION >= 7
-  this->parentSensor->LaserShape()->DisconnectNewLaserScans(
-#else
-  this->parentSensor->GetLaserShape()->DisconnectNewLaserScans(
-#endif
-      this->newLaserScansConnection);
+  this->newLaserScansConnection->~Connection();
+
+      
   this->newLaserScansConnection.reset();
 
   this->parentSensor.reset();

--- a/src/gazebo_mavlink_interface.cpp
+++ b/src/gazebo_mavlink_interface.cpp
@@ -24,6 +24,7 @@
 #include "geo_mag_declination.h"
 #include <cstdlib>
 #include <string>
+#include <ignition/math.hh>
 
 namespace gazebo {
 
@@ -49,7 +50,7 @@ static const float earth_radius = 6353000;  // m
 GZ_REGISTER_MODEL_PLUGIN(GazeboMavlinkInterface);
 
 GazeboMavlinkInterface::~GazeboMavlinkInterface() {
-  event::Events::DisconnectWorldUpdateBegin(updateConnection_);
+  updateConnection_->~Connection();
 }
 
 void GazeboMavlinkInterface::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf) {
@@ -434,11 +435,11 @@ void GazeboMavlinkInterface::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf
   motor_velocity_reference_pub_ = node_handle_->Advertise<mav_msgs::msgs::CommandMotorSpeed>("~/" + model_->GetName() + motor_velocity_reference_pub_topic_, 1);
 
   _rotor_count = 5;
-  last_time_ = world_->GetSimTime();
-  last_gps_time_ = world_->GetSimTime();
+  last_time_ = world_->SimTime();
+  last_gps_time_ = world_->SimTime();
   gps_update_interval_ = 0.2;  // in seconds for 5Hz
 
-  gravity_W_ = world_->GetPhysicsEngine()->GetGravity();
+  gravity_W_ = world_->Gravity();
 
   // Magnetic field data for Zurich from WMM2015 (10^5xnanoTesla (N, E D) n-frame )
   // mag_n_ = {0.21523, 0.00771, -0.42741};
@@ -447,9 +448,9 @@ void GazeboMavlinkInterface::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf
   // and so we need to start without any offsets.
   // The real value for Zurich would be 0.00771
   // frame d is the magnetic north frame
-  mag_d_.x = 0.21523;
-  mag_d_.y = 0;
-  mag_d_.z = -0.42741;
+  mag_d_.X() = 0.21523;
+  mag_d_.Y() = 0;
+  mag_d_.Z() = -0.42741;
 
   //Create socket
   // udp socket data
@@ -499,7 +500,7 @@ void GazeboMavlinkInterface::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf
 // This gets called by the world update start event.
 void GazeboMavlinkInterface::OnUpdate(const common::UpdateInfo& /*_info*/) {
 
-  common::Time current_time = world_->GetSimTime();
+  common::Time current_time = world_->SimTime();
   double dt = (current_time - last_time_).Double();
 
   pollForMAVLinkMessages(dt, 1000);
@@ -528,18 +529,18 @@ void GazeboMavlinkInterface::OnUpdate(const common::UpdateInfo& /*_info*/) {
   last_time_ = current_time;
 
   //send gps
-  math::Pose T_W_I = model_->GetWorldPose(); //TODO(burrimi): Check tf.
-  math::Vector3 pos_W_I = T_W_I.pos;  // Use the models' world position for GPS and pressure alt.
+  ignition::math::Pose3<double> T_W_I = model_->WorldPose(); //TODO(burrimi): Check tf.
+  ignition::math::Vector3d pos_W_I = T_W_I.Pos();  // Use the models' world position for GPS and pressure alt.
 
-  math::Vector3 velocity_current_W = model_->GetWorldLinearVel();  // Use the models' world position for GPS velocity.
+  ignition::math::Vector3d velocity_current_W = model_->WorldLinearVel();  // Use the models' world position for GPS velocity.
 
-  math::Vector3 velocity_current_W_xy = velocity_current_W;
-  velocity_current_W_xy.z = 0;
+  ignition::math::Vector3d velocity_current_W_xy = velocity_current_W;
+  velocity_current_W_xy.Z() = 0;
 
   // TODO: Remove GPS message from IMU plugin. Added gazebo GPS plugin. This is temp here.
   // reproject local position to gps coordinates
-  double x_rad = pos_W_I.y / earth_radius; // north
-  double y_rad = pos_W_I.x / earth_radius; // east
+  double x_rad = pos_W_I.Y() / earth_radius; // north
+  double y_rad = pos_W_I.X() / earth_radius; // east
   double c = sqrt(x_rad * x_rad + y_rad * y_rad);
   double sin_c = sin(c);
   double cos_c = cos(c);
@@ -558,15 +559,15 @@ void GazeboMavlinkInterface::OnUpdate(const common::UpdateInfo& /*_info*/) {
     hil_gps_msg.fix_type = 3;
     hil_gps_msg.lat = lat_rad * 180 / M_PI * 1e7;
     hil_gps_msg.lon = lon_rad * 180 / M_PI * 1e7;
-    hil_gps_msg.alt = (pos_W_I.z + alt_home) * 1000;
+    hil_gps_msg.alt = (pos_W_I.Z() + alt_home) * 1000;
     hil_gps_msg.eph = 100;
     hil_gps_msg.epv = 100;
-    hil_gps_msg.vel = velocity_current_W_xy.GetLength() * 100;
-    hil_gps_msg.vn = velocity_current_W.y * 100;
-    hil_gps_msg.ve = velocity_current_W.x * 100;
-    hil_gps_msg.vd = -velocity_current_W.z * 100;
-    // MAVLINK_HIL_GPS_T CoG is [0, 360]. math::Angle::Normalize() is [-pi, pi].
-    math::Angle cog(atan2(velocity_current_W.x, velocity_current_W.y));
+    hil_gps_msg.vel = velocity_current_W_xy.Length() * 100;
+    hil_gps_msg.vn = velocity_current_W.Y() * 100;
+    hil_gps_msg.ve = velocity_current_W.X() * 100;
+    hil_gps_msg.vd = -velocity_current_W.Z() * 100;
+    // MAVLINK_HIL_GPS_T CoG is [0, 360]. ignition::math::Angle::Normalize() is [-pi, pi].
+    ignition::math::Angle cog(atan2(velocity_current_W.X(), velocity_current_W.Y()));
     cog.Normalize();
     hil_gps_msg.cog = static_cast<uint16_t>(GetDegrees360(cog) * 100.0);
     hil_gps_msg.satellites_visible = 10;
@@ -627,7 +628,7 @@ void GazeboMavlinkInterface::ImuCallback(ImuPtr& imu_message) {
   // r - rotors imu frame (FLU), forward, left, up
   // b - px4 (FRD) forward, right down
   // n - px4 (NED) north, east, down
-  math::Quaternion q_gr = math::Quaternion(
+  ignition::math::Quaternion<double> q_gr = ignition::math::Quaternion<double>(
     imu_message->orientation().w(),
     imu_message->orientation().x(),
     imu_message->orientation().y(),
@@ -644,7 +645,7 @@ void GazeboMavlinkInterface::ImuCallback(ImuPtr& imu_message) {
       ]
   )).round(5)
   */
-  math::Quaternion q_br(0, 1, 0, 0);
+  ignition::math::Quaternion<double> q_br(0, 1, 0, 0);
 
 
   // q_ng
@@ -657,55 +658,55 @@ void GazeboMavlinkInterface::ImuCallback(ImuPtr& imu_message) {
       ]
   )).round(5)
   */
-  math::Quaternion q_ng(0, 0.70711, 0.70711, 0);
+  ignition::math::Quaternion<double> q_ng(0, 0.70711, 0.70711, 0);
 
-  math::Quaternion q_gb = q_gr*q_br.GetInverse();
-  math::Quaternion q_nb = q_ng*q_gb;
+  ignition::math::Quaternion<double> q_gb = q_gr*q_br.Inverse();
+  ignition::math::Quaternion<double> q_nb = q_ng*q_gb;
 
-  math::Vector3 pos_g = model_->GetWorldPose().pos;
-  math::Vector3 pos_n = q_ng.RotateVector(pos_g);
+  ignition::math::Vector3d pos_g = model_->WorldPose().Pos();
+  ignition::math::Vector3d pos_n = q_ng.RotateVector(pos_g);
 
   //gzerr << "got imu: " << C_W_I << "\n";
   //gzerr << "got pose: " << T_W_I.rot << "\n";
   float declination = get_mag_declination(lat_rad, lon_rad);
 
-  math::Quaternion q_dn(0.0, 0.0, declination);
-  math::Vector3 mag_n = q_dn.RotateVectorReverse(mag_d_);
+  ignition::math::Quaternion<double> q_dn(0.0, 0.0, declination);
+  ignition::math::Vector3d mag_n = q_dn.RotateVectorReverse(mag_d_);
 
-  math::Vector3 vel_b = q_br.RotateVector(model_->GetRelativeLinearVel());
-  math::Vector3 vel_n = q_ng.RotateVector(model_->GetWorldLinearVel());
-  math::Vector3 omega_nb_b = q_br.RotateVector(model_->GetRelativeAngularVel());
+  ignition::math::Vector3d vel_b = q_br.RotateVector(model_->RelativeLinearVel());
+  ignition::math::Vector3d vel_n = q_ng.RotateVector(model_->WorldLinearVel());
+  ignition::math::Vector3d omega_nb_b = q_br.RotateVector(model_->RelativeAngularVel());
 
   standard_normal_distribution_ = std::normal_distribution<float>(0, 0.01f);
-  math::Vector3 mag_noise_b(
+  ignition::math::Vector3d mag_noise_b(
     standard_normal_distribution_(random_generator_),
     standard_normal_distribution_(random_generator_),
     standard_normal_distribution_(random_generator_));
 
-  math::Vector3 accel_b = q_br.RotateVector(math::Vector3(
+  ignition::math::Vector3d accel_b = q_br.RotateVector(ignition::math::Vector3d(
     imu_message->linear_acceleration().x(),
     imu_message->linear_acceleration().y(),
     imu_message->linear_acceleration().z()));
-  math::Vector3 gyro_b = q_br.RotateVector(math::Vector3(
+  ignition::math::Vector3d gyro_b = q_br.RotateVector(ignition::math::Vector3d(
     imu_message->angular_velocity().x(),
     imu_message->angular_velocity().y(),
     imu_message->angular_velocity().z()));
-  math::Vector3 mag_b = q_nb.RotateVectorReverse(mag_n) + mag_noise_b;
+  ignition::math::Vector3d mag_b = q_nb.RotateVectorReverse(mag_n) + mag_noise_b;
 
   mavlink_hil_sensor_t sensor_msg;
-  sensor_msg.time_usec = world_->GetSimTime().nsec*1000;
-  sensor_msg.xacc = accel_b.x;
-  sensor_msg.yacc = accel_b.y;
-  sensor_msg.zacc = accel_b.z;
-  sensor_msg.xgyro = gyro_b.x;
-  sensor_msg.ygyro = gyro_b.y;
-  sensor_msg.zgyro = gyro_b.z;
-  sensor_msg.xmag = mag_b.x;
-  sensor_msg.ymag = mag_b.y;
-  sensor_msg.zmag = mag_b.z;
+  sensor_msg.time_usec = world_->SimTime().nsec*1000;
+  sensor_msg.xacc = accel_b.X();
+  sensor_msg.yacc = accel_b.Y();
+  sensor_msg.zacc = accel_b.Z();
+  sensor_msg.xgyro = gyro_b.X();
+  sensor_msg.ygyro = gyro_b.Y();
+  sensor_msg.zgyro = gyro_b.Z();
+  sensor_msg.xmag = mag_b.X();
+  sensor_msg.ymag = mag_b.Y();
+  sensor_msg.zmag = mag_b.Z();
   sensor_msg.abs_pressure = 0.0;
   float rho = 1.2754f; // density of air, TODO why is this not 1.225 as given by std. atmos.
-  sensor_msg.diff_pressure = 0.5f*rho*vel_b.x*vel_b.x / 100;
+  sensor_msg.diff_pressure = 0.5f*rho*vel_b.X()*vel_b.X() / 100;
 
   float p1, p2;
 
@@ -716,49 +717,49 @@ void GazeboMavlinkInterface::ImuCallback(ImuPtr& imu_message) {
   } while (p1 <= FLT_EPSILON);
 
   float n = sqrtf(-2.0 * logf(p1)) * cosf(2.0f * M_PI * p2);
-  float alt_n = -pos_n.z + n * sqrtf(0.006f);
+  float alt_n = -pos_n.Z() + n * sqrtf(0.006f);
 
-  sensor_msg.pressure_alt = (std::isfinite(alt_n)) ? alt_n : -pos_n.z;
+  sensor_msg.pressure_alt = (std::isfinite(alt_n)) ? alt_n : -pos_n.Z();
   sensor_msg.temperature = 0.0;
   sensor_msg.fields_updated = 4095;
 
   //gyro needed for optical flow message
-  optflow_xgyro = gyro_b.x;
-  optflow_ygyro = gyro_b.y;
-  optflow_zgyro = gyro_b.z;
+  optflow_xgyro = gyro_b.X();
+  optflow_ygyro = gyro_b.Y();
+  optflow_zgyro = gyro_b.Z();
 
   send_mavlink_message(MAVLINK_MSG_ID_HIL_SENSOR, &sensor_msg, 200);
 
   // ground truth
-  math::Vector3 accel_true_b = q_br.RotateVector(model_->GetRelativeLinearAccel());
+  ignition::math::Vector3d accel_true_b = q_br.RotateVector(model_->RelativeLinearAccel());
 
   // send ground truth
   mavlink_hil_state_quaternion_t hil_state_quat;
-  hil_state_quat.time_usec = world_->GetSimTime().nsec*1000;
-  hil_state_quat.attitude_quaternion[0] = q_nb.w;
-  hil_state_quat.attitude_quaternion[1] = q_nb.x;
-  hil_state_quat.attitude_quaternion[2] = q_nb.y;
-  hil_state_quat.attitude_quaternion[3] = q_nb.z;
+  hil_state_quat.time_usec = world_->SimTime().nsec*1000;
+  hil_state_quat.attitude_quaternion[0] = q_nb.W();
+  hil_state_quat.attitude_quaternion[1] = q_nb.X();
+  hil_state_quat.attitude_quaternion[2] = q_nb.Y();
+  hil_state_quat.attitude_quaternion[3] = q_nb.Z();
 
-  hil_state_quat.rollspeed = omega_nb_b.x;
-  hil_state_quat.pitchspeed = omega_nb_b.y;
-  hil_state_quat.yawspeed = omega_nb_b.z;
+  hil_state_quat.rollspeed = omega_nb_b.X();
+  hil_state_quat.pitchspeed = omega_nb_b.Y();
+  hil_state_quat.yawspeed = omega_nb_b.Z();
 
   hil_state_quat.lat = lat_rad * 180 / M_PI * 1e7;
   hil_state_quat.lon = lon_rad * 180 / M_PI * 1e7;
-  hil_state_quat.alt = (-pos_n.z + alt_home) * 1000;
+  hil_state_quat.alt = (-pos_n.Z() + alt_home) * 1000;
 
-  hil_state_quat.vx = vel_n.x * 100;
-  hil_state_quat.vy = vel_n.y * 100;
-  hil_state_quat.vz = vel_n.z * 100;
+  hil_state_quat.vx = vel_n.X() * 100;
+  hil_state_quat.vy = vel_n.Y() * 100;
+  hil_state_quat.vz = vel_n.Z() * 100;
 
   // assumed indicated airspeed due to flow aligned with pitot (body x)
-  hil_state_quat.ind_airspeed = vel_b.x;
-  hil_state_quat.true_airspeed = model_->GetWorldLinearVel().GetLength() * 100; //no wind simulated
+  hil_state_quat.ind_airspeed = vel_b.X();
+  hil_state_quat.true_airspeed = model_->WorldLinearVel().Length() * 100; //no wind simulated
 
-  hil_state_quat.xacc = accel_true_b.x * 1000;
-  hil_state_quat.yacc = accel_true_b.y * 1000;
-  hil_state_quat.zacc = accel_true_b.z * 1000;
+  hil_state_quat.xacc = accel_true_b.X() * 1000;
+  hil_state_quat.yacc = accel_true_b.Y() * 1000;
+  hil_state_quat.zacc = accel_true_b.Z() * 1000;
 
   send_mavlink_message(MAVLINK_MSG_ID_HIL_STATE_QUATERNION, &hil_state_quat, 200);
 }
@@ -874,7 +875,7 @@ void GazeboMavlinkInterface::handle_message(mavlink_message_t *msg)
       armed = true;
     }
 
-    last_actuator_time_ = world_->GetSimTime();
+    last_actuator_time_ = world_->SimTime();
 
     for (unsigned i = 0; i < n_out_max; i++) {
       input_index_[i] = i;
@@ -916,7 +917,7 @@ void GazeboMavlinkInterface::handle_control(double _dt)
         }
         else if (joint_control_type_[i] == "position")
         {
-          double current = joints_[i]->GetAngle(0).Radian();
+          double current = joints_[i]->Position(0);
           double err = current - target;
           double force = pids_[i].Update(err, _dt);
           joints_[i]->SetForce(0, force);

--- a/src/gazebo_multirotor_base_plugin.cpp
+++ b/src/gazebo_multirotor_base_plugin.cpp
@@ -25,7 +25,8 @@
 namespace gazebo {
 
 GazeboMultirotorBasePlugin::~GazeboMultirotorBasePlugin() {
-  event::Events::DisconnectWorldUpdateBegin(update_connection_);
+  //event::Events::DisconnectWorldUpdateBegin(update_connection_);
+  update_connection_->~Connection();
 }
 
 void GazeboMultirotorBasePlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf) {
@@ -75,7 +76,7 @@ void GazeboMultirotorBasePlugin::Load(physics::ModelPtr _model, sdf::ElementPtr 
 // This gets called by the world update start event.
 void GazeboMultirotorBasePlugin::OnUpdate(const common::UpdateInfo& _info) {
   // Get the current simulation time.
-  common::Time now = world_->GetSimTime();
+  common::Time now = world_->SimTime();
   mav_msgs::msgs::MotorSpeed msg;
   MotorNumberToJointMap::iterator m;
   for (m = motor_joints_.begin(); m != motor_joints_.end(); ++m) {

--- a/src/liftdrag_plugin/liftdrag_plugin.cpp
+++ b/src/liftdrag_plugin/liftdrag_plugin.cpp
@@ -17,6 +17,7 @@
 
 #include <algorithm>
 #include <string>
+#include <ignition/math.hh>
 
 #include "gazebo/common/Assert.hh"
 #include "gazebo/physics/physics.hh"
@@ -32,9 +33,9 @@ GZ_REGISTER_MODEL_PLUGIN(LiftDragPlugin)
 /////////////////////////////////////////////////
 LiftDragPlugin::LiftDragPlugin() : cla(1.0), cda(0.01), cma(0.01), rho(1.2041)
 {
-  this->cp = math::Vector3(0, 0, 0);
-  this->forward = math::Vector3(1, 0, 0);
-  this->upward = math::Vector3(0, 0, 1);
+  this->cp = ignition::math::Vector3d(0, 0, 0);
+  this->forward = ignition::math::Vector3d(1, 0, 0);
+  this->upward = ignition::math::Vector3d(0, 0, 1);
   this->area = 1.0;
   this->alpha0 = 0.0;
   this->alpha = 0.0;
@@ -72,7 +73,7 @@ void LiftDragPlugin::Load(physics::ModelPtr _model,
   this->world = this->model->GetWorld();
   GZ_ASSERT(this->world, "LiftDragPlugin world pointer is NULL");
 
-  this->physics = this->world->GetPhysicsEngine();
+  this->physics = this->world->Physics();
   GZ_ASSERT(this->physics, "LiftDragPlugin physics pointer is NULL");
 
   GZ_ASSERT(_sdf, "LiftDragPlugin _sdf pointer is NULL");
@@ -105,16 +106,16 @@ void LiftDragPlugin::Load(physics::ModelPtr _model,
     this->cmaStall = _sdf->Get<double>("cma_stall");
 
   if (_sdf->HasElement("cp"))
-    this->cp = _sdf->Get<math::Vector3>("cp");
+    this->cp = _sdf->Get<ignition::math::Vector3d>("cp");
 
   // blade forward (-drag) direction in link frame
   if (_sdf->HasElement("forward"))
-    this->forward = _sdf->Get<math::Vector3>("forward");
+    this->forward = _sdf->Get<ignition::math::Vector3d>("forward");
   this->forward.Normalize();
 
   // blade upward (+lift) direction in link frame
   if (_sdf->HasElement("upward"))
-    this->upward = _sdf->Get<math::Vector3>("upward");
+    this->upward = _sdf->Get<ignition::math::Vector3d>("upward");
   this->upward.Normalize();
 
   if (_sdf->HasElement("area"))
@@ -162,8 +163,8 @@ void LiftDragPlugin::OnUpdate()
 {
   GZ_ASSERT(this->link, "Link was NULL");
   // get linear velocity at cp in inertial frame
-  math::Vector3 vel = this->link->GetWorldLinearVel(this->cp);
-  math::Vector3 velI = vel;
+  ignition::math::Vector3d vel = this->link->WorldLinearVel(this->cp);
+  ignition::math::Vector3d velI = vel;
   velI.Normalize();
 
   // smoothing
@@ -171,35 +172,35 @@ void LiftDragPlugin::OnUpdate()
   // this->velSmooth = e*vel + (1.0 - e)*velSmooth;
   // vel = this->velSmooth;
 
-  if (vel.GetLength() <= 0.01)
+  if (vel.Length() <= 0.01)
     return;
 
   // pose of body
-  math::Pose pose = this->link->GetWorldPose();
+  ignition::math::Pose3<double> pose = this->link->WorldPose();
 
   // rotate forward and upward vectors into inertial frame
-  math::Vector3 forwardI = pose.rot.RotateVector(this->forward);
+  ignition::math::Vector3d forwardI = pose.Rot().RotateVector(this->forward);
 
-  math::Vector3 upwardI;
+  ignition::math::Vector3d upwardI;
   if (this->radialSymmetry)
   {
     // use inflow velocity to determine upward direction
     // which is the component of inflow perpendicular to forward direction.
-    math::Vector3 tmp = forwardI.Cross(velI);
+    ignition::math::Vector3d tmp = forwardI.Cross(velI);
     upwardI = forwardI.Cross(tmp).Normalize();
   }
   else
   {
-    upwardI = pose.rot.RotateVector(this->upward);
+    upwardI = pose.Rot().RotateVector(this->upward);
   }
 
   // spanwiseI: a vector normal to lift-drag-plane described in inertial frame
-  math::Vector3 spanwiseI = forwardI.Cross(upwardI).Normalize();
+  ignition::math::Vector3d spanwiseI = forwardI.Cross(upwardI).Normalize();
 
   const double minRatio = -1.0;
   const double maxRatio = 1.0;
   // check sweep (angle between velI and lift-drag-plane)
-  double sinSweepAngle = math::clamp(
+  double sinSweepAngle = ignition::math::clamp(
       spanwiseI.Dot(velI), minRatio, maxRatio);
 
   // get cos from trig identity
@@ -220,25 +221,25 @@ void LiftDragPlugin::OnUpdate()
   //
   // so,
   // removing spanwise velocity from vel
-  math::Vector3 velInLDPlane = vel - vel.Dot(spanwiseI)*velI;
+  ignition::math::Vector3d velInLDPlane = vel - vel.Dot(spanwiseI)*velI;
 
   // get direction of drag
-  math::Vector3 dragDirection = -velInLDPlane;
+  ignition::math::Vector3d dragDirection = -velInLDPlane;
   dragDirection.Normalize();
 
   // get direction of lift
-  math::Vector3 liftI = spanwiseI.Cross(velInLDPlane);
+  ignition::math::Vector3d liftI = spanwiseI.Cross(velInLDPlane);
   liftI.Normalize();
 
   // get direction of moment
-  math::Vector3 momentDirection = spanwiseI;
+  ignition::math::Vector3d momentDirection = spanwiseI;
 
   // compute angle between upwardI and liftI
   // in general, given vectors a and b:
   //   cos(theta) = a.Dot(b)/(a.Length()*b.Lenghth())
   // given upwardI and liftI are both unit vectors, we can drop the denominator
   //   cos(theta) = a.Dot(b)
-  double cosAlpha = math::clamp(liftI.Dot(upwardI), minRatio, maxRatio);
+  double cosAlpha = ignition::math::clamp(liftI.Dot(upwardI), minRatio, maxRatio);
 
   // Is alpha positive or negative? Test:
   // forwardI points toward zero alpha
@@ -255,7 +256,7 @@ void LiftDragPlugin::OnUpdate()
                                   : this->alpha + M_PI;
 
   // compute dynamic pressure
-  double speedInLDPlane = velInLDPlane.GetLength();
+  double speedInLDPlane = velInLDPlane.Length();
   double q = 0.5 * this->rho * speedInLDPlane * speedInLDPlane;
 
   // compute cl at cp, check for stall, correct for sweep
@@ -282,13 +283,13 @@ void LiftDragPlugin::OnUpdate()
   // modify cl per control joint value
   if (this->controlJoint)
   {
-    double controlAngle = this->controlJoint->GetAngle(0).Radian();
+    double controlAngle = this->controlJoint->Position(0);
     cl = cl + this->controlJointRadToCL * controlAngle;
     /// \TODO: also change cm and cd
   }
 
   // compute lift force at cp
-  math::Vector3 lift = cl * q * this->area * liftI;
+  ignition::math::Vector3d lift = cl * q * this->area * liftI;
 
   // compute cd at cp, check for stall, correct for sweep
   double cd;
@@ -311,7 +312,7 @@ void LiftDragPlugin::OnUpdate()
   cd = fabs(cd);
 
   // drag at cp
-  math::Vector3 drag = cd * q * this->area * dragDirection;
+  ignition::math::Vector3d drag = cd * q * this->area * dragDirection;
 
   // compute cm at cp, check for stall, correct for sweep
   double cm;
@@ -339,18 +340,18 @@ void LiftDragPlugin::OnUpdate()
   cm = 0.0;
 
   // compute moment (torque) at cp
-  math::Vector3 moment = cm * q * this->area * momentDirection;
+  ignition::math::Vector3d moment = cm * q * this->area * momentDirection;
 
   // moment arm from cg to cp in inertial plane
-  math::Vector3 momentArm = pose.rot.RotateVector(
-    this->cp - this->link->GetInertial()->GetCoG());
+  ignition::math::Vector3d momentArm = pose.Rot().RotateVector(
+    this->cp - this->link->GetInertial()->CoG());
   // gzerr << this->cp << " : " << this->link->GetInertial()->GetCoG() << "\n";
 
   // force and torque about cg in inertial frame
-  math::Vector3 force = lift + drag;
+  ignition::math::Vector3d force = lift + drag;
   // + moment.Cross(momentArm);
 
-  math::Vector3 torque = moment;
+  ignition::math::Vector3d torque = moment;
   // - lift.Cross(momentArm) - drag.Cross(momentArm);
 
   // debug
@@ -366,9 +367,9 @@ void LiftDragPlugin::OnUpdate()
     gzdbg << "Link: [" << this->link->GetName()
           << "] pose: [" << pose
           << "] dynamic pressure: [" << q << "]\n";
-    gzdbg << "spd: [" << vel.GetLength()
+    gzdbg << "spd: [" << vel.Length()
           << "] vel: [" << vel << "]\n";
-    gzdbg << "LD plane spd: [" << velInLDPlane.GetLength()
+    gzdbg << "LD plane spd: [" << velInLDPlane.Length()
           << "] vel : [" << velInLDPlane << "]\n";
     gzdbg << "forward (inertial): " << forwardI << "\n";
     gzdbg << "upward (inertial): " << upwardI << "\n";


### PR DESCRIPTION
Rewrote the sitl_gazebo plugin to work with the newest version of Gazebo. The Gazebo 8 fixes used functions that were marked as deprecated in Gazebo 8, but have been removed since. In addition, I wrote support for the ignition math library, which has replaced the gazebo math library.