### PR TITLE
cmake: include a level above for mavlink

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,7 +128,7 @@ include_directories(
   /usr/local/include/OGRE
   /usr/local/include/OGRE/Paging
   ${GSTREAMER_INCLUDE_DIRS}
-  ../../mavlink/include
+  ../../../mavlink/include
   )
 
 link_libraries(


### PR DESCRIPTION
This will fix the build of https://github.com/PX4/Firmware/pull/7851, where I pushed `sitl_gazebo` to lower directory, bellow `sim_tools`.
Though in this process, I found out that there is an issue with our build when we use `sitl_gazebo` out of the Firmware tree - since it relays on the Mavlink ROS release, if one is not synced with the current mavlink release being used on `sitl_gazebo` plugins, it basically won't build.
Here the build error that occurs:
```bash
*error: too many arguments to function ‘uint16_t mavlink_msg_command_ack_pack_chan(uint8_t, uint8_t, uint8_t, mavlink_message_t*, uint16_t, uint8_t, uint8_t)’
                                      msg.compid);*
```
which is related to https://github.com/PX4/sitl_gazebo/commit/ef7d0aa81321521a8b2496131d636858b95b6068.
So though this fixes the build and allows CI to run, for guys like me that like to work out of the Firmware branch for SITL development, this is currently broken unless I manually update the msg definitions with `pymavlink` or hardcode the path of the latest `mavlink.h`.