### PR TITLE
Enable Video Streaming by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,8 @@ include(GNUInstallDirs)
 list(APPEND CMAKE_MODULE_PATH /usr/local/share/cmake/Modules)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 
-option(BUILD_GSTREAMER_PLUGIN "enable gstreamer plugin" "OFF")
+option(BUILD_GSTREAMER_PLUGIN "enable gstreamer plugin" "ON")
+
 option(BUILD_ROS_INTERFACE "enable ROS subscriber for motor failure plugin" "OFF")
 
 ## System dependencies are found with CMake's conventions

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,10 @@ find_package(OpenCV REQUIRED)
 find_package(Boost REQUIRED COMPONENTS system thread timer)
 if (BUILD_GSTREAMER_PLUGIN)
   find_package(GStreamer)
+  find_package (Qt4)
+  include (${QT_USE_FILE})
+  include_directories(SYSTEM ${GAZEBO_INCLUDE_DIRS})
+  link_directories(${GAZEBO_LIBRARY_DIRS})
 endif()
 add_subdirectory( external/OpticalFlow OpticalFlow )
 set( OpticalFlow_LIBS "OpticalFlow" )
@@ -252,11 +256,19 @@ endif()
 
 if (GSTREAMER_FOUND)
   add_library(gazebo_gst_camera_plugin SHARED src/gazebo_gst_camera_plugin.cpp)
+  QT4_WRAP_CPP(headers_MOC include/gazebo_video_stream_widget.h)
+  add_library(gazebo_video_stream_widget SHARED ${headers_MOC} src/gazebo_video_stream_widget.cpp)
+  target_link_libraries(gazebo_video_stream_widget ${GAZEBO_LIBRARIES} ${QT_LIBRARIES} ${PROTOBUF_LIBRARIES})
   set(plugins
     ${plugins}
     gazebo_gst_camera_plugin
   )
+  set(plugins
+    ${plugins}
+    gazebo_video_stream_widget
+  )
   message(STATUS "Found GStreamer: adding gst_camera_plugin")
+  message(STATUS "Found GStreamer: adding gst_video_stream_widget")
 endif()
 
 # Linux is not consistent with plugin availability, even on Gazebo 7

--- a/include/gazebo_gst_camera_plugin.h
+++ b/include/gazebo_gst_camera_plugin.h
@@ -54,7 +54,12 @@ class GAZEBO_VISIBLE GstCameraPlugin : public SensorPlugin
 		unsigned int depth, const std::string &format);
 
   public: void startGstThread();
+  public: void stopGstThread();
   public: void gstCallback(GstElement *appsrc);
+
+  public: void cbVideoStream(const boost::shared_ptr<const msgs::Int> &_msg);
+  private: void startStreaming();
+  private: void stopStreaming();
 
   protected: unsigned int width, height, depth;
   float rate;
@@ -69,7 +74,11 @@ class GAZEBO_VISIBLE GstCameraPlugin : public SensorPlugin
 
   private: transport::NodePtr node_handle_;
   private: std::string namespace_;
-  private: const std::string topicName = "gst_video";
+
+  private: transport::SubscriberPtr mVideoSub;
+  private: pthread_t mThreadId;
+  private: const std::string mTopicName = "~/video_stream";
+  private: bool mIsActive;
 
   GstBuffer *frameBuffer;
   std::mutex frameBufferMutex;

--- a/include/gazebo_video_stream_widget.h
+++ b/include/gazebo_video_stream_widget.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2014 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+#ifndef _VIDEO_STREAM_WIDGET_H_
+#define _VIDEO_STREAM_WIDGET_H_
+
+#include <gazebo/common/Plugin.hh>
+#include <gazebo/gui/GuiPlugin.hh>
+#ifndef Q_MOC_RUN  // See: https://bugreports.qt-project.org/browse/QTBUG-22829
+# include <gazebo/transport/transport.hh>
+# include <gazebo/gui/gui.hh>
+#endif
+
+namespace gazebo
+{
+    class GAZEBO_VISIBLE VideoStreamWidget : public GUIPlugin
+    {
+      Q_OBJECT
+
+      /// \brief Constructor
+      /// \param[in] _parent Parent widget
+      public: VideoStreamWidget();
+
+      /// \brief Destructor
+      public: virtual ~VideoStreamWidget();
+
+      /// \brief Callback trigged when the button is pressed.
+      protected slots: void OnButton();
+
+      /// \brief Counter used to create unique model names
+      private: unsigned int counter;
+
+      QPushButton *mButton;
+
+      private: bool mVideoON;
+      private: void enable();
+      private: void disable();
+    };
+}
+#endif
+

--- a/include/gazebo_video_stream_widget.h
+++ b/include/gazebo_video_stream_widget.h
@@ -43,8 +43,13 @@ namespace gazebo
       /// \brief Counter used to create unique model names
       private: unsigned int counter;
 
-      QPushButton *mButton;
+      /// \brief Node used to establish communication with gzserver.
+      private: transport::NodePtr node;
 
+      /// \brief Publisher of video streaming control messages.
+      private: transport::PublisherPtr videoPub;
+
+      private: QPushButton *mButton;
       private: bool mVideoON;
       private: void enable();
       private: void disable();

--- a/models/typhoon_h480/typhoon_h480.sdf
+++ b/models/typhoon_h480/typhoon_h480.sdf
@@ -417,13 +417,11 @@
         </plugin>
         -->
         <!-- GStreamer camera plugin (needs a lot of CPU! Consider lowering the
-             camera image size when enabling) -->
-        <!--
+             camera image size) -->
         <plugin name="GstCameraPlugin" filename="libgazebo_gst_camera_plugin.so">
             <robotNamespace></robotNamespace>
             <udpPort>5600</udpPort>
         </plugin>
-        -->
         <plugin name="GeotaggedImagesPlugin" filename="libgazebo_geotagged_images_plugin.so">
             <robotNamespace></robotNamespace>
             <interval>1</interval>

--- a/src/gazebo_video_stream_widget.cpp
+++ b/src/gazebo_video_stream_widget.cpp
@@ -16,6 +16,7 @@
 */
 #include <sstream>
 #include <gazebo/msgs/msgs.hh>
+#include <std_msgs/Int32.h>
 #include "gazebo_video_stream_widget.h"
 
 using namespace gazebo;
@@ -66,6 +67,12 @@ VideoStreamWidget::VideoStreamWidget()
   this->move(10, 10);
   this->resize(100, 30);
 
+  // Create a node for transportation
+  this->node = transport::NodePtr(new transport::Node());
+  this->node->Init();
+  this->videoPub = this->node->Advertise<msgs::Int>("~/video_stream");
+  videoPub->WaitForConnection();
+
   if(mVideoON)
     enable();
   else
@@ -94,6 +101,11 @@ void VideoStreamWidget::OnButton()
 void VideoStreamWidget::enable()
 {
   gzwarn << "Enable Video Streaming \n";
+
+  msgs::Int request;
+  request.set_data(1);
+  videoPub->Publish(request);
+
   mButton->setText("Video: ON");
   mButton->setStyleSheet(QString("QPushButton {"
                                   "background-color: green; font-weight: bold"
@@ -105,6 +117,11 @@ void VideoStreamWidget::enable()
 void VideoStreamWidget::disable()
 {
   gzwarn << "Disable Video Streaming \n";
+
+  msgs::Int request;
+  request.set_data(0);
+  videoPub->Publish(request);
+
   mButton->setText("Video: OFF");
   mButton->setStyleSheet(QString("QPushButton {"
                                   "background-color: red; font-weight: bold"

--- a/src/gazebo_video_stream_widget.cpp
+++ b/src/gazebo_video_stream_widget.cpp
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2014 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+#include <sstream>
+#include <gazebo/msgs/msgs.hh>
+#include "gazebo_video_stream_widget.h"
+
+using namespace gazebo;
+
+// Register this plugin with the simulator
+GZ_REGISTER_GUI_PLUGIN(VideoStreamWidget)
+
+/////////////////////////////////////////////////
+VideoStreamWidget::VideoStreamWidget()
+  : GUIPlugin()
+  , mVideoON(false)
+{
+  this->counter = 0;
+
+  // Set the frame background and foreground colors
+  this->setStyleSheet(
+      "QFrame { background-color : rgba(100, 100, 100, 255); color : white; }");
+
+  // Create the main layout
+  QHBoxLayout *mainLayout = new QHBoxLayout;
+
+  // Create the frame to hold all the widgets
+  QFrame *mainFrame = new QFrame();
+
+  // Create the layout that sits inside the frame
+  QVBoxLayout *frameLayout = new QVBoxLayout();
+
+  // Create a push button, and connect it to the OnButton function
+  mButton = new QPushButton(tr("Video: OFF"));
+  connect(mButton, SIGNAL(clicked()), this, SLOT(OnButton()));
+
+  // Add the button to the frame's layout
+  frameLayout->addWidget(mButton);
+
+  // Add frameLayout to the frame
+  mainFrame->setLayout(frameLayout);
+
+  // Add the frame to the main layout
+  mainLayout->addWidget(mainFrame);
+
+  // Remove margins to reduce space
+  frameLayout->setContentsMargins(0, 0, 0, 0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
+
+  this->setLayout(mainLayout);
+
+  // Position and resize this widget
+  this->move(10, 10);
+  this->resize(100, 30);
+
+  if(mVideoON)
+    enable();
+  else
+    disable();
+
+}
+
+/////////////////////////////////////////////////
+VideoStreamWidget::~VideoStreamWidget()
+{
+}
+
+/////////////////////////////////////////////////
+void VideoStreamWidget::OnButton()
+{
+  if(mVideoON) {
+    mVideoON = false;
+    disable();
+  } else {
+    mVideoON = true;
+    enable();
+  }
+
+}
+
+void VideoStreamWidget::enable()
+{
+  gzwarn << "Enable Video Streaming \n";
+  mButton->setText("Video: ON");
+  mButton->setStyleSheet(QString("QPushButton {"
+                                  "background-color: green; font-weight: bold"
+                                  "}")
+                             );
+
+}
+
+void VideoStreamWidget::disable()
+{
+  gzwarn << "Disable Video Streaming \n";
+  mButton->setText("Video: OFF");
+  mButton->setStyleSheet(QString("QPushButton {"
+                                  "background-color: red; font-weight: bold"
+                                  "}")
+                             );
+
+}
+
+
+

--- a/worlds/typhoon_h480.world
+++ b/worlds/typhoon_h480.world
@@ -2,6 +2,9 @@
 <sdf version="1.5">
   <world name="default">
     <!-- A global light source -->
+    <gui>
+      <plugin name="video_widget" filename="libgazebo_video_stream_widget.so"/>
+    </gui>
     <include>
       <uri>model://sun</uri>
     </include>


### PR DESCRIPTION
This is to enable video streaming over UDP by default.
Would like to highlight following things- 
1. As mentioned while disabling, should we lower the camera image size (640x360) ?
2. Currently, the video stream from gazebo can be played running a gstreamer pipeline. However QGC is not able to play the video due to gstreamer errors (https://github.com/mavlink/qgroundcontrol/issues/5447). This is due to the color format mismatch. Adding color conversion(RGB->NV12) in the UDP streaming gst pipeline in GstCameraPlugin should fix this. However when I do that, I get following errors while running gazebo -

> [Err] [ConnectionManager.cc:119] Failed to connect to master in 30 seconds.
> [Err] [gazebo_shared.cc:83] Unable to initialize transport.
> [Err] [gazebo_client.cc:62] Unable to setup Gazebo

3. Another way to fix https://github.com/mavlink/qgroundcontrol/issues/5447 is to add videoconvert element in the video receiving gstreamer pipeline of QGC. When I do that, I can see video streams from gazebo in QGC. @dogmaphobic Is it OK to make this change in QGC?