### PR TITLE
Add IRLock simulation and GPS noise

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,6 +183,7 @@ set (msgs
   msgs/MotorSpeed.proto
   #msgs/Wind.proto
   msgs/sonarSens.proto
+  msgs/irlock.proto
 )
 PROTOBUF_GENERATE_CPP(PROTO_SRCS PROTO_HDRS ${msgs})
 add_library(mav_msgs SHARED ${PROTO_SRCS})
@@ -207,6 +208,7 @@ add_library(rotors_gazebo_imu_plugin SHARED src/gazebo_imu_plugin.cpp)
 add_library(gazebo_opticalFlow_plugin SHARED src/gazebo_opticalFlow_plugin.cpp)
 target_link_libraries(gazebo_opticalFlow_plugin ${OpticalFlow_LIBS})
 add_library(gazebo_lidar_plugin SHARED src/gazebo_lidar_plugin.cpp)
+add_library(gazebo_irlock_plugin SHARED src/gazebo_irlock_plugin.cpp)
 add_library(rotors_gazebo_mavlink_interface SHARED src/gazebo_mavlink_interface.cpp src/geo_mag_declination.cpp)
 #add_library(rotors_gazebo_wind_plugin SHARED src/gazebo_wind_plugin.cpp)
 add_library(gazebo_sonar_plugin SHARED src/gazebo_sonar_plugin.cpp)
@@ -219,6 +221,7 @@ set(plugins
   rotors_gazebo_imu_plugin
   gazebo_opticalFlow_plugin
   gazebo_lidar_plugin
+  gazebo_irlock_plugin
   rotors_gazebo_mavlink_interface
   #rotors_gazebo_wind_plugin
   gazebo_sonar_plugin

--- a/include/gazebo_irlock_plugin.h
+++ b/include/gazebo_irlock_plugin.h
@@ -1,0 +1,44 @@
+#ifndef _GAZEBO_IRLOCK_PLUGIN_HH_
+#define _GAZEBO_IRLOCK_PLUGIN_HH_
+
+#include <string>
+
+#include "gazebo/common/Plugin.hh"
+#include "gazebo/sensors/LogicalCameraSensor.hh"
+#include "gazebo/gazebo.hh"
+#include "gazebo/common/common.hh"
+#include "gazebo/util/system.hh"
+#include "gazebo/transport/transport.hh"
+#include "gazebo/msgs/msgs.hh"
+#include "gazebo/physics/physics.hh"
+#include "gazebo/math/gzmath.hh"
+
+#include "irlock.pb.h"
+
+#include <iostream>
+
+using namespace std;
+
+namespace gazebo
+{
+  class GAZEBO_VISIBLE IRLockPlugin : public SensorPlugin
+  {
+    public:
+      IRLockPlugin();
+      virtual ~IRLockPlugin();
+      virtual void Load(sensors::SensorPtr _sensor, sdf::ElementPtr _sdf);
+      virtual void OnUpdated();
+
+    protected:
+      sensors::LogicalCameraSensorPtr camera;
+
+    private:
+      event::ConnectionPtr updateConnection;
+      transport::PublisherPtr irlock_pub_;
+      transport::NodePtr node_handle_;
+      irlock_msgs::msgs::irlock irlock_message;
+      std::string namespace_;
+
+  };
+}
+#endif

--- a/include/gazebo_mavlink_interface.h
+++ b/include/gazebo_mavlink_interface.h
@@ -36,6 +36,7 @@
 #include "opticalFlow.pb.h"
 #include "lidar.pb.h"
 #include "sonarSens.pb.h"
+#include <irlock.pb.h>
 #include <boost/bind.hpp>
 
 #include <iostream>
@@ -59,6 +60,7 @@ typedef const boost::shared_ptr<const sensor_msgs::msgs::Imu> ImuPtr;
 typedef const boost::shared_ptr<const lidar_msgs::msgs::lidar> LidarPtr;
 typedef const boost::shared_ptr<const opticalFlow_msgs::msgs::opticalFlow> OpticalFlowPtr;
 typedef const boost::shared_ptr<const sonarSens_msgs::msgs::sonarSens> SonarSensPtr;
+typedef const boost::shared_ptr<const irlock_msgs::msgs::irlock> IRLockPtr;
 
 // Default values
 static const std::string kDefaultNamespace = "";
@@ -71,6 +73,7 @@ static const std::string kDefaultImuTopic = "/imu";
 static const std::string kDefaultLidarTopic = "/lidar/link/lidar";
 static const std::string kDefaultOpticalFlowTopic = "/camera/link/opticalFlow";
 static const std::string kDefaultSonarTopic = "/sonar_model/link/sonar";
+static const std::string kDefaultIRLockTopic = "/camera/link/irlock";
 
 class GazeboMavlinkInterface : public ModelPlugin {
  public:
@@ -84,6 +87,7 @@ class GazeboMavlinkInterface : public ModelPlugin {
         opticalFlow_sub_topic_(kDefaultOpticalFlowTopic),
         lidar_sub_topic_(kDefaultLidarTopic),
         sonar_sub_topic_(kDefaultSonarTopic),
+        irlock_sub_topic_(kDefaultIRLockTopic),
         model_{},
         world_(nullptr),
         left_elevon_joint_(nullptr),
@@ -154,6 +158,7 @@ class GazeboMavlinkInterface : public ModelPlugin {
   void LidarCallback(LidarPtr& lidar_msg);
   void SonarCallback(SonarSensPtr& sonar_msg);
   void OpticalFlowCallback(OpticalFlowPtr& opticalFlow_msg);
+  void IRLockCallback(IRLockPtr& irlock_msg);
   void send_mavlink_message(const mavlink_message_t *message, const int destination_port=0);
   void handle_message(mavlink_message_t *msg);
   void pollForMAVLinkMessages(double _dt, uint32_t _timeoutMs);
@@ -180,11 +185,13 @@ class GazeboMavlinkInterface : public ModelPlugin {
   transport::SubscriberPtr lidar_sub_;
   transport::SubscriberPtr sonar_sub_;
   transport::SubscriberPtr opticalFlow_sub_;
+  transport::SubscriberPtr irlock_sub_;
   transport::PublisherPtr gps_pub_;
   std::string imu_sub_topic_;
   std::string lidar_sub_topic_;
   std::string opticalFlow_sub_topic_;
   std::string sonar_sub_topic_;
+  std::string irlock_sub_topic_;
 
   common::Time last_time_;
   common::Time last_gps_time_;

--- a/include/gazebo_mavlink_interface.h
+++ b/include/gazebo_mavlink_interface.h
@@ -169,6 +169,9 @@ class GazeboMavlinkInterface : public ModelPlugin {
   static constexpr double ev_corellation_time = 60.0; // s
   static constexpr double ev_random_walk = 2.0; // (m/s) / sqrt(hz)
   static constexpr double ev_noise_density = 2e-4; // (m) / sqrt(hz)
+  static constexpr double gps_corellation_time = 30.0; // s
+  static constexpr double gps_random_walk = 1.0; // (m/s) / sqrt(hz)
+  static constexpr double gps_noise_density = 2e-4; // (m) / sqrt(hz)
 
   unsigned _rotor_count;
 
@@ -206,6 +209,9 @@ class GazeboMavlinkInterface : public ModelPlugin {
   double ev_bias_x_;
   double ev_bias_y_;
   double ev_bias_z_;
+  double gps_bias_x_;
+  double gps_bias_y_;
+  double gps_bias_z_;
 
   void handle_control(double _dt);
 

--- a/include/irlock.h
+++ b/include/irlock.h
@@ -1,0 +1,42 @@
+
+#ifndef IRLOCK_H_
+#define IRLOCK_H_
+
+/** irlock constants */
+
+#define IRLOCK_RES_X 320
+#define IRLOCK_RES_Y 200
+
+#define IRLOCK_CENTER_X				(IRLOCK_RES_X/2)			// the x-axis center pixel position
+#define IRLOCK_CENTER_Y				(IRLOCK_RES_Y/2)			// the y-axis center pixel position
+
+#define IRLOCK_FOV_X (60.0f*M_PI_F/180.0f)
+#define IRLOCK_FOV_Y (35.0f*M_PI_F/180.0f)
+
+#define IRLOCK_TAN_HALF_FOV_X 0.57735026919f // tan(0.5 * 60 * pi/180)
+#define IRLOCK_TAN_HALF_FOV_Y 0.31529878887f // tan(0.5 * 35 * pi/180)
+
+#define IRLOCK_TAN_ANG_PER_PIXEL_X	(2*IRLOCK_TAN_HALF_FOV_X/IRLOCK_RES_X)
+#define IRLOCK_TAN_ANG_PER_PIXEL_Y	(2*IRLOCK_TAN_HALF_FOV_Y/IRLOCK_RES_Y)
+
+/** irlock data structures */
+
+#define IRLOCK_OBJECTS_MAX	5	/** up to 5 objects can be detected/reported **/
+
+struct irlock_target_s {
+	uint16_t signature;	/** target signature **/
+	float pos_x;	/** x-axis distance from center of image to center of target in units of tan(theta) **/
+	float pos_y;	/** y-axis distance from center of image to center of target in units of tan(theta) **/
+	float size_x;	/** size of target along x-axis in units of tan(theta) **/
+	float size_y;	/** size of target along y-axis in units of tan(theta) **/
+};
+
+/** irlock_s structure returned from read calls **/
+struct irlock_s {
+	uint64_t timestamp; /** microseconds since system start **/
+	uint8_t num_targets;
+	struct irlock_target_s targets[IRLOCK_OBJECTS_MAX];
+};
+
+
+#endif /* IRLOCK_H_ */

--- a/models/iris_irlock/iris_irlock.sdf
+++ b/models/iris_irlock/iris_irlock.sdf
@@ -1,0 +1,41 @@
+<sdf version='1.5'>
+  <model name='iris_irlock'>
+
+    <include>
+      <uri>model://iris</uri>
+    </include>
+
+    <include>
+      <uri>model://lidar</uri>
+      <pose>-0.12 0 0 0 3.1415 0</pose>
+    </include>
+    <joint name="lidar_joint" type="revolute">
+      <child>lidar::link</child>
+      <parent>iris::base_link</parent>
+      <axis>
+        <xyz>0 0 1</xyz>
+        <limit>
+          <upper>0</upper>
+          <lower>0</lower>
+        </limit>
+      </axis>
+    </joint>
+
+    <include>
+      <uri>model://irlock</uri>
+      <pose>-0 0 0 0 1.5708 0</pose>
+    </include>
+    <joint name="irlock_joint" type="revolute">
+      <child>camera::link</child>
+      <parent>iris::base_link</parent>
+      <axis>
+        <xyz>0 0 1</xyz>
+        <limit>
+          <upper>0</upper>
+          <lower>0</lower>
+        </limit>
+      </axis>
+    </joint>
+
+  </model>
+</sdf>

--- a/models/iris_irlock/model.config
+++ b/models/iris_irlock/model.config
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<model>
+  <name>3DR Iris with lidar and IRLock</name>
+  <version>1.0</version>
+  <sdf version='1.4'>iris_irlock.sdf</sdf>
+
+  <author>
+   <name>Daniel Agar</name>
+   <email>daniel@agar.ca</email>
+  </author>
+
+  <description>
+    This is a model of the 3DR Iris Quadrotor with lidar and IRLock sensors. The original model has been created by
+    Thomas Gubler and is maintained by Lorenz Meier. The sensors have been created by Christoph Tobler and Daniel Agar, respectively.
+  </description>
+</model>

--- a/models/irlock/model.config
+++ b/models/irlock/model.config
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<model>
+  <name>irlock</name>
+  <version>1.0</version>
+  <sdf version='1.4'>model.sdf</sdf>
+
+  <author>
+   <name>Daniel Agar</name>
+   <email>daniel@agar.ca</email>
+  </author>
+
+  <description>
+    IRLock camera
+  </description>
+</model>

--- a/models/irlock/model.sdf
+++ b/models/irlock/model.sdf
@@ -1,0 +1,44 @@
+<?xml version="1.0" ?>
+<sdf version="1.4">
+  <model name="camera">
+    <link name="link">
+      <inertial>
+        <pose>0.01 0.025 0.025 0 -0 0</pose>
+        <mass>0.01</mass>
+        <inertia>
+          <ixx>4.15e-6</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>2.407e-6</iyy>
+          <iyz>0</iyz>
+          <izz>2.407e-6</izz>
+        </inertia>
+      </inertial>
+      <visual name="visual">
+        <geometry>
+          <box>
+            <size>0.02 0.05 0.05</size>
+          </box>
+        </geometry>
+      </visual>
+
+      <sensor name="IRLock" type="logical_camera">
+        <always_on>true</always_on>
+        <update_rate>50.0</update_rate> <!-- according to IRLock spec -->
+        <visualize>true</visualize>
+        <topic>/irlock</topic>
+        <logical_camera>
+          <horizontal_fov>0.611</horizontal_fov> <!-- 35 deg -->
+          <near>0.1</near>
+          <far>15</far> <!-- detection range according to IRLock spec -->
+          <aspect_ratio>1.71</aspect_ratio>
+        </logical_camera>
+        <plugin name="irlock_plugin" filename="libgazebo_irlock_plugin.so">
+            <robotNamespace></robotNamespace>
+        </plugin>
+      </sensor>
+    </link>
+
+  </model>
+</sdf>
+<!-- vim: set et fenc=utf-8 ff=unix sts=0 sw=4 ts=4 : -->

--- a/msgs/irlock.proto
+++ b/msgs/irlock.proto
@@ -1,0 +1,12 @@
+syntax = "proto2";
+package irlock_msgs.msgs;
+
+message irlock
+{
+  required float time_usec	= 1;
+  required int32 signature	= 2;
+  required float pos_x		= 3;
+  required float pos_y		= 4;
+  required float size_x		= 5;
+  required float size_y		= 6;
+}

--- a/src/gazebo_irlock_plugin.cpp
+++ b/src/gazebo_irlock_plugin.cpp
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2012-2015 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+#ifdef _WIN32
+  // Ensure that Winsock2.h is included before Windows.h, which can get
+  // pulled in by anybody (e.g., Boost).
+#include <Winsock2.h>
+#endif
+
+#include "gazebo/sensors/DepthCameraSensor.hh"
+#include "gazebo_irlock_plugin.h"
+
+#include <highgui.h>
+#include <math.h>
+#include <string>
+#include <iostream>
+#include <boost/algorithm/string.hpp>
+
+using namespace cv;
+using namespace std;
+
+using namespace gazebo;
+GZ_REGISTER_SENSOR_PLUGIN(IRLockPlugin)
+
+IRLockPlugin::IRLockPlugin() : SensorPlugin()
+{
+
+}
+
+IRLockPlugin::~IRLockPlugin()
+{
+  this->camera.reset();
+}
+
+void IRLockPlugin::Load(sensors::SensorPtr _sensor, sdf::ElementPtr _sdf)
+{
+  if (!_sensor)
+    gzerr << "Invalid sensor pointer.\n";
+
+  this->camera = std::dynamic_pointer_cast<sensors::LogicalCameraSensor>(_sensor);
+
+  if (!this->camera) {
+    gzerr << "IRLockPlugin requires a CameraSensor.\n";
+  }
+
+  if (_sdf->HasElement("robotNamespace")) {
+    namespace_ = _sdf->GetElement("robotNamespace")->Get<std::string>();
+  } else {
+    gzwarn << "Please specify a robotNamespace.\n";
+  }
+
+  node_handle_ = transport::NodePtr(new transport::Node());
+  node_handle_->Init(namespace_);
+
+  const string scopedName = _sensor->ParentName();
+
+  string topicName = "~/" + scopedName + "/irlock";
+  boost::replace_all(topicName, "::", "/");
+
+  irlock_pub_ = node_handle_->Advertise<irlock_msgs::msgs::irlock>(topicName, 10);
+
+  this->updateConnection = this->camera->ConnectUpdated(
+      std::bind(&IRLockPlugin::OnUpdated, this));
+
+  this->camera->SetActive(true);
+
+}
+
+void IRLockPlugin::OnUpdated()
+{
+  gazebo::msgs::LogicalCameraImage img = this->camera->Image();
+
+  for (int idx = 0; idx < img.model_size(); idx++) {
+
+    gazebo::msgs::LogicalCameraImage_Model model = img.model(idx);
+
+    if (model.has_name() && model.name() == "irlock_beacon") {
+
+      if (model.has_pose()) {
+
+        // position of the beacon in camera frame
+        gazebo::math::Vector3 pos;
+        pos.x = model.pose().position().x();
+        pos.y = model.pose().position().y();
+        pos.z = model.pose().position().z();
+
+        // the default orientation of the IRLock sensor reports beacon in front of vehicle as -y values, beacon right of vehicle as x values
+        // rotate the measurement accordingly
+        gazebo::math::Vector3 meas(-pos.y/pos.x, -pos.z/pos.x, 1.0);
+
+        // prepare irlock message
+        irlock_message.set_time_usec(0); // will be filled in simulator_mavlink.cpp
+        irlock_message.set_signature(idx); // unused by beacon estimator
+        irlock_message.set_pos_x(meas.x);
+        irlock_message.set_pos_y(meas.y);
+        irlock_message.set_size_x(0); // unused by beacon estimator
+        irlock_message.set_size_y(0); // unused by beacon estimator
+
+        // send message
+        irlock_pub_->Publish(irlock_message);
+
+      }
+    }
+  }
+
+}
+
+/* vim: set et fenc=utf-8 ff=unix sts=0 sw=2 ts=2 : */

--- a/worlds/iris_irlock.world
+++ b/worlds/iris_irlock.world
@@ -14,6 +14,7 @@
     </include>
     <include>
       <uri>model://iris_irlock</uri>
+      <pose>0 0 0.3 0 0 1.5708</pose>
     </include>
     <physics name='default_physics' default='0' type='ode'>
       <gravity>0 0 -9.8066</gravity>
@@ -38,7 +39,7 @@
     </physics>
     
     <model name="irlock_beacon">
-      <pose>0.3 0.0 0.06 0 0 0</pose>
+      <pose>0.5 1.5 0.06 0 0 0</pose>
       <link name="link">
          <inertial>
           <pose>0 0 0 0 0 0</pose>

--- a/worlds/iris_irlock.world
+++ b/worlds/iris_irlock.world
@@ -1,0 +1,95 @@
+<?xml version="1.0" ?>
+<sdf version="1.5">
+  <world name="default">
+    <!-- A global light source -->
+    <include>
+      <uri>model://sun</uri>
+    </include>
+    <!-- A ground plane -->
+    <include>
+      <uri>model://ground_plane</uri>
+    </include>
+    <include>
+      <uri>model://asphalt_plane</uri>
+    </include>
+    <include>
+      <uri>model://iris_irlock</uri>
+    </include>
+    <physics name='default_physics' default='0' type='ode'>
+      <gravity>0 0 -9.8066</gravity>
+      <ode>
+        <solver>
+          <type>quick</type>
+          <iters>10</iters>
+          <sor>1.3</sor>
+          <use_dynamic_moi_rescaling>0</use_dynamic_moi_rescaling>
+        </solver>
+        <constraints>
+          <cfm>0</cfm>
+          <erp>0.2</erp>
+          <contact_max_correcting_vel>100</contact_max_correcting_vel>
+          <contact_surface_layer>0.001</contact_surface_layer>
+        </constraints>
+      </ode>
+      <max_step_size>0.002</max_step_size>
+      <real_time_factor>1</real_time_factor>
+      <real_time_update_rate>500</real_time_update_rate>
+      <magnetic_field>6e-06 2.3e-05 -4.2e-05</magnetic_field>
+    </physics>
+    
+    <model name="irlock_beacon">
+      <pose>0.3 0.0 0.06 0 0 0</pose>
+      <link name="link">
+         <inertial>
+          <pose>0 0 0 0 0 0</pose>
+          <mass>10.0</mass>
+          <inertia>
+            <ixx>0.01</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.01</iyy>
+            <iyz>0</iyz>
+            <izz>0.01</izz>
+          </inertia>
+        </inertial>
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>0.1 0.1 0.01</size>
+            </box>
+          </geometry>
+          <surface>
+            <friction>
+              <ode>
+                <mu>1.0</mu>
+                <mu2>1.0</mu2>
+                <fdir1>1 0 0</fdir1>
+              </ode>
+            </friction>
+            <contact>
+              <ode>
+                <kp>1e+12</kp>
+                <kd>1</kd>
+                <max_vel>10</max_vel>
+                <min_depth>0.003</min_depth>
+              </ode>
+            </contact>
+          </surface>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>0.1 0.1 0.02</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <name>Gazebo/Green</name>
+            </script>
+          </material>
+        </visual>
+      </link>
+    </model>
+    
+  </world>
+</sdf>


### PR DESCRIPTION
This adds a simulation for the IRLock camera and beacon, which allows testing of the precision land feature.

It also adds noise to the simulated GPS measurements with a decaying random walk.