### PR TITLE
Feature to add motor failure over ROS interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ list(APPEND CMAKE_MODULE_PATH /usr/local/share/cmake/Modules)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 
 option(BUILD_GSTREAMER_PLUGIN "enable gstreamer plugin" "OFF")
+option(BUILD_ROS_INTERFACE "enable ROS subscriber for motor model plugin" "OFF")
 
 ## System dependencies are found with CMake's conventions
 find_package(PkgConfig REQUIRED)
@@ -34,6 +35,14 @@ endif()
 add_subdirectory( external/OpticalFlow OpticalFlow )
 set( OpticalFlow_LIBS "OpticalFlow" )
 
+# for ROS subscriber
+if (BUILD_ROS_INTERFACE)
+  find_package(roscpp REQUIRED)
+  find_package(std_msgs REQUIRED)
+  include_directories(${roscpp_INCLUDE_DIRS})
+  include_directories(${std_msgs_INCLUDE_DIRS})
+endif()
+
 # find ROS include directories for building against ROS mavlink version
 find_package(roscpp)
 if (roscpp_FOUND)
@@ -45,7 +54,8 @@ if (CATKIN_DEVEL_PREFIX)
   message(STATUS "catkin ENABLED")
   find_package(catkin REQUIRED)
   if (catkin_FOUND)
-    catkin_package()
+    catkin_package(  DEPENDS 
+    roscpp)
   else()
     message(FATAL_ERROR "catkin not found")
   endif()
@@ -183,7 +193,6 @@ set (msgs
   msgs/MotorSpeed.proto
   #msgs/Wind.proto
   msgs/sonarSens.proto
-  msgs/irlock.proto
 )
 PROTOBUF_GENERATE_CPP(PROTO_SRCS PROTO_HDRS ${msgs})
 add_library(mav_msgs SHARED ${PROTO_SRCS})
@@ -208,7 +217,6 @@ add_library(rotors_gazebo_imu_plugin SHARED src/gazebo_imu_plugin.cpp)
 add_library(gazebo_opticalFlow_plugin SHARED src/gazebo_opticalFlow_plugin.cpp)
 target_link_libraries(gazebo_opticalFlow_plugin ${OpticalFlow_LIBS})
 add_library(gazebo_lidar_plugin SHARED src/gazebo_lidar_plugin.cpp)
-add_library(gazebo_irlock_plugin SHARED src/gazebo_irlock_plugin.cpp)
 add_library(rotors_gazebo_mavlink_interface SHARED src/gazebo_mavlink_interface.cpp src/geo_mag_declination.cpp)
 #add_library(rotors_gazebo_wind_plugin SHARED src/gazebo_wind_plugin.cpp)
 add_library(gazebo_sonar_plugin SHARED src/gazebo_sonar_plugin.cpp)
@@ -221,7 +229,6 @@ set(plugins
   rotors_gazebo_imu_plugin
   gazebo_opticalFlow_plugin
   gazebo_lidar_plugin
-  gazebo_irlock_plugin
   rotors_gazebo_mavlink_interface
   #rotors_gazebo_wind_plugin
   gazebo_sonar_plugin
@@ -232,6 +239,13 @@ set(plugins
 if (NOT roscpp_FOUND)
   add_library(gazebo_geotagged_images_plugin SHARED src/gazebo_geotagged_images_plugin.cpp)
   list(APPEND plugins gazebo_geotagged_images_plugin)
+endif()
+
+if (BUILD_ROS_INTERFACE)
+  add_library(rotors_gazebo_motor_failure_model SHARED src/gazebo_motor_failure_model.cpp)
+  target_link_libraries(rotors_gazebo_motor_failure_model ${GAZEBO_libraries} ${roscpp_LIBRARIES})
+  list(APPEND plugins rotors_gazebo_motor_failure_model)
+  message(STATUS "adding gazebo_ros_interface to build")
 endif()
 
 if (GSTREAMER_FOUND)

--- a/include/gazebo_motor_failure_model.h
+++ b/include/gazebo_motor_failure_model.h
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2015 Fadri Furrer, ASL, ETH Zurich, Switzerland
+ * Copyright 2015 Michael Burri, ASL, ETH Zurich, Switzerland
+ * Copyright 2015 Mina Kamel, ASL, ETH Zurich, Switzerland
+ * Copyright 2015 Janosch Nikolic, ASL, ETH Zurich, Switzerland
+ * Copyright 2015 Markus Achtelik, ASL, ETH Zurich, Switzerland
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+
+#include <stdio.h>
+
+#include <boost/bind.hpp>
+#include <Eigen/Eigen>
+#include <gazebo/gazebo.hh>
+#include <gazebo/physics/physics.hh>
+#include <gazebo/common/common.hh>
+#include <gazebo/common/Plugin.hh>
+#include <rotors_model/motor_model.hpp>
+#include "CommandMotorSpeed.pb.h"
+#include "gazebo/math/Vector3.hh"
+#include "gazebo/transport/transport.hh"
+#include "gazebo/msgs/msgs.hh"
+#include "MotorSpeed.pb.h"
+#include "Float.pb.h"
+
+#include "common.h"
+
+// ROS Topic subscriber
+#include <thread>
+#include "ros/ros.h"
+#include "ros/callback_queue.h"
+#include "ros/subscribe_options.h"
+#include "std_msgs/Bool.h"
+#include <std_msgs/Int32.h>
+
+namespace turning_direction {
+const static int CCW = 1;
+const static int CW = -1;
+}
+
+namespace gazebo {
+// Default values
+static const std::string kDefaultNamespace = "";
+static const std::string kDefaultCommandSubTopic = "/gazebo/command/motor_speed";
+static const std::string kDefaultMotorVelocityPubTopic = "/motor_speed";
+
+typedef const boost::shared_ptr<const mav_msgs::msgs::CommandMotorSpeed> CommandMotorSpeedPtr;
+
+/*
+// Protobuf test
+typedef const boost::shared_ptr<const mav_msgs::msgs::MotorSpeed> MotorSpeedPtr;  
+static const std::string kDefaultMotorTestSubTopic = "motors";
+*/
+
+// Set the max_force_ to the max double value. The limitations get handled by the FirstOrderFilter.
+static constexpr double kDefaultMaxForce = std::numeric_limits<double>::max();
+static constexpr double kDefaultMotorConstant = 8.54858e-06;
+static constexpr double kDefaultMomentConstant = 0.016;
+static constexpr double kDefaultTimeConstantUp = 1.0 / 80.0;
+static constexpr double kDefaultTimeConstantDown = 1.0 / 40.0;
+static constexpr double kDefaulMaxRotVelocity = 838.0;
+static constexpr double kDefaultRotorDragCoefficient = 1.0e-4;
+static constexpr double kDefaultRollingMomentCoefficient = 1.0e-6;
+static constexpr double kDefaultRotorVelocitySlowdownSim = 10.0;
+
+class GazeboMotorModel : public MotorModel, public ModelPlugin {
+ public:
+
+  int motor_Failure_Number_, tmp_motor_num;
+  void motorFailNumCallBack(const std_msgs::Int32ConstPtr& _msg1){
+    this->motor_Failure_Number_ = _msg1->data;
+  }
+
+  GazeboMotorModel()
+      : ModelPlugin(),
+        MotorModel(),
+        command_sub_topic_(kDefaultCommandSubTopic),
+        motor_speed_pub_topic_(kDefaultMotorVelocityPubTopic),
+        motor_number_(0),
+        turning_direction_(turning_direction::CW),
+        max_force_(kDefaultMaxForce),
+        max_rot_velocity_(kDefaulMaxRotVelocity),
+        moment_constant_(kDefaultMomentConstant),
+        motor_constant_(kDefaultMotorConstant),
+        //motor_test_sub_topic_(kDefaultMotorTestSubTopic),
+        ref_motor_rot_vel_(0.0),
+        rolling_moment_coefficient_(kDefaultRollingMomentCoefficient),
+        rotor_drag_coefficient_(kDefaultRotorDragCoefficient),
+        rotor_velocity_slowdown_sim_(kDefaultRotorVelocitySlowdownSim),
+        time_constant_down_(kDefaultTimeConstantDown),
+        time_constant_up_(kDefaultTimeConstantUp) {
+  }
+
+  virtual ~GazeboMotorModel();
+
+  virtual void InitializeParams();
+  virtual void Publish();
+  //void testProto(MotorSpeedPtr &msg);
+ protected:
+  virtual void UpdateForcesAndMoments();
+  virtual void UpdateMotorFail();
+  virtual void Load(physics::ModelPtr _model, sdf::ElementPtr _sdf);
+  virtual void OnUpdate(const common::UpdateInfo & /*_info*/);
+
+ private:
+  std::string command_sub_topic_;
+  std::string joint_name_;
+  std::string link_name_;
+  std::string motor_speed_pub_topic_;
+  std::string namespace_;
+
+  int motor_number_;
+  int turning_direction_;
+
+  double max_force_;
+  double max_rot_velocity_;
+  double moment_constant_;
+  double motor_constant_;
+  double ref_motor_rot_vel_;
+  double rolling_moment_coefficient_;
+  double rotor_drag_coefficient_;
+  double rotor_velocity_slowdown_sim_;
+  double time_constant_down_;
+  double time_constant_up_;
+
+  transport::NodePtr node_handle_;
+  transport::PublisherPtr motor_velocity_pub_;
+  transport::SubscriberPtr command_sub_;
+
+  physics::ModelPtr model_;
+  physics::JointPtr joint_;
+  common::PID pid_;
+  bool use_pid_;
+  physics::LinkPtr link_;
+  /// \brief Pointer to the update event connection.
+  event::ConnectionPtr updateConnection_;
+
+  boost::thread callback_queue_thread_;
+  void QueueThread();
+  std_msgs::msgs::Float turning_velocity_msg_;
+  void VelocityCallback(CommandMotorSpeedPtr &rot_velocities);
+  std::unique_ptr<FirstOrderFilter<double>>  rotor_velocity_filter_;
+
+  void QueueThread(){
+    static const double timeout = 0.01;
+    while (this->rosNode->ok())
+    {
+      this->rosQueue.callAvailable(ros::WallDuration(timeout));
+    }
+  }
+
+  // ROS communication
+  std::unique_ptr<ros::NodeHandle> rosNode;
+  ros::Subscriber rosSub;
+  ros::CallbackQueue rosQueue;
+  std::thread rosQueueThread;
+
+  int screen_msg_flag = 1;
+
+/*
+  // Protobuf test
+  std::string motor_test_sub_topic_;
+  transport::SubscriberPtr motor_sub_;
+*/
+};
+}

--- a/src/gazebo_motor_failure_model.cpp
+++ b/src/gazebo_motor_failure_model.cpp
@@ -1,0 +1,300 @@
+/*
+ * Copyright 2015 Fadri Furrer, ASL, ETH Zurich, Switzerland
+ * Copyright 2015 Michael Burri, ASL, ETH Zurich, Switzerland
+ * Copyright 2015 Mina Kamel, ASL, ETH Zurich, Switzerland
+ * Copyright 2015 Janosch Nikolic, ASL, ETH Zurich, Switzerland
+ * Copyright 2015 Markus Achtelik, ASL, ETH Zurich, Switzerland
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#include "gazebo_motor_failure_model.h"
+
+namespace gazebo {
+
+GazeboMotorModel::~GazeboMotorModel() {
+  event::Events::DisconnectWorldUpdateBegin(updateConnection_);
+  use_pid_ = false;
+}
+
+void GazeboMotorModel::InitializeParams() {}
+
+void GazeboMotorModel::Publish() {
+  turning_velocity_msg_.set_data(joint_->GetVelocity(0));
+  motor_velocity_pub_->Publish(turning_velocity_msg_);
+}
+
+void GazeboMotorModel::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf) {
+  model_ = _model;
+
+  namespace_.clear();
+
+  if (_sdf->HasElement("robotNamespace"))
+    namespace_ = _sdf->GetElement("robotNamespace")->Get<std::string>();
+  else
+    gzerr << "[gazebo_motor_failure_model] Please specify a robotNamespace.\n";
+  node_handle_ = transport::NodePtr(new transport::Node());
+  node_handle_->Init(namespace_);
+
+  if (_sdf->HasElement("jointName"))
+    joint_name_ = _sdf->GetElement("jointName")->Get<std::string>();
+  else
+    gzerr << "[gazebo_motor_failure_model] Please specify a jointName, where the rotor is attached.\n";
+  // Get the pointer to the joint.
+  joint_ = model_->GetJoint(joint_name_);
+  if (joint_ == NULL)
+    gzthrow("[gazebo_motor_failure_model] Couldn't find specified joint \"" << joint_name_ << "\".");
+
+  // setup joint control pid to control joint
+  if (_sdf->HasElement("joint_control_pid"))
+  {
+    sdf::ElementPtr pid = _sdf->GetElement("joint_control_pid");
+    double p = 0.1;
+    if (pid->HasElement("p"))
+      p = pid->Get<double>("p");
+    double i = 0;
+    if (pid->HasElement("i"))
+      i = pid->Get<double>("i");
+    double d = 0;
+    if (pid->HasElement("d"))
+      d = pid->Get<double>("d");
+    double iMax = 0;
+    if (pid->HasElement("iMax"))
+      iMax = pid->Get<double>("iMax");
+    double iMin = 0;
+    if (pid->HasElement("iMin"))
+      iMin = pid->Get<double>("iMin");
+    double cmdMax = 3;
+    if (pid->HasElement("cmdMax"))
+      cmdMax = pid->Get<double>("cmdMax");
+    double cmdMin = -3;
+    if (pid->HasElement("cmdMin"))
+      cmdMin = pid->Get<double>("cmdMin");
+    pid_.Init(p, i, d, iMax, iMin, cmdMax, cmdMin);
+    use_pid_ = true;
+  }
+  else
+  {
+    use_pid_ = false;
+  }
+
+  if (_sdf->HasElement("linkName"))
+    link_name_ = _sdf->GetElement("linkName")->Get<std::string>();
+  else
+    gzerr << "[gazebo_motor_failure_model] Please specify a linkName of the rotor.\n";
+  link_ = model_->GetLink(link_name_);
+  if (link_ == NULL)
+    gzthrow("[gazebo_motor_failure_model] Couldn't find specified link \"" << link_name_ << "\".");
+
+
+  if (_sdf->HasElement("motorNumber"))
+    motor_number_ = _sdf->GetElement("motorNumber")->Get<int>();
+  else
+    gzerr << "[gazebo_motor_failure_model] Please specify a motorNumber.\n";
+
+  if (_sdf->HasElement("turningDirection")) {
+    std::string turning_direction = _sdf->GetElement("turningDirection")->Get<std::string>();
+    if (turning_direction == "cw")
+      turning_direction_ = turning_direction::CW;
+    else if (turning_direction == "ccw")
+      turning_direction_ = turning_direction::CCW;
+    else
+      gzerr << "[gazebo_motor_failure_model] Please only use 'cw' or 'ccw' as turningDirection.\n";
+  }
+  else
+    gzerr << "[gazebo_motor_failure_model] Please specify a turning direction ('cw' or 'ccw').\n";
+
+  getSdfParam<std::string>(_sdf, "commandSubTopic", command_sub_topic_, command_sub_topic_);
+  getSdfParam<std::string>(_sdf, "motorSpeedPubTopic", motor_speed_pub_topic_,
+                           motor_speed_pub_topic_);
+
+  getSdfParam<double>(_sdf, "rotorDragCoefficient", rotor_drag_coefficient_, rotor_drag_coefficient_);
+  getSdfParam<double>(_sdf, "rollingMomentCoefficient", rolling_moment_coefficient_,
+                      rolling_moment_coefficient_);
+  getSdfParam<double>(_sdf, "maxRotVelocity", max_rot_velocity_, max_rot_velocity_);
+  getSdfParam<double>(_sdf, "motorConstant", motor_constant_, motor_constant_);
+  getSdfParam<double>(_sdf, "momentConstant", moment_constant_, moment_constant_);
+
+  getSdfParam<double>(_sdf, "timeConstantUp", time_constant_up_, time_constant_up_);
+  getSdfParam<double>(_sdf, "timeConstantDown", time_constant_down_, time_constant_down_);
+  getSdfParam<double>(_sdf, "rotorVelocitySlowdownSim", rotor_velocity_slowdown_sim_, 10);
+
+  /*
+  std::cout << "Subscribing to: " << motor_test_sub_topic_ << std::endl;
+  motor_sub_ = node_handle_->Subscribe<mav_msgs::msgs::MotorSpeed>("~/" + model_->GetName() + motor_test_sub_topic_, &GazeboMotorModel::testProto, this);
+  */
+
+  // Set the maximumForce on the joint. This is deprecated from V5 on, and the joint won't move.
+#if GAZEBO_MAJOR_VERSION < 5
+  joint_->SetMaxForce(0, max_force_);
+#endif
+
+  command_sub_ = node_handle_->Subscribe<mav_msgs::msgs::CommandMotorSpeed>("~/" + model_->GetName() + command_sub_topic_, &GazeboMotorModel::VelocityCallback, this);
+  motor_velocity_pub_ = node_handle_->Advertise<std_msgs::msgs::Float>("~/" + model_->GetName() + motor_speed_pub_topic_, 1);
+
+  // Create the first order filter.
+  rotor_velocity_filter_.reset(new FirstOrderFilter<double>(time_constant_up_, time_constant_down_, ref_motor_rot_vel_));
+
+  // ROS Topic subscriber
+  // Initialize ros, if it has not already bee initialized.
+  if (!ros::isInitialized())  {
+      /*{
+      ROS_FATAL_STREAM("A ROS node for Gazebo has not been initialized, unable to load plugin. "
+        << "Load the Gazebo system plugin 'libgazebo_ros_api_plugin.so' in the gazebo_ros package)");
+      return;
+      }
+
+    ROS_INFO("Hello World!");*/
+
+    int argc = 0;
+    char **argv = NULL;
+    ros::init(argc, argv, "gazebo_ros_sub", ros::init_options::NoSigintHandler);
+    gzwarn << "[gazebo_motor_failure_model]: Subscribe to /gazebo/motor_failure \n" ;
+  }
+
+  // Create our ROS node. This acts in a similar manner to the Gazebo node
+  this->rosNode.reset(new ros::NodeHandle("gazebo_client"));
+
+  // Create a named topic, and subscribe to it.
+  ros::SubscribeOptions so = ros::SubscribeOptions::create<std_msgs::Int32>("/gazebo/motor_failure/motor_number", 1, boost::bind(&GazeboMotorModel::motorFailNumCallBack, this, _1), ros::VoidPtr(), &this->rosQueue);
+  this->rosSub = this->rosNode->subscribe(so);
+  
+  this->rosQueueThread = std::thread(std::bind(&GazeboMotorModel::QueueThread, this));
+
+  // Listen to the update event. This event is broadcast every
+  // simulation iteration.
+  updateConnection_ = event::Events::ConnectWorldUpdateBegin(boost::bind(&GazeboMotorModel::OnUpdate, this, _1));
+}
+
+// Protobuf test
+/*
+void GazeboMotorModel::testProto(MotorSpeedPtr &msg) {
+  std::cout << "Received message" << std::endl;
+  std::cout << msg->motor_speed_size()<< std::endl;
+  for(int i; i < msg->motor_speed_size(); i++){
+    std::cout << msg->motor_speed(i) <<" ";
+  }
+  std::cout << std::endl;
+}
+*/
+
+// This gets called by the world update start event.
+void GazeboMotorModel::OnUpdate(const common::UpdateInfo& _info) {
+  sampling_time_ = _info.simTime.Double() - prev_sim_time_;
+  prev_sim_time_ = _info.simTime.Double();
+  UpdateForcesAndMoments();
+  UpdateMotorFail();
+  Publish();
+}
+
+void GazeboMotorModel::VelocityCallback(CommandMotorSpeedPtr &rot_velocities) {
+  if(rot_velocities->motor_speed_size() < motor_number_) {
+    std::cout  << "You tried to access index " << motor_number_
+      << " of the MotorSpeed message array which is of size " << rot_velocities->motor_speed_size() << "." << std::endl;
+  } else ref_motor_rot_vel_ = std::min(static_cast<double>(rot_velocities->motor_speed(motor_number_)), static_cast<double>(max_rot_velocity_));
+}
+
+void GazeboMotorModel::UpdateForcesAndMoments() {
+  motor_rot_vel_ = joint_->GetVelocity(0);
+  if (motor_rot_vel_ / (2 * M_PI) > 1 / (2 * sampling_time_)) {
+    gzerr << "Aliasing on motor [" << motor_number_ << "] might occur. Consider making smaller simulation time steps or raising the rotor_velocity_slowdown_sim_ param.\n";
+  }
+  double real_motor_velocity = motor_rot_vel_ * rotor_velocity_slowdown_sim_;
+  double force = real_motor_velocity * real_motor_velocity * motor_constant_;
+
+  // scale down force linearly with forward speed
+  // XXX this has to be modelled better
+  math::Vector3 body_velocity = link_->GetWorldLinearVel();
+  double vel = body_velocity.GetLength();
+  double scalar = 1 - vel / 25.0; // at 50 m/s the rotor will not produce any force anymore
+  scalar = math::clamp(scalar, 0.0, 1.0);
+  // Apply a force to the link.
+  link_->AddRelativeForce(math::Vector3(0, 0, force * scalar));
+
+  // Forces from Philppe Martin's and Erwan Salaün's
+  // 2010 IEEE Conference on Robotics and Automation paper
+  // The True Role of Accelerometer Feedback in Quadrotor Control
+  // - \omega * \lambda_1 * V_A^{\perp}
+  math::Vector3 joint_axis = joint_->GetGlobalAxis(0);
+  //math::Vector3 body_velocity = link_->GetWorldLinearVel();
+  math::Vector3 body_velocity_perpendicular = body_velocity - (body_velocity * joint_axis) * joint_axis;
+  math::Vector3 air_drag = -std::abs(real_motor_velocity) * rotor_drag_coefficient_ * body_velocity_perpendicular;
+  // Apply air_drag to link.
+  link_->AddForce(air_drag);
+  // Moments
+  // Getting the parent link, such that the resulting torques can be applied to it.
+  physics::Link_V parent_links = link_->GetParentJointsLinks();
+  // The tansformation from the parent_link to the link_.
+  math::Pose pose_difference = link_->GetWorldCoGPose() - parent_links.at(0)->GetWorldCoGPose();
+  math::Vector3 drag_torque(0, 0, -turning_direction_ * force * moment_constant_);
+  // Transforming the drag torque into the parent frame to handle arbitrary rotor orientations.
+  math::Vector3 drag_torque_parent_frame = pose_difference.rot.RotateVector(drag_torque);
+  parent_links.at(0)->AddRelativeTorque(drag_torque_parent_frame);
+
+  math::Vector3 rolling_moment;
+  // - \omega * \mu_1 * V_A^{\perp}
+  rolling_moment = -std::abs(real_motor_velocity) * rolling_moment_coefficient_ * body_velocity_perpendicular;
+  parent_links.at(0)->AddTorque(rolling_moment);
+  // Apply the filter on the motor's velocity.
+  double ref_motor_rot_vel;
+  ref_motor_rot_vel = rotor_velocity_filter_->updateFilter(ref_motor_rot_vel_, sampling_time_);
+
+#if 0 //FIXME: disable PID for now, it does not play nice with the PX4 CI system.
+  if (use_pid_)
+  {
+    double err = joint_->GetVelocity(0) - turning_direction_ * ref_motor_rot_vel / rotor_velocity_slowdown_sim_;
+    double rotorForce = pid_.Update(err, sampling_time_);
+    joint_->SetForce(0, rotorForce);
+    // gzerr << "rotor " << joint_->GetName() << " : " << rotorForce << "\n";
+  }
+  else
+  {
+#if GAZEBO_MAJOR_VERSION >= 7
+    // Not desirable to use SetVelocity for parts of a moving model
+    // impact on rest of the dynamic system is non-physical.
+    joint_->SetVelocity(0, turning_direction_ * ref_motor_rot_vel / rotor_velocity_slowdown_sim_);
+#elif GAZEBO_MAJOR_VERSION >= 6
+    // Not ideal as the approach could result in unrealistic impulses, and
+    // is only available in ODE
+    joint_->SetParam("fmax", 0, 2.0);
+    joint_->SetParam("vel", 0, turning_direction_ * ref_motor_rot_vel / rotor_velocity_slowdown_sim_);
+#endif
+  }
+#else
+  joint_->SetVelocity(0, turning_direction_ * ref_motor_rot_vel / rotor_velocity_slowdown_sim_);
+#endif /* if 0 */
+}
+
+void GazeboMotorModel::UpdateMotorFail() {
+  if (motor_number_ == motor_Failure_Number_ - 1){
+    motor_constant_ = 0.0;
+    if (screen_msg_flag){
+      std::cout << "Motor number [" << motor_Failure_Number_ <<"] failed! [Motor constant = " << motor_constant_ << "]" << std::endl;
+      tmp_motor_num = motor_Failure_Number_;
+      
+      screen_msg_flag = 0;
+    }
+  }else if (motor_Failure_Number_ == 0 && motor_number_ ==  tmp_motor_num - 1){
+     if (!screen_msg_flag){
+       motor_constant_ = kDefaultMotorConstant;
+       std::cout << "Motor number [" << tmp_motor_num <<"] failed! [Motor constant = " << motor_constant_ << " (default)]" << std::endl;
+       screen_msg_flag = 1;
+     }
+  }else{
+     motor_constant_ = kDefaultMotorConstant;
+  }
+}
+
+GZ_REGISTER_MODEL_PLUGIN(GazeboMotorModel);
+}


### PR DESCRIPTION
This modification in the `gazebo_motor_failure_model` plugin will enable to simulate motor failure in the robot model in real time by subscribing to a rostopic `/gazebo/motor_failure/motor_number` [ex: [Publisher](https://drive.google.com/open?id=18uW0NMYJ-7YJcluNlkrneRmmSy7aRlPe) & [cfg](https://drive.google.com/open?id=190Mdq-2zdGiCqljhI_2AqJbDFN8huH-0)] and fail that motor by setting the `motor_constant_ = 0`. 

Any suggestions to make the code better are welcome. And if someone could contribute to making the rotor visually stop rotating when it fails, that would be great. 
Please review @TSC21

Thanks!
PS: Hope this one is correct. base fork: current master, from: my motor_failure branch.