### PR TITLE
Motor failure feature with new plugin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ list(APPEND CMAKE_MODULE_PATH /usr/local/share/cmake/Modules)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 
 option(BUILD_GSTREAMER_PLUGIN "enable gstreamer plugin" "OFF")
+option(BUILD_ROS_INTERFACE "enable ROS subscriber for motor failure plugin" "OFF")
 
 ## System dependencies are found with CMake's conventions
 find_package(PkgConfig REQUIRED)
@@ -34,10 +35,17 @@ endif()
 add_subdirectory( external/OpticalFlow OpticalFlow )
 set( OpticalFlow_LIBS "OpticalFlow" )
 
+# for ROS subscriber
+if (BUILD_ROS_INTERFACE)
+  find_package(roscpp REQUIRED)
+  find_package(std_msgs REQUIRED)
+endif()
+
 # find ROS include directories for building against ROS mavlink version
 find_package(roscpp)
 if (roscpp_FOUND)
    include_directories(${roscpp_INCLUDE_DIRS})
+   include_directories(${std_msgs_INCLUDE_DIRS})
 endif()
 
 # see if catkin was invoked to build this
@@ -232,6 +240,13 @@ set(plugins
 if (NOT roscpp_FOUND)
   add_library(gazebo_geotagged_images_plugin SHARED src/gazebo_geotagged_images_plugin.cpp)
   list(APPEND plugins gazebo_geotagged_images_plugin)
+endif()
+
+if (BUILD_ROS_INTERFACE)
+  add_library(gazebo_motor_failure_plugin SHARED src/gazebo_motor_failure_plugin.cpp)
+  target_link_libraries(gazebo_motor_failure_plugin ${GAZEBO_libraries} ${roscpp_LIBRARIES})
+  list(APPEND plugins gazebo_motor_failure_plugin)
+  message(STATUS "adding gazebo_motor_failure_plugin to build")
 endif()
 
 if (GSTREAMER_FOUND)

--- a/include/gazebo_motor_failure_plugin.h
+++ b/include/gazebo_motor_failure_plugin.h
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2017 Nuno Marques, PX4 Pro Dev Team, Lisbon
+ * Copyright 2017 Siddharth Patel, NTU Singapore
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "gazebo_motor_model.h"
+
+#include <stdio.h>
+#include <boost/bind.hpp>
+#include <gazebo/gazebo.hh>
+#include <gazebo/common/common.hh>
+#include <gazebo/common/Plugin.hh>
+#include "gazebo/transport/transport.hh"
+#include "gazebo/msgs/msgs.hh"
+#include "common.h"
+
+// ROS Topic subscriber
+#include <thread>
+#include "ros/ros.h"
+#include "ros/callback_queue.h"
+#include "ros/subscribe_options.h"
+#include <std_msgs/Int32.h>
+
+namespace gazebo {
+
+// Default values
+static const std::string kDefaultROSMotorNumSubTopic = "/motor_failure/motor_number";
+static const std::string kDefaultMotorFailureNumPubTopic = "/gazebo/motor_failure_num";
+
+class GazeboMotorFailure : public ModelPlugin {
+ public:
+
+  void motorFailNumCallBack(const std_msgs::Int32ConstPtr& _msg) {
+    this->motor_Failure_Number_ = _msg->data;
+    //std::cout << "[gazebo_motor_failure_plugin]: Subscribe to " << ROS_motor_num_sub_topic_ << std::endl;
+  }
+
+  GazeboMotorFailure()
+      : ModelPlugin(),
+	ROS_motor_num_sub_topic_(kDefaultROSMotorNumSubTopic),
+	motor_failure_num_pub_topic_(kDefaultMotorFailureNumPubTopic) {
+  }
+
+  virtual ~GazeboMotorFailure();
+  virtual void Publish_num();
+
+ protected:
+
+  /// \brief Create subscription to ROS topic that triggers the motor failure
+  /// \details Inits a rosnode in case there's not one and subscribes to ROS_motor_num_sub_topic_
+  virtual void Load(physics::ModelPtr _model, sdf::ElementPtr _sdf);
+	
+  /// \brief Updates and publishes the motor_Failure_Number_ to motor_failure_num_pub_topic_
+  virtual void OnUpdate(const common::UpdateInfo & /*_info*/);
+
+ private:
+
+  std::string ROS_motor_num_sub_topic_;
+  std::string motor_failure_num_pub_topic_;
+  std::string namespace_;
+
+  transport::PublisherPtr motor_failure_pub_; /*!< Publish the motor_Failure_num to gazebo topic motor_failure_num_pub_topic_ */
+
+  boost::thread callback_queue_thread_;
+  void QueueThread()
+  {
+    static const double timeout = 0.01;
+    while (this->rosNode->ok())
+    {
+      this->rosQueue.callAvailable(ros::WallDuration(timeout));
+    }
+  }
+
+  msgs::Int motor_failure_msg_;
+
+  // ROS communication
+  std::unique_ptr<ros::NodeHandle> rosNode;
+  ros::Subscriber rosSub;
+  ros::CallbackQueue rosQueue;
+  std::thread rosQueueThread;
+};
+}

--- a/package.xml
+++ b/package.xml
@@ -45,7 +45,11 @@
   <buildtool_depend>gazebo_ros</buildtool_depend>
 
   <build_depend>gazebo_ros</build_depend>
+  <build_depend>roscpp</build_depend>
+  <build_depend>std_msgs</build_depend>
   <run_depend>gazebo_ros</run_depend>
+  <run_depend>roscpp</run_depend>
+  <run_depend>std_msgs</run_depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->

--- a/src/gazebo_motor_failure_plugin.cpp
+++ b/src/gazebo_motor_failure_plugin.cpp
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2017 Nuno Marques, PX4 Pro Dev Team, Lisbon
+ * Copyright 2017 Siddharth Patel, NTU Singapore
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "gazebo_motor_failure_plugin.h"
+
+namespace gazebo {
+
+GazeboMotorFailure::~GazeboMotorFailure() {
+  event::Events::DisconnectWorldUpdateBegin(updateConnection_);
+}
+
+
+void GazeboMotorFailure::Publish_num() {
+  motor_failure_msg_.set_data(motor_Failure_Number_);
+  motor_failure_pub_->Publish(motor_failure_msg_);
+}
+
+void GazeboMotorFailure::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf) {
+
+  namespace_.clear();
+
+  node_handle_ = transport::NodePtr(new transport::Node());
+  node_handle_->Init(namespace_);
+
+  motor_failure_pub_ = node_handle_->Advertise<msgs::Int>(motor_failure_num_pub_topic_, 1);
+
+  getSdfParam<std::string>(_sdf, "ROSMotorNumSubTopic", ROS_motor_num_sub_topic_, ROS_motor_num_sub_topic_);
+  getSdfParam<std::string>(_sdf, "MotorFailureNumPubTopic", motor_failure_num_pub_topic_, motor_failure_num_pub_topic_);
+
+
+  // ROS Topic subscriber
+  // Initialize ROS, if it has not already bee initialized.
+  if (!ros::isInitialized())  {
+    int argc = 0;
+    char **argv = NULL;
+    ros::init(argc, argv, "gazebo_ros_sub", ros::init_options::NoSigintHandler);
+  }
+
+  // Create our ROS node. This acts in a similar manner to the Gazebo node
+  this->rosNode.reset(new ros::NodeHandle("gazebo_client"));
+
+  // Create a named topic, and subscribe to it.
+  ros::SubscribeOptions so = ros::SubscribeOptions::create<std_msgs::Int32>(ROS_motor_num_sub_topic_, 1, boost::bind(&GazeboMotorFailure::motorFailNumCallBack, this, _1), ros::VoidPtr(), &this->rosQueue);
+  this->rosSub = this->rosNode->subscribe(so);
+  
+  this->rosQueueThread = std::thread(std::bind(&GazeboMotorFailure::QueueThread, this));
+
+  std::cout << "[gazebo_motor_failure_plugin]: Subscribe to ROS topic: "<< ROS_motor_num_sub_topic_ << std::endl;
+
+  // Listen to the update event. This event is broadcast every
+  // simulation iteration.
+  updateConnection_ = event::Events::ConnectWorldUpdateBegin(boost::bind(&GazeboMotorFailure::OnUpdate, this, _1));
+}
+
+void GazeboMotorFailure::OnUpdate(const common::UpdateInfo& _info) {
+  Publish_num();
+}
+
+GZ_REGISTER_MODEL_PLUGIN(GazeboMotorFailure);
+}
+


### PR DESCRIPTION
This new plugin `gazebo_motor_failure_plugin` and a minor modification in the `gazebo_motor_model` plugin will enable to simulate motor failure in the robot model in real time by subscribing to a rostopic `/motor_failure/motor_number` and fail that motor by setting `joint_->SetVelocity(0,0)`.

Here is the [video](https://drive.google.com/open?id=1p4Cj_Fk8N_ceWpK3yXD9K1SB_gVV8hCy) of this feature working. 

**Note**: 

1. Use the new plugin **only** if you want to use ROS to publish. If you want, you can directly publish to the gazebo topic `/gazebo/motor_failure_num` and the modification in `gazebo_motor_model` will take care of the motor failure without the need to use `gazebo_motor_failure_plugin` [_Just publish an integer number (motor_number+1) for the motor you want to fail (as 0 flags no motor failure, thus if you want to fail motor#0 then publish 1, or fail motor#1 then publish 2) as shown in ex:_ [ROS cpp Publisher](https://drive.google.com/open?id=1sr4UHeCFDqJyZX03hIKP86zymGCCaluj) & [cfg](https://drive.google.com/open?id=190Mdq-2zdGiCqljhI_2AqJbDFN8huH-0)].
2. Set the `-DBUILD_ROS_INTERFACE` option to `ON` in `CMakeLists.txt` to compile the plugin `gazebo_motor_failure_plugin`. You just have to issue catkin `clean --all -y` to delete the `build`, `devel` and `logs` folder. Then issue again `catkin build` to do a clean build. Also, not forgetting to source the `setup.bash` (or sh) of your `devel` folder.
3. Tried to do `joint_->SetForce(0,0)` but didn't work.

Any suggestions to make the code better are welcome.
@TSC21 Please review!
Thanks