### PR TITLE
build: add FindMAVLink.cmake module and enhance Mavlink dir search

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,12 +46,8 @@ if (BUILD_ROS_INTERFACE)
   find_package(mav_msgs REQUIRED)
 endif()
 
-# find ROS include directories for building against ROS mavlink version
-find_package(roscpp)
-if (roscpp_FOUND)
-   include_directories(${roscpp_INCLUDE_DIRS})
-   include_directories(${std_msgs_INCLUDE_DIRS})
-endif()
+# find MAVLink
+find_package(MAVLink)
 
 # see if catkin was invoked to build this
 if (CATKIN_DEVEL_PREFIX)
@@ -141,7 +137,7 @@ include_directories(
   /usr/local/include/OGRE
   /usr/local/include/OGRE/Paging
   ${GSTREAMER_INCLUDE_DIRS}
-  ../../mavlink/include
+  ${MAVLINK_INCLUDE_DIRS}
   )
 
 link_libraries(
@@ -256,7 +252,7 @@ if (BUILD_ROS_INTERFACE)
   target_link_libraries(gazebo_motor_failure_plugin ${GAZEBO_libraries} ${roscpp_LIBRARIES})
   list(APPEND plugins gazebo_motor_failure_plugin)
   message(STATUS "adding gazebo_motor_failure_plugin to build")
- 
+
   include_directories(
     include
     ${mavros_msgs_INCLUDE_DIRS}
@@ -267,7 +263,7 @@ if (BUILD_ROS_INTERFACE)
   add_executable(gazebo_hil_interface
     src/gazebo_hil_interface.cpp
   )
-  
+
   add_dependencies(gazebo_hil_interface
     ${catkin_EXPORTED_TARGETS}
     ${mavros_EXPORTED_TARGETS}

--- a/cmake/FindMAVLink.cmake
+++ b/cmake/FindMAVLink.cmake
@@ -1,0 +1,43 @@
+# - Try to find  MAVLink
+# Once done, this will define
+#
+#  MAVLINK_FOUND        : library found
+#  MAVLINK_INCLUDE_DIRS : include directories
+#  MAVLINK_VERSION      : version
+
+# macros
+include(FindPackageHandleStandardArgs)
+
+set(_MAVLINK_EXTRA_SEARCH_PATHS
+    /usr/
+    /usr/local/
+    /opt/local/
+    mavlink/
+    ../mavlink/
+    ../../mavlink/
+    )
+
+# find the include directory
+find_path(_MAVLINK_INCLUDE_DIR
+    NAMES mavlink/v1.0/mavlink_types.h mavlink/v2.0/mavlink_types.h
+    PATHS ${_MAVLINK_EXTRA_SEARCH_PATHS}
+    PATH_SUFFIXES include
+    )
+
+# read the version
+if (EXISTS ${_MAVLINK_INCLUDE_DIR}/mavlink/config.h)
+    file(READ ${_MAVLINK_INCLUDE_DIR}/mavlink/config.h MAVLINK_CONFIG_FILE)
+    string(REGEX MATCH "#define MAVLINK_VERSION[ ]+\"(([0-9]+\\.)+[0-9]+)\""
+        _MAVLINK_VERSION_MATCH "${MAVLINK_CONFIG_FILE}")
+    set(MAVLINK_VERSION "${CMAKE_MATCH_1}")
+else()
+    set(MAVLINK_VERSION "")
+endif()
+
+# handle arguments
+set(MAVLINK_INCLUDE_DIRS ${_MAVLINK_INCLUDE_DIR})
+find_package_handle_standard_args(
+    MAVLink
+    REQUIRED_VARS MAVLINK_INCLUDE_DIRS MAVLINK_VERSION
+    VERSION_VAR MAVLINK_VERSION
+    )


### PR DESCRIPTION
This actually solves some trouble with people trying to use `sitl_gazebo` without: 1. PX4 Firmware folder; 2. ROS. This allows to check for Mavlink in the most common folders and also sets the current version of them and also to unblock https://github.com/PX4/sitl_gazebo/pull/136 and finally have CI for `sitl_gazebo`.
Note: this is an adaption from a @jgoppert `.cmake` file, so credits go to him. 