### PR TITLE
Fix Typhoon gimbal control

### DIFF
--- a/include/gazebo_gimbal_controller_plugin.hh
+++ b/include/gazebo_gimbal_controller_plugin.hh
@@ -31,8 +31,12 @@
 #include <gazebo/util/system.hh>
 #include <gazebo/sensors/sensors.hh>
 
+#include "SensorImu.pb.h"
+
 namespace gazebo
 {
+  typedef const boost::shared_ptr<const sensor_msgs::msgs::Imu> ImuPtr;
+
   class GAZEBO_VISIBLE GimbalControllerPlugin : public ModelPlugin
   {
     /// \brief Constructor
@@ -43,6 +47,8 @@ namespace gazebo
     public: virtual void Init();
 
     private: void OnUpdate();
+
+    private: void ImuCallback(ImuPtr& imu_message);
 
 #if GAZEBO_MAJOR_VERSION >= 7 && GAZEBO_MINOR_VERSION >= 4
     /// only gazebo 7.4 and above support Any
@@ -74,6 +80,7 @@ namespace gazebo
 
     private: std::vector<event::ConnectionPtr> connections;
 
+    private: transport::SubscriberPtr imuSub;
     private: transport::SubscriberPtr pitchSub;
     private: transport::SubscriberPtr rollSub;
     private: transport::SubscriberPtr yawSub;
@@ -93,7 +100,8 @@ namespace gazebo
     /// \brief camera pitch joint
     private: physics::JointPtr pitchJoint;
 
-    private: sensors::ImuSensorPtr imuSensor;
+    private: sensors::ImuSensorPtr cameraImuSensor;
+    private: double lastImuYaw;
 
     private: std::string status;
 

--- a/models/typhoon_h480/typhoon_h480.sdf
+++ b/models/typhoon_h480/typhoon_h480.sdf
@@ -439,8 +439,8 @@
       <axis>
         <xyz>0 -1 0</xyz>
         <limit>
-          <lower>-0.0872665</lower>
-          <upper>1.5708</upper>
+          <lower>-1.05</lower>
+          <upper>2.09</upper>
           <effort>100</effort>
           <velocity>-1</velocity>
         </limit>

--- a/models/typhoon_h480/typhoon_h480.sdf
+++ b/models/typhoon_h480/typhoon_h480.sdf
@@ -399,7 +399,7 @@
         </camera>
         <always_on>1</always_on>
         <update_rate>10</update_rate>
-        <visualize>false</visualize>
+        <visualize>true</visualize>
         <!-- how to make this work without using urdf?
         <plugin name="cgo3_camera_controller" filename="libgazebo_ros_camera.so">
           <alwaysOn>true</alwaysOn>


### PR DESCRIPTION
This changes the gimbal control so that the gimbal is controlled in the drone's body frame instead of the global coordinate frame.

For this, we subscribe to the autopilot's IMU and add its yaw to the yaw setpoint.

When the drone is moving forward it is pitched down, however, we still want to have the camera/gimbal pointing level forwards. Therefore, we need to allow the gimbal to be able to point higher than horizontal.
Similarly, we need to increase the range down for when the drone moves backwards.

Also, this enables the gimbal/camera visualization again.

@DonLakeFlyer this could resolve the gimbal issues you have been seeing. Please give it a test.