### PR TITLE
add camera pose again for iris and iris_opt_flow worlds

### DIFF
--- a/worlds/iris.world
+++ b/worlds/iris.world
@@ -12,9 +12,9 @@
     <include>
       <uri>model://iris</uri>
     </include>
-    <!--<include>
+    <include>
       <uri>model://uneven_ground</uri>
-    </include>-->
+    </include>
     <physics name='default_physics' default='0' type='ode'>
       <gravity>0 0 -9.8066</gravity>
       <ode>
@@ -36,18 +36,16 @@
       <real_time_update_rate>500</real_time_update_rate>
       <magnetic_field>6.0e-6 2.3e-5 -4.2e-5</magnetic_field>
     </physics>
-    <!--
     <gui fullscreen='0'>
       <camera name='user_camera'>
-        <pose>5.4634 -5.46339 2.17586 0 0.275643 2.35619</pose>
-        <view_controller>orbit</view_controller>
+        <pose>-10 0 6 0 0.3 0</pose>
+        <!-- <view_controller>orbit</view_controller>
         <projection_type>perspective</projection_type>
         <track_visual>
           <name>iris</name>
           <use_model_frame>1</use_model_frame>
-        </track_visual>
+        </track_visual> -->
       </camera>
     </gui>
-  -->
   </world>
 </sdf>

--- a/worlds/iris_opt_flow.world
+++ b/worlds/iris_opt_flow.world
@@ -33,18 +33,16 @@
       <real_time_update_rate>500</real_time_update_rate>
       <magnetic_field>6.0e-6 2.3e-5 -4.2e-5</magnetic_field>
     </physics>
-    <!--
     <gui fullscreen='0'>
       <camera name='user_camera'>
-        <pose>5.4634 -5.46339 2.17586 0 0.275643 2.35619</pose>
-        <view_controller>orbit</view_controller>
+        <pose>-10 0 6 0 0.3 0</pose>
+        <!-- <view_controller>orbit</view_controller>
         <projection_type>perspective</projection_type>
         <track_visual>
           <name>iris_opt_flow</name>
           <use_model_frame>1</use_model_frame>
-        </track_visual>
+        </track_visual> -->
       </camera>
     </gui>
-  -->
   </world>
 </sdf>


### PR DESCRIPTION
also added the uneven ground again for the iris world.
I don't know why both of them have been reverted at some point... But as `iris_opt_flow` has the `uneven_ground` again it needs to have the camera pose (otherwise it is way off...).