### PR TITLE
fix flow sim

### DIFF
--- a/include/gazebo_mavlink_interface.h
+++ b/include/gazebo_mavlink_interface.h
@@ -156,7 +156,7 @@ public:
     hil_mode_(false),
     hil_state_level_(false)
     {}
-  
+
   ~GazeboMavlinkInterface();
 
   void Publish();
@@ -214,7 +214,7 @@ private:
   void send_mavlink_message(const mavlink_message_t *message, const int destination_port = 0);
   void handle_message(mavlink_message_t *msg);
   void pollForMAVLinkMessages(double _dt, uint32_t _timeoutMs);
-  
+
   // Serial interface
   void open();
   void close();
@@ -302,11 +302,11 @@ private:
 
   in_addr_t mavlink_addr_;
   int mavlink_udp_port_;
-  
+
   in_addr_t qgc_addr_;
   int qgc_udp_port_;
-  
-  // Serial interface 
+
+  // Serial interface
   mavlink_status_t m_status;
   mavlink_message_t m_buffer;
   bool serial_enabled_;
@@ -319,7 +319,7 @@ private:
   std::deque<MsgBuffer> tx_q;
   boost::asio::io_service io_service;
   boost::asio::serial_port serial_dev;
-  
+
   bool hil_mode_;
   bool hil_state_level_;
 

--- a/models/iris_opt_flow/iris_opt_flow.sdf
+++ b/models/iris_opt_flow/iris_opt_flow.sdf
@@ -11,9 +11,16 @@
       <pose>0.05 0 -0.05 0 0 0</pose>
     </include>
 
-    <joint name="px4flow_joint" type="fixed">
+    <joint name="px4flow_joint" type="revolute">
       <parent>iris::base_link</parent>
       <child>px4flow::link</child>
+      <axis>
+        <xyz>0 0 1</xyz>
+        <limit>
+          <upper>0</upper>
+          <lower>0</lower>
+        </limit>
+      </axis>
     </joint>
 
     <!--lidar-->

--- a/models/px4flow/px4flow.sdf.jinja
+++ b/models/px4flow/px4flow.sdf.jinja
@@ -58,7 +58,7 @@
       <sensor name="px4flow" type="camera">
         <always_on>true</always_on>
         <update_rate>100</update_rate>
-        <visualize>false</visualize>
+        <visualize>true</visualize>
         <topic>/px4flow</topic>
         <camera>
           <horizontal_fov>0.25</horizontal_fov>
@@ -69,6 +69,7 @@
           <image>
             <width>64</width>
             <height>64</height>
+            <format>L8</format>
           </image>
           <clip>
             <near>0.1</near>
@@ -82,6 +83,7 @@
         </camera>
         <plugin name="opticalflow_plugin" filename="libgazebo_opticalFlow_plugin.so">
             <robotNamespace></robotNamespace>
+            <outputRate>20</outputRate>
         </plugin>
         <!--<plugin name="camera_controller" filename="libgazebo_ros_camera.so">-->
             <!--<robotNamespace></robotNamespace>-->

--- a/models/sf10a/sf10a.sdf.jinja
+++ b/models/sf10a/sf10a.sdf.jinja
@@ -48,7 +48,7 @@
       </collision>
 
       <sensor name="sf10a" type="ray">
-        <visualize>false</visualize>
+        <visualize>true</visualize>
         <always_on>1</always_on>
         <update_rate>20</update_rate>
         <pose>0 0 0 0 {{ 90*deg2rad }} 0</pose>
@@ -62,8 +62,8 @@
             </horizontal>
           </scan>
           <range>
-            <min>0.06</min>
-            <max>25</max>
+            <min>0.06</min> <!-- do not change: use min_distance (below) for realistic behavior (smaller values cause issues) -->
+            <max>35</max>   <!-- do not change: use min_distance (below) for realistic behavior (bigger values cause issues) -->
             <resolution>0.01</resolution>
           </range>
           <noise>
@@ -76,6 +76,8 @@
         <plugin name="LaserPlugin"
           filename="libgazebo_lidar_plugin.so">
           <robotNamespace></robotNamespace>
+          <min_distance>0.1</min_distance>
+          <max_distance>25.0</max_distance>
         </plugin>
 
       </sensor>


### PR DESCRIPTION
This fixes the optical flow simulation (`make posix_sitl_default gazebo_iris_opt_flow`) for me. The fixed joint in iris_opt_flow.sdf somehow doesn't work for the camera... (That's also why it was there before)

In addition I made the sensors visible again as I like to have a distinction between the "normal" and the optical flow simulation.

I'll create a PR on Firmware as soon as this is in.