### PR TITLE
default iris position

### DIFF
--- a/worlds/iris.world
+++ b/worlds/iris.world
@@ -7,6 +7,7 @@
     </include>
     <include>
       <uri>model://iris</uri>
+      <pose>1.01 0.98 0.83 0 0 1.14</pose>
     </include>
     <include>
       <uri>model://uneven_ground</uri>

--- a/worlds/iris_opt_flow.world
+++ b/worlds/iris_opt_flow.world
@@ -8,6 +8,7 @@
     <!-- A ground plane -->
     <include>
       <uri>model://iris_opt_flow</uri>
+      <pose>1.01 0.98 0.83 0 0 1.14</pose>
     </include>
     <include>
       <uri>model://uneven_ground</uri>


### PR DESCRIPTION
I think it makes sense to use another starting position than zero. (0.83 is the height of the uneven ground at that position). 