### PR TITLE
Gazebo 9 compatibility (take 2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,8 @@ if (BUILD_GSTREAMER_PLUGIN)
   endif()
 endif()
 
+pkg_check_modules(OGRE OGRE)
+
 include_directories(SYSTEM ${GAZEBO_INCLUDE_DIRS})
 link_directories(${GAZEBO_LIBRARY_DIRS})
 
@@ -144,7 +146,11 @@ include_directories(
   # Workaround for Eigen3
   ${Boost_INCLUDE_DIR}/eigen3
   ${EIGEN3_INCLUDE_DIRS}/eigen3
+  ${OGRE_INCLUDE_DIRS}
+  # workaround for: "fatal error: OgrePagedWorldSection.h: No such file or directory"
+  ${OGRE_INCLUDE_DIRS}/Paging
   # Workaround for OGRE include dirs on Mac OS
+  # TODO: remove these hardcoded includes now that we have
   /usr/local/include/OGRE
   /usr/local/include/OGRE/Paging
   ${MAVLINK_INCLUDE_DIRS}
@@ -174,6 +180,7 @@ endif()
 link_directories(
   ${GAZEBO_LIBRARY_DIRS}
   ${CMAKE_CURRENT_BINARY_DIR}
+  ${OGRE_LIBRARY_DIRS}
   )
 
 #--------------------------#

--- a/include/common.h
+++ b/include/common.h
@@ -23,6 +23,7 @@
 
 #include <Eigen/Dense>
 #include <gazebo/gazebo.hh>
+#include <ignition/math.hh>
 
 namespace gazebo {
 
@@ -52,7 +53,7 @@ bool getSdfParam(sdf::ElementPtr sdf, const std::string& name, T& param, const T
 /**
  * \brief Get a math::Angle as an angle from [0, 360)
  */
-double GetDegrees360(const math::Angle& angle) {
+double GetDegrees360(const ignition::math::Angle& angle) {
   double degrees = angle.Degree();
   while (degrees < 0.) degrees += 360.0;
   while (degrees >= 360.0) degrees -= 360.0;

--- a/include/common.h
+++ b/include/common.h
@@ -139,6 +139,7 @@ void copyPosition(const In& in, Out* out) {
   out->z = in.z;
 }
 
+#if GAZEBO_MAJOR_VERSION < 9
 inline ignition::math::Vector3d ignitionFromGazeboMath(const gazebo::math::Vector3 &vec_gz) {
   return ignition::math::Vector3d(vec_gz.x, vec_gz.y, vec_gz.z);
 }
@@ -148,5 +149,6 @@ inline ignition::math::Pose3d ignitionFromGazeboMath(const gazebo::math::Pose &p
   return ignition::math::Pose3d(pose_gz.pos.x, pose_gz.pos.y, pose_gz.pos.z,
                                 pose_gz.rot.w, pose_gz.rot.x, pose_gz.rot.y, pose_gz.rot.z);
 }
+#endif
 
 #endif  // SITL_GAZEBO_COMMON_H_

--- a/include/common.h
+++ b/include/common.h
@@ -139,4 +139,14 @@ void copyPosition(const In& in, Out* out) {
   out->z = in.z;
 }
 
+inline ignition::math::Vector3d ignitionFromGazeboMath(const gazebo::math::Vector3 &vec_gz) {
+  return ignition::math::Vector3d(vec_gz.x, vec_gz.y, vec_gz.z);
+}
+
+inline ignition::math::Pose3d ignitionFromGazeboMath(const gazebo::math::Pose &pose_gz) {
+
+  return ignition::math::Pose3d(pose_gz.pos.x, pose_gz.pos.y, pose_gz.pos.z,
+                                pose_gz.rot.w, pose_gz.rot.x, pose_gz.rot.y, pose_gz.rot.z);
+}
+
 #endif  // SITL_GAZEBO_COMMON_H_

--- a/include/gazebo_controller_interface.h
+++ b/include/gazebo_controller_interface.h
@@ -29,6 +29,7 @@
 #include "MotorSpeed.pb.h"
 #include "gazebo/transport/transport.hh"
 #include "gazebo/msgs/msgs.hh"
+#include <ignition/math.hh>
 
 #include <stdio.h>
 

--- a/include/gazebo_geotagged_images_plugin.h
+++ b/include/gazebo_geotagged_images_plugin.h
@@ -29,6 +29,7 @@
 #include <gazebo/physics/physics.hh>
 #include <gazebo/rendering/rendering.hh>
 #include <SITLGps.pb.h>
+#include <ignition/math.hh>
 
 namespace gazebo
 {
@@ -93,7 +94,7 @@ private:
     rendering::ScenePtr         _scene;
     event::ConnectionPtr        _newFrameConnection;
     std::string                 _storageDir;
-    math::Vector3               _lastGpsPosition;
+    ignition::math::Vector3d    _lastGpsPosition;
     transport::NodePtr          _node_handle;
     std::string                 _namespace;
     transport::SubscriberPtr    _gpsSub;

--- a/include/gazebo_gimbal_controller_plugin.hh
+++ b/include/gazebo_gimbal_controller_plugin.hh
@@ -30,6 +30,7 @@
 #include <gazebo/transport/transport.hh>
 #include <gazebo/util/system.hh>
 #include <gazebo/sensors/sensors.hh>
+#include <ignition/math.hh>
 
 #include "SensorImu.pb.h"
 

--- a/include/gazebo_gps_plugin.h
+++ b/include/gazebo_gps_plugin.h
@@ -42,7 +42,7 @@
 #include <gazebo/transport/transport.hh>
 #include <gazebo/msgs/msgs.hh>
 #include <gazebo/physics/physics.hh>
-#include <gazebo/math/gzmath.hh>
+#include <ignition/math.hh>
 
 #include <SITLGps.pb.h>
 #include <Groundtruth.pb.h>
@@ -60,7 +60,7 @@ protected:
   virtual void OnUpdate(const common::UpdateInfo&);
 
 private:
-  std::pair<double, double> reproject(math::Vector3& pos);
+  std::pair<double, double> reproject(ignition::math::Vector3d& pos);
 
   std::string namespace_;
   std::default_random_engine random_generator_;
@@ -107,12 +107,12 @@ private:
   static constexpr int gps_buffer_size_max = 1000;
   std::queue<gps_msgs::msgs::SITLGps> gps_delay_buffer;
 
-  math::Vector3 gps_bias;
-  math::Vector3 noise_gps_pos;
-  math::Vector3 noise_gps_vel;
-  math::Vector3 random_walk_gps;
-  math::Vector3 gravity_W_;
-  math::Vector3 velocity_prev_W_;
+  ignition::math::Vector3d gps_bias;
+  ignition::math::Vector3d noise_gps_pos;
+  ignition::math::Vector3d noise_gps_vel;
+  ignition::math::Vector3d random_walk_gps;
+  ignition::math::Vector3d gravity_W_;
+  ignition::math::Vector3d velocity_prev_W_;
 
   // gps noise parameters
   double std_xy;    // meters

--- a/include/gazebo_imu_plugin.h
+++ b/include/gazebo_imu_plugin.h
@@ -26,6 +26,7 @@
 #include <gazebo/common/Plugin.hh>
 #include <gazebo/gazebo.hh>
 #include <gazebo/physics/physics.hh>
+#include <ignition/math.hh>
 #include "gazebo/transport/transport.hh"
 #include "gazebo/msgs/msgs.hh"
 
@@ -137,8 +138,8 @@ class GazeboImuPlugin : public ModelPlugin {
 
   sensor_msgs::msgs::Imu imu_message_;
 
-  math::Vector3 gravity_W_;
-  math::Vector3 velocity_prev_W_;
+  ignition::math::Vector3d gravity_W_;
+  ignition::math::Vector3d velocity_prev_W_;
 
   Eigen::Vector3d gyroscope_bias_;
   Eigen::Vector3d accelerometer_bias_;

--- a/include/gazebo_irlock_plugin.h
+++ b/include/gazebo_irlock_plugin.h
@@ -11,7 +11,6 @@
 #include "gazebo/transport/transport.hh"
 #include "gazebo/msgs/msgs.hh"
 #include "gazebo/physics/physics.hh"
-#include "gazebo/math/gzmath.hh"
 
 #include "irlock.pb.h"
 

--- a/include/gazebo_mavlink_interface.h
+++ b/include/gazebo_mavlink_interface.h
@@ -45,13 +45,13 @@
 #include <Eigen/Eigen>
 
 #include <gazebo/gazebo.hh>
-#include <gazebo/math/Vector3.hh>
 #include <gazebo/common/common.hh>
 #include <gazebo/common/Plugin.hh>
 #include <gazebo/physics/physics.hh>
 #include <gazebo/transport/transport.hh>
 #include <gazebo/msgs/msgs.hh>
 
+#include <ignition/math.hh>
 #include <sdf/sdf.hh>
 #include <common.h>
 #include <CommandMotorSpeed.pb.h>
@@ -280,9 +280,9 @@ private:
 
   void handle_control(double _dt);
 
-  math::Vector3 gravity_W_;
-  math::Vector3 velocity_prev_W_;
-  math::Vector3 mag_d_;
+  ignition::math::Vector3d gravity_W_;
+  ignition::math::Vector3d velocity_prev_W_;
+  ignition::math::Vector3d mag_d_;
 
   std::default_random_engine rand_;
   std::normal_distribution<float> randn_;
@@ -297,7 +297,7 @@ private:
   struct sockaddr_in _srcaddr_2;  ///< MAVROS
 
   //so we dont have to do extra callbacks
-  math::Vector3 optflow_gyro {};
+  ignition::math::Vector3d optflow_gyro {};
   double optflow_distance;
   double sonar_distance;
 

--- a/include/gazebo_motor_model.h
+++ b/include/gazebo_motor_model.h
@@ -30,7 +30,6 @@
 #include <gazebo/common/Plugin.hh>
 #include <rotors_model/motor_model.hpp>
 #include "CommandMotorSpeed.pb.h"
-#include "gazebo/math/Vector3.hh"
 #include "gazebo/transport/transport.hh"
 #include "gazebo/msgs/msgs.hh"
 #include "MotorSpeed.pb.h"
@@ -55,7 +54,7 @@ typedef const boost::shared_ptr<const mav_msgs::msgs::CommandMotorSpeed> Command
 
 /*
 // Protobuf test
-typedef const boost::shared_ptr<const mav_msgs::msgs::MotorSpeed> MotorSpeedPtr;  
+typedef const boost::shared_ptr<const mav_msgs::msgs::MotorSpeed> MotorSpeedPtr;
 static const std::string kDefaultMotorTestSubTopic = "motors";
 */
 

--- a/include/gazebo_multirotor_base_plugin.h
+++ b/include/gazebo_multirotor_base_plugin.h
@@ -28,7 +28,6 @@
 
 #include "common.h"
 
-#include "gazebo/math/Vector3.hh"
 #include "gazebo/transport/transport.hh"
 #include "gazebo/msgs/msgs.hh"
 #include "MotorSpeed.pb.h"

--- a/include/gazebo_uuv_plugin.h
+++ b/include/gazebo_uuv_plugin.h
@@ -21,7 +21,6 @@
 #include <gazebo/physics/physics.hh>
 
 #include "common.h"
-#include "gazebo/math/Vector3.hh"
 #include "gazebo/transport/transport.hh"
 #include "gazebo/msgs/msgs.hh"
 #include "CommandMotorSpeed.pb.h"
@@ -53,14 +52,14 @@ class GazeboUUVPlugin : public ModelPlugin {
 
   private:
     event::ConnectionPtr update_connection_;
-    
+
     std::string namespace_;
     std::string command_sub_topic_;
     std::string link_name_;
-    
+
     transport::NodePtr node_handle_;
     transport::SubscriberPtr command_sub_;
-    
+
     physics::LinkPtr link_;
     physics::Link_V rotor_links_;
 
@@ -69,7 +68,7 @@ class GazeboUUVPlugin : public ModelPlugin {
 
     double last_time_;
     double time_delta_;
-    
+
     double motor_force_constant_;
     double motor_torque_constant_;
 

--- a/include/gazebo_vision_plugin.h
+++ b/include/gazebo_vision_plugin.h
@@ -51,7 +51,7 @@
 #include <gazebo/transport/transport.hh>
 #include <gazebo/msgs/msgs.hh>
 #include <gazebo/physics/physics.hh>
-#include <gazebo/math/gzmath.hh>
+#include <ignition/math.hh>
 
 #include <odom.pb.h>
 
@@ -85,7 +85,7 @@ private:
   common::Time _last_pub_time;
   common::Time _last_time;
 
-  math::Pose _pose_model_start;
+  ignition::math::Pose3d _pose_model_start;
 
   int _pub_rate;
   // vision position estimate noise parameters
@@ -93,7 +93,7 @@ private:
   float _random_walk;
   float _noise_density;
 
-  math::Vector3 _bias;
+  ignition::math::Vector3d _bias;
 
   std::default_random_engine _rand;
   std::normal_distribution<float> _randn;

--- a/include/liftdrag_plugin/liftdrag_plugin.h
+++ b/include/liftdrag_plugin/liftdrag_plugin.h
@@ -23,6 +23,7 @@
 #include "gazebo/common/Plugin.hh"
 #include "gazebo/physics/physics.hh"
 #include "gazebo/transport/TransportTypes.hh"
+#include <ignition/math.hh>
 
 namespace gazebo
 {
@@ -107,19 +108,19 @@ namespace gazebo
     protected: double alpha;
 
     /// \brief center of pressure in link local coordinates
-    protected: math::Vector3 cp;
+    protected: ignition::math::Vector3d cp;
 
     /// \brief Normally, this is taken as a direction parallel to the chord
     /// of the airfoil in zero angle of attack forward flight.
-    protected: math::Vector3 forward;
+    protected: ignition::math::Vector3d forward;
 
     /// \brief A vector in the lift/drag plane, perpendicular to the forward
     /// vector. Inflow velocity orthogonal to forward and upward vectors
     /// is considered flow in the wing sweep direction.
-    protected: math::Vector3 upward;
+    protected: ignition::math::Vector3d upward;
 
     /// \brief Smoothed velocity
-    protected: math::Vector3 velSmooth;
+    protected: ignition::math::Vector3d velSmooth;
 
     /// \brief Pointer to link currently targeted by mud joint.
     protected: physics::LinkPtr link;

--- a/src/gazebo_controller_interface.cpp
+++ b/src/gazebo_controller_interface.cpp
@@ -24,7 +24,7 @@
 namespace gazebo {
 
 GazeboControllerInterface::~GazeboControllerInterface() {
-  event::Events::DisconnectWorldUpdateBegin(updateConnection_);
+  updateConnection_->~Connection();
 }
 
 void GazeboControllerInterface::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf) {
@@ -66,7 +66,7 @@ void GazeboControllerInterface::OnUpdate(const common::UpdateInfo& /*_info*/) {
   if(!received_first_referenc_)
     return;
 
-  common::Time now = world_->GetSimTime();
+  common::Time now = world_->SimTime();
 
   mav_msgs::msgs::CommandMotorSpeed turning_velocities_msg;
 

--- a/src/gazebo_controller_interface.cpp
+++ b/src/gazebo_controller_interface.cpp
@@ -66,7 +66,11 @@ void GazeboControllerInterface::OnUpdate(const common::UpdateInfo& /*_info*/) {
   if(!received_first_referenc_)
     return;
 
+#if GAZEBO_MAJOR_VERSION >= 9
   common::Time now = world_->SimTime();
+#else
+  common::Time now = world_->GetSimTime();
+#endif
 
   mav_msgs::msgs::CommandMotorSpeed turning_velocities_msg;
 

--- a/src/gazebo_geotagged_images_plugin.cpp
+++ b/src/gazebo_geotagged_images_plugin.cpp
@@ -153,10 +153,10 @@ void GeotaggedImagesPlugin::Load(sensors::SensorPtr sensor, sdf::ElementPtr sdf)
 }
 
 void GeotaggedImagesPlugin::OnNewGpsPosition(GpsPtr& gps_msg) {
-    _lastGpsPosition.x = gps_msg->latitude_deg();
-    _lastGpsPosition.y = gps_msg->longitude_deg();
-    _lastGpsPosition.z = gps_msg->altitude();
-    //gzdbg << "got gps pos: "<<_lastGpsPosition.x<<", "<<lastGpsPosition.y<<endl;
+    _lastGpsPosition.X() = gps_msg->latitude_deg();
+    _lastGpsPosition.Y() = gps_msg->longitude_deg();
+    _lastGpsPosition.Z() = gps_msg->altitude();
+    //gzdbg << "got gps pos: "<<_lastGpsPosition.X() <<", "<<lastGpsPosition.Y() <<endl;
 }
 
 void GeotaggedImagesPlugin::OnNewFrame(const unsigned char * image)
@@ -207,9 +207,9 @@ void GeotaggedImagesPlugin::OnNewFrame(const unsigned char * image)
     }
 
     char gps_tag_command[1024];
-    double lat = _lastGpsPosition.x;
+    double lat = _lastGpsPosition.X();
     char north_south = 'N', east_west = 'E';
-    double lon = _lastGpsPosition.y;
+    double lon = _lastGpsPosition.Y();
     if (lat < 0.) {
         lat = -lat;
         north_south = 'S';
@@ -223,7 +223,7 @@ void GeotaggedImagesPlugin::OnNewFrame(const unsigned char * image)
 //           " -gpsdatetime=now -gpsmapdatum=WGS-84"
              " -datetimeoriginal=now -gpsdop=0.8"
              " -gpsmeasuremode=3-d -gpssatellites=13 -gpsaltitude=%.3lf -overwrite_original %s &>/dev/null",
-             north_south, east_west, lat, lon, _lastGpsPosition.z, file_name);
+             north_south, east_west, lat, lon, _lastGpsPosition.Z(), file_name);
 
     system(gps_tag_command);
 
@@ -241,7 +241,7 @@ void GeotaggedImagesPlugin::OnNewFrame(const unsigned char * image)
         1, // camera ID
         lat * 1e7,
         lon * 1e7,
-        _lastGpsPosition.z,
+        _lastGpsPosition.Z(),
         0, // relative alt
         0, // q[4]
         _imageCounter,

--- a/src/gazebo_gimbal_controller_plugin.cpp
+++ b/src/gazebo_gimbal_controller_plugin.cpp
@@ -136,9 +136,9 @@ void GimbalControllerPlugin::Load(physics::ModelPtr _model,
 void GimbalControllerPlugin::Init()
 {
   this->node = transport::NodePtr(new transport::Node());
-  this->node->Init(this->model->GetWorld()->GetName());
+  this->node->Init(this->model->GetWorld()->Name());
 
-  this->lastUpdateTime = this->model->GetWorld()->GetSimTime();
+  this->lastUpdateTime = this->model->GetWorld()->SimTime();
 
   // receive pitch command via gz transport
   std::string pitchTopic = std::string("~/") +  this->model->GetName() +
@@ -280,7 +280,7 @@ void GimbalControllerPlugin::OnUpdate()
   if (!this->pitchJoint || !this->rollJoint || !this->yawJoint)
     return;
 
-  common::Time time = this->model->GetWorld()->GetSimTime();
+  common::Time time = this->model->GetWorld()->SimTime();
   if (time < this->lastUpdateTime)
   {
     gzerr << "time reset event\n";
@@ -303,14 +303,14 @@ void GimbalControllerPlugin::OnUpdate()
 
     // truncate command inside joint angle limits
     double rollLimited = ignition::math::clamp(this->rollCommand,
-      rDir*this->rollJoint->GetUpperLimit(0).Radian(),
-	  rDir*this->rollJoint->GetLowerLimit(0).Radian());
+      rDir*this->rollJoint->UpperLimit(0),
+	  rDir*this->rollJoint->LowerLimit(0));
     double pitchLimited = ignition::math::clamp(this->pitchCommand,
-      pDir*this->pitchJoint->GetUpperLimit(0).Radian(),
-      pDir*this->pitchJoint->GetLowerLimit(0).Radian());
+      pDir*this->pitchJoint->UpperLimit(0),
+      pDir*this->pitchJoint->LowerLimit(0));
     double yawLimited = ignition::math::clamp(this->yawCommand,
-      yDir*this->yawJoint->GetLowerLimit(0).Radian(),
-	  yDir*this->yawJoint->GetUpperLimit(0).Radian());
+      yDir*this->yawJoint->LowerLimit(0),
+	  yDir*this->yawJoint->UpperLimit(0));
 
     /// currentAngleYPRVariable is defined in roll-pitch-yaw-fixed-axis
     /// and gimbal is constructed using yaw-roll-pitch-variable-axis
@@ -328,13 +328,13 @@ void GimbalControllerPlugin::OnUpdate()
     /// get joint limits (in sensor frame)
     /// TODO: move to Load() if limits do not change
     ignition::math::Vector3d lowerLimitsPRY
-      (pDir*this->pitchJoint->GetLowerLimit(0).Radian(),
-       rDir*this->rollJoint->GetLowerLimit(0).Radian(),
-       yDir*this->yawJoint->GetLowerLimit(0).Radian());
+      (pDir*this->pitchJoint->LowerLimit(0),
+       rDir*this->rollJoint->LowerLimit(0),
+       yDir*this->yawJoint->LowerLimit(0));
     ignition::math::Vector3d upperLimitsPRY
-      (pDir*this->pitchJoint->GetUpperLimit(0).Radian(),
-       rDir*this->rollJoint->GetUpperLimit(0).Radian(),
-       yDir*this->yawJoint->GetUpperLimit(0).Radian());
+      (pDir*this->pitchJoint->UpperLimit(0),
+       rDir*this->rollJoint->UpperLimit(0),
+       yDir*this->yawJoint->UpperLimit(0));
 
     // normalize errors
     double pitchError = this->ShortestAngularDistance(
@@ -421,27 +421,27 @@ void GimbalControllerPlugin::OnUpdate()
     gazebo::msgs::Any m;
     m.set_type(gazebo::msgs::Any_ValueType_DOUBLE);
 
-    m.set_double_value(this->pitchJoint->GetAngle(0).Radian());
+    m.set_double_value(this->pitchJoint->Position(0));
     this->pitchPub->Publish(m);
 
-    m.set_double_value(this->rollJoint->GetAngle(0).Radian());
+    m.set_double_value(this->rollJoint->Position(0));
     this->rollPub->Publish(m);
 
-    m.set_double_value(this->yawJoint->GetAngle(0).Radian());
+    m.set_double_value(this->yawJoint->Position(0));
     this->yawPub->Publish(m);
 #else
     std::stringstream ss;
     gazebo::msgs::GzString m;
 
-    ss << this->pitchJoint->GetAngle(0).Radian();
+    ss << this->pitchJoint->Position(0);
     m.set_data(ss.str());
     this->pitchPub->Publish(m);
 
-    ss << this->rollJoint->GetAngle(0).Radian();
+    ss << this->rollJoint->Position(0);
     m.set_data(ss.str());
     this->rollPub->Publish(m);
 
-    ss << this->yawJoint->GetAngle(0).Radian();
+    ss << this->yawJoint->Position(0);
     m.set_data(ss.str());
     this->yawPub->Publish(m);
 #endif

--- a/src/gazebo_imu_plugin.cpp
+++ b/src/gazebo_imu_plugin.cpp
@@ -36,7 +36,7 @@ GazeboImuPlugin::GazeboImuPlugin()
 }
 
 GazeboImuPlugin::~GazeboImuPlugin() {
-  event::Events::DisconnectWorldUpdateBegin(updateConnection_);
+  updateConnection_->~Connection();
 }
 
 
@@ -94,7 +94,7 @@ void GazeboImuPlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf) {
                       imu_parameters_.accelerometer_turn_on_bias_sigma,
                       imu_parameters_.accelerometer_turn_on_bias_sigma);
 
-  last_time_ = world_->GetSimTime();
+  last_time_ = world_->SimTime();
 
   // Listen to the update event. This event is broadcast every
   // simulation iteration.
@@ -161,8 +161,8 @@ void GazeboImuPlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf) {
     }
   }
 
-  gravity_W_ = world_->GetPhysicsEngine()->GetGravity();
-  imu_parameters_.gravity_magnitude = gravity_W_.GetLength();
+  gravity_W_ = world_->Gravity();
+  imu_parameters_.gravity_magnitude = gravity_W_.Length();
 
   standard_normal_distribution_ = std::normal_distribution<double>(0.0, 1.0);
 
@@ -238,20 +238,20 @@ void GazeboImuPlugin::addNoise(Eigen::Vector3d* linear_acceleration,
 
 // This gets called by the world update start event.
 void GazeboImuPlugin::OnUpdate(const common::UpdateInfo& _info) {
-  common::Time current_time  = world_->GetSimTime();
+  common::Time current_time  = world_->SimTime();
   double dt = (current_time - last_time_).Double();
   last_time_ = current_time;
   double t = current_time.Double();
 
-  math::Pose T_W_I = link_->GetWorldPose(); //TODO(burrimi): Check tf.
-  math::Quaternion C_W_I = T_W_I.rot;
+  ignition::math::Pose3d T_W_I = link_->WorldPose(); //TODO(burrimi): Check tf.
+  ignition::math::Quaterniond C_W_I = T_W_I.Rot();
 
-  // Copy math::Quaternion to gazebo::msgs::Quaternion
+  // Copy ignition::math::Quaterniond to gazebo::msgs::Quaternion
   gazebo::msgs::Quaternion* orientation = new gazebo::msgs::Quaternion();
-  orientation->set_x(C_W_I.x);
-  orientation->set_y(C_W_I.y);
-  orientation->set_z(C_W_I.z);
-  orientation->set_w(C_W_I.w);
+  orientation->set_x(C_W_I.X());
+  orientation->set_y(C_W_I.Y());
+  orientation->set_z(C_W_I.Z());
+  orientation->set_w(C_W_I.W());
 
 
 
@@ -261,27 +261,27 @@ void GazeboImuPlugin::OnUpdate(const common::UpdateInfo& _info) {
 
 
 #if GAZEBO_MAJOR_VERSION < 5
-  math::Vector3 velocity_current_W = link_->GetWorldLinearVel();
-  // link_->GetRelativeLinearAccel() does not work sometimes with old gazebo versions.
+  ignition::math::Vector3d velocity_current_W = link_->GetWorldLinearVel();
+  // link_->RelativeLinearAccel() does not work sometimes with old gazebo versions.
   // TODO For an accurate simulation, this might have to be fixed. Consider the
   // This issue is solved in gazebo 5.
-  math::Vector3 acceleration = (velocity_current_W - velocity_prev_W_) / dt;
-  math::Vector3 acceleration_I =
+  ignition::math::Vector3d acceleration = (velocity_current_W - velocity_prev_W_) / dt;
+  ignition::math::Vector3d acceleration_I =
       C_W_I.RotateVectorReverse(acceleration - gravity_W_);
 
   velocity_prev_W_ = velocity_current_W;
 #else
-  math::Vector3 acceleration_I = link_->GetRelativeLinearAccel() - C_W_I.RotateVectorReverse(gravity_W_);
+  ignition::math::Vector3d acceleration_I = link_->RelativeLinearAccel() - C_W_I.RotateVectorReverse(gravity_W_);
 #endif
 
-  math::Vector3 angular_vel_I = link_->GetRelativeAngularVel();
+  ignition::math::Vector3d angular_vel_I = link_->RelativeAngularVel();
 
-  Eigen::Vector3d linear_acceleration_I(acceleration_I.x,
-                                        acceleration_I.y,
-                                        acceleration_I.z);
-  Eigen::Vector3d angular_velocity_I(angular_vel_I.x,
-                                     angular_vel_I.y,
-                                     angular_vel_I.z);
+  Eigen::Vector3d linear_acceleration_I(acceleration_I.X(),
+                                        acceleration_I.Y(),
+                                        acceleration_I.Z());
+  Eigen::Vector3d angular_velocity_I(angular_vel_I.X(),
+                                     angular_vel_I.Y(),
+                                     angular_vel_I.Z());
 
   addNoise(&linear_acceleration_I, &angular_velocity_I, dt);
 
@@ -307,7 +307,7 @@ void GazeboImuPlugin::OnUpdate(const common::UpdateInfo& _info) {
   // imu_message_.orientation.x = 0;
   // imu_message_.orientation.y = 0;
   // imu_message_.orientation.z = 0;
-  
+
   imu_message_.set_allocated_orientation(orientation);
   imu_message_.set_allocated_linear_acceleration(linear_acceleration);
   imu_message_.set_allocated_angular_velocity(angular_velocity);

--- a/src/gazebo_irlock_plugin.cpp
+++ b/src/gazebo_irlock_plugin.cpp
@@ -28,6 +28,7 @@
 #include <string>
 #include <iostream>
 #include <boost/algorithm/string.hpp>
+#include <ignition/math.hh>
 
 using namespace cv;
 using namespace std;
@@ -92,20 +93,20 @@ void IRLockPlugin::OnUpdated()
       if (model.has_pose()) {
 
         // position of the beacon in camera frame
-        gazebo::math::Vector3 pos;
-        pos.x = model.pose().position().x();
-        pos.y = model.pose().position().y();
-        pos.z = model.pose().position().z();
+        ignition::math::Vector3d pos;
+        pos.X() = model.pose().position().x();
+        pos.Y() = model.pose().position().y();
+        pos.Z() = model.pose().position().z();
 
         // the default orientation of the IRLock sensor reports beacon in front of vehicle as -y values, beacon right of vehicle as x values
         // rotate the measurement accordingly
-        gazebo::math::Vector3 meas(-pos.y/pos.x, -pos.z/pos.x, 1.0);
+        ignition::math::Vector3d meas(-pos.Y()/pos.X(), -pos.Z()/pos.X(), 1.0);
 
         // prepare irlock message
         irlock_message.set_time_usec(0); // will be filled in simulator_mavlink.cpp
         irlock_message.set_signature(idx); // unused by beacon estimator
-        irlock_message.set_pos_x(meas.x);
-        irlock_message.set_pos_y(meas.y);
+        irlock_message.set_pos_x(meas.X());
+        irlock_message.set_pos_y(meas.Y());
         irlock_message.set_size_x(0); // unused by beacon estimator
         irlock_message.set_size_y(0); // unused by beacon estimator
 

--- a/src/gazebo_lidar_plugin.cpp
+++ b/src/gazebo_lidar_plugin.cpp
@@ -50,12 +50,8 @@ RayPlugin::RayPlugin()
 /////////////////////////////////////////////////
 RayPlugin::~RayPlugin()
 {
-#if GAZEBO_MAJOR_VERSION >= 7
-  this->parentSensor_->LaserShape()->DisconnectNewLaserScans(
-#else
-  this->parentSensor_->GetLaserShape()->DisconnectNewLaserScans(
-#endif
-      this->newLaserScansConnection);
+  this->newLaserScansConnection->~Connection();
+
   this->newLaserScansConnection.reset();
 
   this->parentSensor_.reset();

--- a/src/gazebo_mavlink_interface.cpp
+++ b/src/gazebo_mavlink_interface.cpp
@@ -25,7 +25,7 @@ namespace gazebo {
 GZ_REGISTER_MODEL_PLUGIN(GazeboMavlinkInterface);
 
 GazeboMavlinkInterface::~GazeboMavlinkInterface() {
-  event::Events::DisconnectWorldUpdateBegin(updateConnection_);
+    updateConnection_->~Connection();
 }
 
 void GazeboMavlinkInterface::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf) {
@@ -195,9 +195,9 @@ void GazeboMavlinkInterface::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf
   motor_velocity_reference_pub_ = node_handle_->Advertise<mav_msgs::msgs::CommandMotorSpeed>("~/" + model_->GetName() + motor_velocity_reference_pub_topic_, 1);
 
   _rotor_count = 5;
-  last_time_ = world_->GetSimTime();
-  last_imu_time_ = world_->GetSimTime();
-  gravity_W_ = world_->GetPhysicsEngine()->GetGravity();
+  last_time_ = world_->SimTime();
+  last_imu_time_ = world_->SimTime();
+  gravity_W_ = world_->Gravity();
 
   if (_sdf->HasElement("imu_rate")) {
     imu_update_interval_ = 1 / _sdf->GetElement("imu_rate")->Get<int>();
@@ -210,9 +210,9 @@ void GazeboMavlinkInterface::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf
   // and so we need to start without any offsets.
   // The real value for Zurich would be 0.00771
   // frame d is the magnetic north frame
-  mag_d_.x = 0.21523;
-  mag_d_.y = 0;
-  mag_d_.z = -0.42741;
+  mag_d_.X() = 0.21523;
+  mag_d_.Y() = 0;
+  mag_d_.Z() = -0.42741;
 
   if(_sdf->HasElement("hil_state_level"))
   {
@@ -328,7 +328,7 @@ void GazeboMavlinkInterface::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf
 
 // This gets called by the world update start event.
 void GazeboMavlinkInterface::OnUpdate(const common::UpdateInfo&  /*_info*/) {
-  common::Time current_time = world_->GetSimTime();
+  common::Time current_time = world_->SimTime();
   double dt = (current_time - last_time_).Double();
 
   pollForMAVLinkMessages(dt, 1000);
@@ -397,7 +397,7 @@ void GazeboMavlinkInterface::send_mavlink_message(const mavlink_message_t *messa
 }
 
 void GazeboMavlinkInterface::ImuCallback(ImuPtr& imu_message) {
-  common::Time current_time = world_->GetSimTime();
+  common::Time current_time = world_->SimTime();
   double dt = (current_time - last_imu_time_).Double();
 
     // frames
@@ -405,7 +405,7 @@ void GazeboMavlinkInterface::ImuCallback(ImuPtr& imu_message) {
     // r - rotors imu frame (FLU), forward, left, up
     // b - px4 (FRD) forward, right down
     // n - px4 (NED) north, east, down
-    math::Quaternion q_gr = math::Quaternion(
+    ignition::math::Quaterniond q_gr = ignition::math::Quaterniond(
       imu_message->orientation().w(),
       imu_message->orientation().x(),
       imu_message->orientation().y(),
@@ -421,7 +421,7 @@ void GazeboMavlinkInterface::ImuCallback(ImuPtr& imu_message) {
         ]
     )).round(5)
     */
-    math::Quaternion q_br(0, 1, 0, 0);
+    ignition::math::Quaterniond q_br(0, 1, 0, 0);
 
 
     // q_ng
@@ -434,56 +434,56 @@ void GazeboMavlinkInterface::ImuCallback(ImuPtr& imu_message) {
         ]
     )).round(5)
     */
-    math::Quaternion q_ng(0, 0.70711, 0.70711, 0);
+    ignition::math::Quaterniond q_ng(0, 0.70711, 0.70711, 0);
 
-    math::Quaternion q_gb = q_gr*q_br.GetInverse();
-    math::Quaternion q_nb = q_ng*q_gb;
+    ignition::math::Quaterniond q_gb = q_gr*q_br.Inverse();
+    ignition::math::Quaterniond q_nb = q_ng*q_gb;
 
-    math::Vector3 pos_g = model_->GetWorldPose().pos;
-    math::Vector3 pos_n = q_ng.RotateVector(pos_g);
+    ignition::math::Vector3d pos_g = model_->WorldPose().Pos();
+    ignition::math::Vector3d pos_n = q_ng.RotateVector(pos_g);
 
     float declination = get_mag_declination(groundtruth_lat_rad, groundtruth_lon_rad);
 
-    math::Quaternion q_dn(0.0, 0.0, declination);
-    math::Vector3 mag_n = q_dn.RotateVector(mag_d_);
+    ignition::math::Quaterniond q_dn(0.0, 0.0, declination);
+    ignition::math::Vector3d mag_n = q_dn.RotateVector(mag_d_);
 
-    math::Vector3 vel_b = q_br.RotateVector(model_->GetRelativeLinearVel());
-    math::Vector3 vel_n = q_ng.RotateVector(model_->GetWorldLinearVel());
-    math::Vector3 omega_nb_b = q_br.RotateVector(model_->GetRelativeAngularVel());
+    ignition::math::Vector3d vel_b = q_br.RotateVector(model_->RelativeLinearVel());
+    ignition::math::Vector3d vel_n = q_ng.RotateVector(model_->WorldLinearVel());
+    ignition::math::Vector3d omega_nb_b = q_br.RotateVector(model_->RelativeAngularVel());
 
-    math::Vector3 mag_noise_b(
+    ignition::math::Vector3d mag_noise_b(
       0.01 * randn_(rand_),
       0.01 * randn_(rand_),
       0.01 * randn_(rand_));
 
-    math::Vector3 accel_b = q_br.RotateVector(math::Vector3(
+    ignition::math::Vector3d accel_b = q_br.RotateVector(ignition::math::Vector3d(
       imu_message->linear_acceleration().x(),
       imu_message->linear_acceleration().y(),
       imu_message->linear_acceleration().z()));
-    math::Vector3 gyro_b = q_br.RotateVector(math::Vector3(
+    ignition::math::Vector3d gyro_b = q_br.RotateVector(ignition::math::Vector3d(
       imu_message->angular_velocity().x(),
       imu_message->angular_velocity().y(),
       imu_message->angular_velocity().z()));
-    math::Vector3 mag_b = q_nb.RotateVectorReverse(mag_n) + mag_noise_b;
+    ignition::math::Vector3d mag_b = q_nb.RotateVectorReverse(mag_n) + mag_noise_b;
 
   if (imu_update_interval_!=0 && dt >= imu_update_interval_)
   {
     mavlink_hil_sensor_t sensor_msg;
-    sensor_msg.time_usec = world_->GetSimTime().Double() * 1e6;
-    sensor_msg.xacc = accel_b.x;
-    sensor_msg.yacc = accel_b.y;
-    sensor_msg.zacc = accel_b.z;
-    sensor_msg.xgyro = gyro_b.x;
-    sensor_msg.ygyro = gyro_b.y;
-    sensor_msg.zgyro = gyro_b.z;
-    sensor_msg.xmag = mag_b.x;
-    sensor_msg.ymag = mag_b.y;
-    sensor_msg.zmag = mag_b.z;
+    sensor_msg.time_usec = world_->SimTime().Double() * 1e6;
+    sensor_msg.xacc = accel_b.X();
+    sensor_msg.yacc = accel_b.Y();
+    sensor_msg.zacc = accel_b.Z();
+    sensor_msg.xgyro = gyro_b.X();
+    sensor_msg.ygyro = gyro_b.Y();
+    sensor_msg.zgyro = gyro_b.Z();
+    sensor_msg.xmag = mag_b.X();
+    sensor_msg.ymag = mag_b.Y();
+    sensor_msg.zmag = mag_b.Z();
 
     // calculate abs_pressure using an ISA model for the tropsphere (valid up to 11km above MSL)
     const float lapse_rate = 0.0065f; // reduction in temperature with altitude (Kelvin/m)
     const float temperature_msl = 288.0f; // temperature at MSL (Kelvin)
-    float alt_msl = (float)alt_home - pos_n.z;
+    float alt_msl = (float)alt_home - pos_n.Z();
     float temperature_local = temperature_msl - lapse_rate * alt_msl;
     float pressure_ratio = powf((temperature_msl/temperature_local) , 5.256f);
     const float pressure_msl = 101325.0f; // pressure at MSL
@@ -513,14 +513,14 @@ void GazeboMavlinkInterface::ImuCallback(ImuPtr& imu_message) {
     float rho = 1.225f / density_ratio;
 
     // calculate pressure altitude including effect of pressure noise
-    sensor_msg.pressure_alt = alt_msl - abs_pressure_noise / (gravity_W_.GetLength() * rho);
+    sensor_msg.pressure_alt = alt_msl - abs_pressure_noise / (gravity_W_.Length() * rho);
 
     // calculate differential pressure in hPa
     // if vehicle is a tailsitter the airspeed axis is different (z points from nose to tail)
     if (vehicle_is_tailsitter_) {
-      sensor_msg.diff_pressure = 0.005f*rho*vel_b.z*vel_b.z;
+      sensor_msg.diff_pressure = 0.005f*rho*vel_b.Z()*vel_b.Z();
     } else {
-      sensor_msg.diff_pressure = 0.005f*rho*vel_b.x*vel_b.x;
+      sensor_msg.diff_pressure = 0.005f*rho*vel_b.X()*vel_b.X();
     }
 
     // calculate temperature in Celsius
@@ -551,36 +551,36 @@ void GazeboMavlinkInterface::ImuCallback(ImuPtr& imu_message) {
   }
 
     // ground truth
-    math::Vector3 accel_true_b = q_br.RotateVector(model_->GetRelativeLinearAccel());
+    ignition::math::Vector3d accel_true_b = q_br.RotateVector(model_->RelativeLinearAccel());
 
     // send ground truth
 
     mavlink_hil_state_quaternion_t hil_state_quat;
-    hil_state_quat.time_usec = world_->GetSimTime().Double() * 1e6;
-    hil_state_quat.attitude_quaternion[0] = q_nb.w;
-    hil_state_quat.attitude_quaternion[1] = q_nb.x;
-    hil_state_quat.attitude_quaternion[2] = q_nb.y;
-    hil_state_quat.attitude_quaternion[3] = q_nb.z;
+    hil_state_quat.time_usec = world_->SimTime().Double() * 1e6;
+    hil_state_quat.attitude_quaternion[0] = q_nb.W();
+    hil_state_quat.attitude_quaternion[1] = q_nb.X();
+    hil_state_quat.attitude_quaternion[2] = q_nb.Y();
+    hil_state_quat.attitude_quaternion[3] = q_nb.Z();
 
-    hil_state_quat.rollspeed = omega_nb_b.x;
-    hil_state_quat.pitchspeed = omega_nb_b.y;
-    hil_state_quat.yawspeed = omega_nb_b.z;
+    hil_state_quat.rollspeed = omega_nb_b.X();
+    hil_state_quat.pitchspeed = omega_nb_b.Y();
+    hil_state_quat.yawspeed = omega_nb_b.Z();
 
     hil_state_quat.lat = groundtruth_lat_rad * 180 / M_PI * 1e7;
     hil_state_quat.lon = groundtruth_lon_rad * 180 / M_PI * 1e7;
     hil_state_quat.alt = groundtruth_altitude * 1000;
 
-    hil_state_quat.vx = vel_n.x * 100;
-    hil_state_quat.vy = vel_n.y * 100;
-    hil_state_quat.vz = vel_n.z * 100;
+    hil_state_quat.vx = vel_n.X() * 100;
+    hil_state_quat.vy = vel_n.Y() * 100;
+    hil_state_quat.vz = vel_n.Z() * 100;
 
     // assumed indicated airspeed due to flow aligned with pitot (body x)
-    hil_state_quat.ind_airspeed = vel_b.x;
-    hil_state_quat.true_airspeed = model_->GetWorldLinearVel().GetLength() * 100;  //no wind simulated
+    hil_state_quat.ind_airspeed = vel_b.X();
+    hil_state_quat.true_airspeed = model_->WorldLinearVel().Length() * 100;  //no wind simulated
 
-    hil_state_quat.xacc = accel_true_b.x * 1000;
-    hil_state_quat.yacc = accel_true_b.y * 1000;
-    hil_state_quat.zacc = accel_true_b.z * 1000;
+    hil_state_quat.xacc = accel_true_b.X() * 1000;
+    hil_state_quat.yacc = accel_true_b.Y() * 1000;
+    hil_state_quat.zacc = accel_true_b.Z() * 1000;
 
     mavlink_message_t msg;
     mavlink_msg_hil_state_quaternion_encode_chan(1, 200, MAVLINK_COMM_0, &msg, &hil_state_quat);
@@ -610,7 +610,7 @@ void GazeboMavlinkInterface::GpsCallback(GpsPtr& gps_msg){
   hil_gps_msg.ve = gps_msg->velocity_east() * 100.0;
   hil_gps_msg.vd = -gps_msg->velocity_up() * 100.0;
   // MAVLINK_HIL_GPS_T CoG is [0, 360]. math::Angle::Normalize() is [-pi, pi].
-  math::Angle cog(atan2(gps_msg->velocity_east(), gps_msg->velocity_north()));
+  ignition::math::Angle cog(atan2(gps_msg->velocity_east(), gps_msg->velocity_north()));
   cog.Normalize();
   hil_gps_msg.cog = static_cast<uint16_t>(GetDegrees360(cog) * 100.0);
   hil_gps_msg.satellites_visible = 10;
@@ -659,14 +659,14 @@ void GazeboMavlinkInterface::LidarCallback(LidarPtr& lidar_message) {
 
 void GazeboMavlinkInterface::OpticalFlowCallback(OpticalFlowPtr& opticalFlow_message) {
   mavlink_hil_optical_flow_t sensor_msg;
-  sensor_msg.time_usec = world_->GetSimTime().Double() * 1e6;
+  sensor_msg.time_usec = world_->SimTime().Double() * 1e6;
   sensor_msg.sensor_id = opticalFlow_message->sensor_id();
   sensor_msg.integration_time_us = opticalFlow_message->integration_time_us();
   sensor_msg.integrated_x = opticalFlow_message->integrated_x();
   sensor_msg.integrated_y = opticalFlow_message->integrated_y();
-  sensor_msg.integrated_xgyro = opticalFlow_message->quality() ? -optflow_gyro.y : 0.0f;//xy switched
-  sensor_msg.integrated_ygyro = opticalFlow_message->quality() ? optflow_gyro.x : 0.0f;  //xy switched
-  sensor_msg.integrated_zgyro = opticalFlow_message->quality() ? -optflow_gyro.z : 0.0f;//change direction
+  sensor_msg.integrated_xgyro = opticalFlow_message->quality() ? -optflow_gyro.Y() : 0.0f;//xy switched
+  sensor_msg.integrated_ygyro = opticalFlow_message->quality() ? optflow_gyro.X() : 0.0f;  //xy switched
+  sensor_msg.integrated_zgyro = opticalFlow_message->quality() ? -optflow_gyro.Z() : 0.0f;//change direction
   sensor_msg.temperature = opticalFlow_message->temperature();
   sensor_msg.quality = opticalFlow_message->quality();
   sensor_msg.time_delta_distance_us = opticalFlow_message->time_delta_distance_us();
@@ -682,7 +682,7 @@ void GazeboMavlinkInterface::OpticalFlowCallback(OpticalFlowPtr& opticalFlow_mes
 
 void GazeboMavlinkInterface::SonarCallback(SonarSensPtr& sonar_message) {
   mavlink_distance_sensor_t sensor_msg;
-  sensor_msg.time_boot_ms = world_->GetSimTime().Double() * 1e3;
+  sensor_msg.time_boot_ms = world_->SimTime().Double() * 1e3;
   sensor_msg.min_distance = sonar_message->min_distance() * 100.0;
   sensor_msg.max_distance = sonar_message->max_distance() * 100.0;
   sensor_msg.current_distance = sonar_message->current_distance() * 100.0;
@@ -699,7 +699,7 @@ void GazeboMavlinkInterface::SonarCallback(SonarSensPtr& sonar_message) {
 void GazeboMavlinkInterface::IRLockCallback(IRLockPtr& irlock_message) {
   mavlink_landing_target_t sensor_msg;
 
-  sensor_msg.time_usec = world_->GetSimTime().Double() * 1e6;
+  sensor_msg.time_usec = world_->SimTime().Double() * 1e6;
   sensor_msg.target_num = irlock_message->signature();
   sensor_msg.angle_x = irlock_message->pos_x();
   sensor_msg.angle_y = irlock_message->pos_y();
@@ -792,7 +792,7 @@ void GazeboMavlinkInterface::handle_message(mavlink_message_t *msg)
       armed = true;
     }
 
-    last_actuator_time_ = world_->GetSimTime();
+    last_actuator_time_ = world_->SimTime();
 
     for (unsigned i = 0; i < n_out_max; i++) {
       input_index_[i] = i;
@@ -829,7 +829,7 @@ void GazeboMavlinkInterface::handle_control(double _dt)
       }
       else if (joint_control_type_[i] == "position")
       {
-        double current = joints_[i]->GetAngle(0).Radian();
+        double current = joints_[i]->Position(0);
 
         double err = current - target;
         double force = pids_[i].Update(err, _dt);

--- a/src/gazebo_motor_model.cpp
+++ b/src/gazebo_motor_model.cpp
@@ -195,7 +195,12 @@ void GazeboMotorModel::UpdateForcesAndMoments() {
 
   // scale down force linearly with forward speed
   // XXX this has to be modelled better
+  //
+#if GAZEBO_MAJOR_VERSION >= 9
   ignition::math::Vector3d body_velocity = link_->WorldLinearVel();
+#else
+  ignition::math::Vector3d body_velocity = ignitionFromGazeboMath(link_->GetWorldLinearVel());
+#endif
   double vel = body_velocity.Length();
   double scalar = 1 - vel / 25.0; // at 50 m/s the rotor will not produce any force anymore
   scalar = ignition::math::clamp(scalar, 0.0, 1.0);
@@ -206,7 +211,11 @@ void GazeboMotorModel::UpdateForcesAndMoments() {
   // 2010 IEEE Conference on Robotics and Automation paper
   // The True Role of Accelerometer Feedback in Quadrotor Control
   // - \omega * \lambda_1 * V_A^{\perp}
+#if GAZEBO_MAJOR_VERSION >= 9
   ignition::math::Vector3d joint_axis = joint_->GlobalAxis(0);
+#else
+  ignition::math::Vector3d joint_axis = ignitionFromGazeboMath(joint_->GetGlobalAxis(0));
+#endif
   //ignition::math::Vector3d body_velocity = link_->WorldLinearVel();
   ignition::math::Vector3d body_velocity_perpendicular = body_velocity - (body_velocity * joint_axis) * joint_axis;
   ignition::math::Vector3d air_drag = -std::abs(real_motor_velocity) * rotor_drag_coefficient_ * body_velocity_perpendicular;
@@ -216,7 +225,11 @@ void GazeboMotorModel::UpdateForcesAndMoments() {
   // Getting the parent link, such that the resulting torques can be applied to it.
   physics::Link_V parent_links = link_->GetParentJointsLinks();
   // The tansformation from the parent_link to the link_.
+#if GAZEBO_MAJOR_VERSION >= 9
   ignition::math::Pose3d pose_difference = link_->WorldCoGPose() - parent_links.at(0)->WorldCoGPose();
+#else
+  ignition::math::Pose3d pose_difference = ignitionFromGazeboMath(link_->GetWorldCoGPose() - parent_links.at(0)->GetWorldCoGPose());
+#endif
   ignition::math::Vector3d drag_torque(0, 0, -turning_direction_ * force * moment_constant_);
   // Transforming the drag torque into the parent frame to handle arbitrary rotor orientations.
   ignition::math::Vector3d drag_torque_parent_frame = pose_difference.Rot().RotateVector(drag_torque);

--- a/src/gazebo_motor_model.cpp
+++ b/src/gazebo_motor_model.cpp
@@ -20,11 +20,12 @@
 
 
 #include "gazebo_motor_model.h"
+#include <ignition/math.hh>
 
 namespace gazebo {
 
 GazeboMotorModel::~GazeboMotorModel() {
-  event::Events::DisconnectWorldUpdateBegin(updateConnection_);
+  updateConnection_->~Connection();
   use_pid_ = false;
 }
 
@@ -194,34 +195,34 @@ void GazeboMotorModel::UpdateForcesAndMoments() {
 
   // scale down force linearly with forward speed
   // XXX this has to be modelled better
-  math::Vector3 body_velocity = link_->GetWorldLinearVel();
-  double vel = body_velocity.GetLength();
+  ignition::math::Vector3d body_velocity = link_->WorldLinearVel();
+  double vel = body_velocity.Length();
   double scalar = 1 - vel / 25.0; // at 50 m/s the rotor will not produce any force anymore
-  scalar = math::clamp(scalar, 0.0, 1.0);
+  scalar = ignition::math::clamp(scalar, 0.0, 1.0);
   // Apply a force to the link.
-  link_->AddRelativeForce(math::Vector3(0, 0, force * scalar));
+  link_->AddRelativeForce(ignition::math::Vector3d(0, 0, force * scalar));
 
   // Forces from Philppe Martin's and Erwan Salaün's
   // 2010 IEEE Conference on Robotics and Automation paper
   // The True Role of Accelerometer Feedback in Quadrotor Control
   // - \omega * \lambda_1 * V_A^{\perp}
-  math::Vector3 joint_axis = joint_->GetGlobalAxis(0);
-  //math::Vector3 body_velocity = link_->GetWorldLinearVel();
-  math::Vector3 body_velocity_perpendicular = body_velocity - (body_velocity * joint_axis) * joint_axis;
-  math::Vector3 air_drag = -std::abs(real_motor_velocity) * rotor_drag_coefficient_ * body_velocity_perpendicular;
+  ignition::math::Vector3d joint_axis = joint_->GlobalAxis(0);
+  //ignition::math::Vector3d body_velocity = link_->WorldLinearVel();
+  ignition::math::Vector3d body_velocity_perpendicular = body_velocity - (body_velocity * joint_axis) * joint_axis;
+  ignition::math::Vector3d air_drag = -std::abs(real_motor_velocity) * rotor_drag_coefficient_ * body_velocity_perpendicular;
   // Apply air_drag to link.
   link_->AddForce(air_drag);
   // Moments
   // Getting the parent link, such that the resulting torques can be applied to it.
   physics::Link_V parent_links = link_->GetParentJointsLinks();
   // The tansformation from the parent_link to the link_.
-  math::Pose pose_difference = link_->GetWorldCoGPose() - parent_links.at(0)->GetWorldCoGPose();
-  math::Vector3 drag_torque(0, 0, -turning_direction_ * force * moment_constant_);
+  ignition::math::Pose3d pose_difference = link_->WorldCoGPose() - parent_links.at(0)->WorldCoGPose();
+  ignition::math::Vector3d drag_torque(0, 0, -turning_direction_ * force * moment_constant_);
   // Transforming the drag torque into the parent frame to handle arbitrary rotor orientations.
-  math::Vector3 drag_torque_parent_frame = pose_difference.rot.RotateVector(drag_torque);
+  ignition::math::Vector3d drag_torque_parent_frame = pose_difference.Rot().RotateVector(drag_torque);
   parent_links.at(0)->AddRelativeTorque(drag_torque_parent_frame);
 
-  math::Vector3 rolling_moment;
+  ignition::math::Vector3d rolling_moment;
   // - \omega * \mu_1 * V_A^{\perp}
   rolling_moment = -std::abs(real_motor_velocity) * rolling_moment_coefficient_ * body_velocity_perpendicular;
   parent_links.at(0)->AddTorque(rolling_moment);
@@ -262,7 +263,7 @@ void GazeboMotorModel::UpdateMotorFail() {
     if (screen_msg_flag){
       std::cout << "Motor number [" << motor_Failure_Number_ <<"] failed!  [Motor thrust = 0]" << std::endl;
       tmp_motor_num = motor_Failure_Number_;
-      
+
       screen_msg_flag = 0;
     }
   }else if (motor_Failure_Number_ == 0 && motor_number_ ==  tmp_motor_num - 1){

--- a/src/gazebo_multirotor_base_plugin.cpp
+++ b/src/gazebo_multirotor_base_plugin.cpp
@@ -25,7 +25,7 @@
 namespace gazebo {
 
 GazeboMultirotorBasePlugin::~GazeboMultirotorBasePlugin() {
-  event::Events::DisconnectWorldUpdateBegin(update_connection_);
+  update_connection_->~Connection();
 }
 
 void GazeboMultirotorBasePlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf) {
@@ -75,7 +75,7 @@ void GazeboMultirotorBasePlugin::Load(physics::ModelPtr _model, sdf::ElementPtr 
 // This gets called by the world update start event.
 void GazeboMultirotorBasePlugin::OnUpdate(const common::UpdateInfo& _info) {
   // Get the current simulation time.
-  common::Time now = world_->GetSimTime();
+  common::Time now = world_->SimTime();
   mav_msgs::msgs::MotorSpeed msg;
   MotorNumberToJointMap::iterator m;
   for (m = motor_joints_.begin(); m != motor_joints_.end(); ++m) {

--- a/src/gazebo_multirotor_base_plugin.cpp
+++ b/src/gazebo_multirotor_base_plugin.cpp
@@ -75,7 +75,11 @@ void GazeboMultirotorBasePlugin::Load(physics::ModelPtr _model, sdf::ElementPtr 
 // This gets called by the world update start event.
 void GazeboMultirotorBasePlugin::OnUpdate(const common::UpdateInfo& _info) {
   // Get the current simulation time.
+#if GAZEBO_MAJOR_VERSION >= 9
   common::Time now = world_->SimTime();
+#else
+  common::Time now = world_->GetSimTime();
+#endif
   mav_msgs::msgs::MotorSpeed msg;
   MotorNumberToJointMap::iterator m;
   for (m = motor_joints_.begin(); m != motor_joints_.end(); ++m) {

--- a/src/gazebo_uuv_plugin.cpp
+++ b/src/gazebo_uuv_plugin.cpp
@@ -177,12 +177,20 @@ void GazeboUUVPlugin::OnUpdate(const common::UpdateInfo& _info) {
   } */
 
   // Calculate and apply body Coriolis and Drag forces and torques
+#if GAZEBO_MAJOR_VERSION >= 9
   ignition::math::Vector3d linear_velocity = link_->RelativeLinearVel();
+#else
+  ignition::math::Vector3d linear_velocity = ignitionFromGazeboMath(link_->GetRelativeLinearVel());
+#endif
   double u = linear_velocity[0];
   double v = linear_velocity[1];
   double w = linear_velocity[2];
 
+#if GAZEBO_MAJOR_VERSION >= 9
   ignition::math::Vector3d angular_velocity = link_->RelativeAngularVel();
+#else
+  ignition::math::Vector3d angular_velocity = ignitionFromGazeboMath(link_->GetRelativeAngularVel());
+#endif
   double p = angular_velocity[0];
   double q = angular_velocity[1];
   double r = angular_velocity[2];

--- a/src/liftdrag_plugin/liftdrag_plugin.cpp
+++ b/src/liftdrag_plugin/liftdrag_plugin.cpp
@@ -32,9 +32,9 @@ GZ_REGISTER_MODEL_PLUGIN(LiftDragPlugin)
 /////////////////////////////////////////////////
 LiftDragPlugin::LiftDragPlugin() : cla(1.0), cda(0.01), cma(0.01), rho(1.2041)
 {
-  this->cp = math::Vector3(0, 0, 0);
-  this->forward = math::Vector3(1, 0, 0);
-  this->upward = math::Vector3(0, 0, 1);
+  this->cp = ignition::math::Vector3d(0, 0, 0);
+  this->forward = ignition::math::Vector3d(1, 0, 0);
+  this->upward = ignition::math::Vector3d(0, 0, 1);
   this->area = 1.0;
   this->alpha0 = 0.0;
   this->alpha = 0.0;
@@ -72,7 +72,7 @@ void LiftDragPlugin::Load(physics::ModelPtr _model,
   this->world = this->model->GetWorld();
   GZ_ASSERT(this->world, "LiftDragPlugin world pointer is NULL");
 
-  this->physics = this->world->GetPhysicsEngine();
+  this->physics = this->world->Physics();
   GZ_ASSERT(this->physics, "LiftDragPlugin physics pointer is NULL");
 
   GZ_ASSERT(_sdf, "LiftDragPlugin _sdf pointer is NULL");
@@ -105,16 +105,16 @@ void LiftDragPlugin::Load(physics::ModelPtr _model,
     this->cmaStall = _sdf->Get<double>("cma_stall");
 
   if (_sdf->HasElement("cp"))
-    this->cp = _sdf->Get<math::Vector3>("cp");
+    this->cp = _sdf->Get<ignition::math::Vector3d>("cp");
 
   // blade forward (-drag) direction in link frame
   if (_sdf->HasElement("forward"))
-    this->forward = _sdf->Get<math::Vector3>("forward");
+    this->forward = _sdf->Get<ignition::math::Vector3d>("forward");
   this->forward.Normalize();
 
   // blade upward (+lift) direction in link frame
   if (_sdf->HasElement("upward"))
-    this->upward = _sdf->Get<math::Vector3>("upward");
+    this->upward = _sdf->Get<ignition::math::Vector3d>("upward");
   this->upward.Normalize();
 
   if (_sdf->HasElement("area"))
@@ -162,8 +162,8 @@ void LiftDragPlugin::OnUpdate()
 {
   GZ_ASSERT(this->link, "Link was NULL");
   // get linear velocity at cp in inertial frame
-  math::Vector3 vel = this->link->GetWorldLinearVel(this->cp);
-  math::Vector3 velI = vel;
+  ignition::math::Vector3d vel = this->link->WorldLinearVel(this->cp);
+  ignition::math::Vector3d velI = vel;
   velI.Normalize();
 
   // smoothing
@@ -171,35 +171,35 @@ void LiftDragPlugin::OnUpdate()
   // this->velSmooth = e*vel + (1.0 - e)*velSmooth;
   // vel = this->velSmooth;
 
-  if (vel.GetLength() <= 0.01)
+  if (vel.Length() <= 0.01)
     return;
 
   // pose of body
-  math::Pose pose = this->link->GetWorldPose();
+  ignition::math::Pose3d pose = this->link->WorldPose();
 
   // rotate forward and upward vectors into inertial frame
-  math::Vector3 forwardI = pose.rot.RotateVector(this->forward);
+  ignition::math::Vector3d forwardI = pose.Rot().RotateVector(this->forward);
 
-  math::Vector3 upwardI;
+  ignition::math::Vector3d upwardI;
   if (this->radialSymmetry)
   {
     // use inflow velocity to determine upward direction
     // which is the component of inflow perpendicular to forward direction.
-    math::Vector3 tmp = forwardI.Cross(velI);
+    ignition::math::Vector3d tmp = forwardI.Cross(velI);
     upwardI = forwardI.Cross(tmp).Normalize();
   }
   else
   {
-    upwardI = pose.rot.RotateVector(this->upward);
+    upwardI = pose.Rot().RotateVector(this->upward);
   }
 
   // spanwiseI: a vector normal to lift-drag-plane described in inertial frame
-  math::Vector3 spanwiseI = forwardI.Cross(upwardI).Normalize();
+  ignition::math::Vector3d spanwiseI = forwardI.Cross(upwardI).Normalize();
 
   const double minRatio = -1.0;
   const double maxRatio = 1.0;
   // check sweep (angle between velI and lift-drag-plane)
-  double sinSweepAngle = math::clamp(
+  double sinSweepAngle = ignition::math::clamp(
       spanwiseI.Dot(velI), minRatio, maxRatio);
 
   // get cos from trig identity
@@ -220,25 +220,25 @@ void LiftDragPlugin::OnUpdate()
   //
   // so,
   // removing spanwise velocity from vel
-  math::Vector3 velInLDPlane = vel - vel.Dot(spanwiseI)*velI;
+  ignition::math::Vector3d velInLDPlane = vel - vel.Dot(spanwiseI)*velI;
 
   // get direction of drag
-  math::Vector3 dragDirection = -velInLDPlane;
+  ignition::math::Vector3d dragDirection = -velInLDPlane;
   dragDirection.Normalize();
 
   // get direction of lift
-  math::Vector3 liftI = spanwiseI.Cross(velInLDPlane);
+  ignition::math::Vector3d liftI = spanwiseI.Cross(velInLDPlane);
   liftI.Normalize();
 
   // get direction of moment
-  math::Vector3 momentDirection = spanwiseI;
+  ignition::math::Vector3d momentDirection = spanwiseI;
 
   // compute angle between upwardI and liftI
   // in general, given vectors a and b:
   //   cos(theta) = a.Dot(b)/(a.Length()*b.Lenghth())
   // given upwardI and liftI are both unit vectors, we can drop the denominator
   //   cos(theta) = a.Dot(b)
-  double cosAlpha = math::clamp(liftI.Dot(upwardI), minRatio, maxRatio);
+  double cosAlpha = ignition::math::clamp(liftI.Dot(upwardI), minRatio, maxRatio);
 
   // Is alpha positive or negative? Test:
   // forwardI points toward zero alpha
@@ -255,7 +255,7 @@ void LiftDragPlugin::OnUpdate()
                                   : this->alpha + M_PI;
 
   // compute dynamic pressure
-  double speedInLDPlane = velInLDPlane.GetLength();
+  double speedInLDPlane = velInLDPlane.Length();
   double q = 0.5 * this->rho * speedInLDPlane * speedInLDPlane;
 
   // compute cl at cp, check for stall, correct for sweep
@@ -282,13 +282,13 @@ void LiftDragPlugin::OnUpdate()
   // modify cl per control joint value
   if (this->controlJoint)
   {
-    double controlAngle = this->controlJoint->GetAngle(0).Radian();
+    double controlAngle = this->controlJoint->Position(0);
     cl = cl + this->controlJointRadToCL * controlAngle;
     /// \TODO: also change cm and cd
   }
 
   // compute lift force at cp
-  math::Vector3 lift = cl * q * this->area * liftI;
+  ignition::math::Vector3d lift = cl * q * this->area * liftI;
 
   // compute cd at cp, check for stall, correct for sweep
   double cd;
@@ -311,7 +311,7 @@ void LiftDragPlugin::OnUpdate()
   cd = fabs(cd);
 
   // drag at cp
-  math::Vector3 drag = cd * q * this->area * dragDirection;
+  ignition::math::Vector3d drag = cd * q * this->area * dragDirection;
 
   // compute cm at cp, check for stall, correct for sweep
   double cm;
@@ -339,26 +339,26 @@ void LiftDragPlugin::OnUpdate()
   cm = 0.0;
 
   // compute moment (torque) at cp
-  math::Vector3 moment = cm * q * this->area * momentDirection;
+  ignition::math::Vector3d moment = cm * q * this->area * momentDirection;
 
   // moment arm from cg to cp in inertial plane
-  math::Vector3 momentArm = pose.rot.RotateVector(
-    this->cp - this->link->GetInertial()->GetCoG());
-  // gzerr << this->cp << " : " << this->link->GetInertial()->GetCoG() << "\n";
+  ignition::math::Vector3d momentArm = pose.Rot().RotateVector(
+    this->cp - this->link->GetInertial()->CoG());
+  // gzerr << this->cp << " : " << this->link->GetInertial()->CoG() << "\n";
 
   // force and torque about cg in inertial frame
-  math::Vector3 force = lift + drag;
+  ignition::math::Vector3d force = lift + drag;
   // + moment.Cross(momentArm);
 
-  math::Vector3 torque = moment;
+  ignition::math::Vector3d torque = moment;
   // - lift.Cross(momentArm) - drag.Cross(momentArm);
 
   // debug
   //
   // if ((this->link->GetName() == "wing_1" ||
   //      this->link->GetName() == "wing_2") &&
-  //     (vel.GetLength() > 50.0 &&
-  //      vel.GetLength() < 50.0))
+  //     (vel.Length() > 50.0 &&
+  //      vel.Length() < 50.0))
   if (0)
   {
     gzdbg << "=============================\n";
@@ -366,9 +366,9 @@ void LiftDragPlugin::OnUpdate()
     gzdbg << "Link: [" << this->link->GetName()
           << "] pose: [" << pose
           << "] dynamic pressure: [" << q << "]\n";
-    gzdbg << "spd: [" << vel.GetLength()
+    gzdbg << "spd: [" << vel.Length()
           << "] vel: [" << vel << "]\n";
-    gzdbg << "LD plane spd: [" << velInLDPlane.GetLength()
+    gzdbg << "LD plane spd: [" << velInLDPlane.Length()
           << "] vel : [" << velInLDPlane << "]\n";
     gzdbg << "forward (inertial): " << forwardI << "\n";
     gzdbg << "upward (inertial): " << upwardI << "\n";


### PR DESCRIPTION
Switch from Gazebo math to ignition math

This makes the plugins compatible with Gazebo 9.

These changes were already done by @william-peale before but never merged.
Instead of fixing the conflicts, I decided to re-apply the changes again cleanly with this commit.

Replaces #109.

Needs testing with Gazebo 7 and 8.