### PR TITLE
add missing dependencies to be able to compile the package after getting deps via rosdep

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -39,12 +39,17 @@
   <!-- <test_depend>gtest</test_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
   <buildtool_depend>gazebo_ros</buildtool_depend>
+  <build_depend>eigen</build_depend>
   <build_depend>gazebo_ros</build_depend>
+  <build_depend>mavlink</build_depend>
+  <build_depend>protobuf-dev</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>python-rospkg</build_depend>
   <build_depend>python-jinja2</build_depend>
+  <run_depend>eigen</run_depend>
   <run_depend>gazebo_ros</run_depend>
+  <run_depend>mavlink</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>std_msgs</run_depend>
 


### PR DESCRIPTION
I needed this to be able to compile the package with catkin_make.

protobuf compiler is required to generate the protobuf messages [here](https://github.com/PX4/sitl_gazebo/blob/1fee531aa18ec4f8f3e621f0ac726604ffbadf2c/CMakeLists.txt#L259)
The mavlink headers are necessary to compile the package (Side note: I added mavlink and this is the only "required" dependency while mavros and friends are necessary only when building with ROS support).
Eigen is `find_package`'d [here](https://github.com/PX4/sitl_gazebo/blob/1fee531aa18ec4f8f3e621f0ac726604ffbadf2c/CMakeLists.txt#L106-L118)

Steps I followed when faced the issue:
1. mkdir -p catkin_ws/src && cd catkin_ws/src
1. git clone --recursive https://github.com/PX4/sitl_gazebo
1. cd ..
1. apt update
1. rosdep install --from-paths src --ignore-src --rosdistro kinetic -y
1. mkdir src/sitl_gazebo/Build && cd src/sitl_gazebo/Build
1. cmake ..
1. make
