### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Clone the gazebo plugins repository to your computer. IMPORTANT: If you do not c
 ```bash
 mkdir -p ~/src
 cd src
-git clone https://github.com/PX4/sitl_gazebo.git
+git clone --recursive https://github.com/PX4/sitl_gazebo.git
 ```
 
 Create a build folder in the top level of your repository:
@@ -73,7 +73,6 @@ Navigate into the build directory and invoke CMake from it:
 
 ```bash
 cd ~/src/sitl_gazebo
-git submodule update --init --recursive
 cd Build
 cmake ..
 ```

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Clone the gazebo plugins repository to your computer. IMPORTANT: If you do not c
 ```bash
 mkdir -p ~/src
 cd src
-git clone https://github.com/Dronecode/sitl_gazebo.git
+git clone https://github.com/PX4/sitl_gazebo.git
 ```
 
 Create a build folder in the top level of your repository:
@@ -73,6 +73,7 @@ Navigate into the build directory and invoke CMake from it:
 
 ```bash
 cd ~/src/sitl_gazebo
+git submodule update --init --recursive
 cd Build
 cmake ..
 ```


### PR DESCRIPTION
Change the repository link. The old link pointed to the Dronecode repository. 
Sitl_gazebo depends on OpticalFlow submodule. One should call submodule update before calling cmake.