### PR TITLE
Separate iris_opt_flow and iris_vision models

### DIFF
--- a/models/iris_opt_flow/iris_opt_flow.sdf
+++ b/models/iris_opt_flow/iris_opt_flow.sdf
@@ -1,13 +1,5 @@
 <sdf version='1.5'>
   <model name='iris_opt_flow'>
-    <plugin name="vision_plugin" filename="libgazebo_vision_plugin.so">
-        <robotNamespace></robotNamespace>
-        <pubRate>30</pubRate>
-        <randomWalk>1.0</randomWalk>
-        <noiseDensity>5e-04</noiseDensity>
-        <corellationTime>60.0</corellationTime>
-    </plugin>
-
     <include>
       <uri>model://iris</uri>
     </include>

--- a/models/iris_vision/iris_vision.sdf
+++ b/models/iris_vision/iris_vision.sdf
@@ -1,0 +1,18 @@
+<sdf version='1.5'>
+  <model name='iris_vision'>
+    <plugin name="vision_plugin" filename="libgazebo_vision_plugin.so">
+        <robotNamespace></robotNamespace>
+        <pubRate>30</pubRate>
+        <randomWalk>1.0</randomWalk>
+        <noiseDensity>5e-04</noiseDensity>
+        <corellationTime>60.0</corellationTime>
+    </plugin>
+
+    <include>
+      <uri>model://iris</uri>
+    </include>
+
+  </model>
+</sdf>
+
+<!-- vim: set et ft=xml fenc=utf-8 ff=unix sts=0 sw=2 ts=2 : -->

--- a/models/iris_vision/model.config
+++ b/models/iris_vision/model.config
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<model>
+  <name>3DR Iris with external vision pose estimation</name>
+  <version>1.0</version>
+  <sdf version='1.4'>iris_vision.sdf</sdf>
+
+  <author>
+   <name>Christoph Tobler</name>
+   <email>toblech@ethz.ch</email>
+  </author>
+
+  <description>
+    This is a model of the 3DR Iris Quadrotor with external vision pose estimation. The original model has been created by
+    Thomas Gubler and is maintained by Lorenz Meier. The external vision pose estimation has been created by Christoph Tobler
+  </description>
+</model>

--- a/models/px4flow/px4flow.sdf.jinja
+++ b/models/px4flow/px4flow.sdf.jinja
@@ -81,7 +81,7 @@
             <stddev>0.001</stddev>
           </noise>
         </camera>
-        <plugin name="opticalflow_plugin" filename="libgazebo_opticalFlow_plugin.so">
+        <plugin name="opticalflow_plugin" filename="libgazebo_opticalflow_plugin.so">
             <robotNamespace></robotNamespace>
             <outputRate>20</outputRate>
         </plugin>

--- a/worlds/iris_vision.world
+++ b/worlds/iris_vision.world
@@ -1,0 +1,49 @@
+<?xml version="1.0" ?>
+<sdf version="1.5">
+  <world name="default">
+    <!-- A global light source -->
+    <include>
+      <uri>model://sun</uri>
+    </include>
+    <!-- A ground plane -->
+    <include>
+      <uri>model://iris_vision</uri>
+      <pose>1.01 0.98 0.83 0 0 1.14</pose>
+    </include>
+    <include>
+      <uri>model://uneven_ground</uri>
+    </include>
+    <physics name='default_physics' default='0' type='ode'>
+      <gravity>0 0 -9.8066</gravity>
+      <ode>
+        <solver>
+          <type>quick</type>
+          <iters>10</iters>
+          <sor>1.3</sor>
+          <use_dynamic_moi_rescaling>0</use_dynamic_moi_rescaling>
+        </solver>
+        <constraints>
+          <cfm>0</cfm>
+          <erp>0.2</erp>
+          <contact_max_correcting_vel>100</contact_max_correcting_vel>
+          <contact_surface_layer>0.001</contact_surface_layer>
+        </constraints>
+      </ode>
+      <max_step_size>0.002</max_step_size>
+      <real_time_factor>1</real_time_factor>
+      <real_time_update_rate>500</real_time_update_rate>
+      <magnetic_field>6.0e-6 2.3e-5 -4.2e-5</magnetic_field>
+    </physics>
+    <gui fullscreen='0'>
+      <camera name='user_camera'>
+        <pose>-10 0 6 0 0.3 0</pose>
+        <!-- <view_controller>orbit</view_controller>
+        <projection_type>perspective</projection_type>
+        <track_visual>
+          <name>iris_opt_flow</name>
+          <use_model_frame>1</use_model_frame>
+        </track_visual> -->
+      </camera>
+    </gui>
+  </world>
+</sdf>


### PR DESCRIPTION
This pr separates two models: iris_vision that uses vision_plugin and iris_opt_flow that now is using optical_flow plugin instead of the previously used vision one.