### PR TITLE
CMakeLists.txt: remove clash between std and sensor_msgs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -243,7 +243,6 @@ set(nav_msgs msgs/Odometry.proto)
 #set(physics_msgs msgs/Wind.proto)
 set(std_msgs msgs/Int32.proto)
 set(sensor_msgs
-  msgs/Int32.proto
   msgs/Imu.proto
   msgs/IRLock.proto
   msgs/Float.proto


### PR DESCRIPTION
Fixes https://github.com/PX4/Firmware/issues/9632. Though, if the idea is to have a common custom namespace, that can be done as well.