### PR TITLE
Fix ros motor failure plugin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,9 +52,6 @@ set( OpticalFlow_LIBS "OpticalFlow" )
 
 # for ROS subscribers and publishers
 if (BUILD_ROS_INTERFACE)
-  find_package(mavros REQUIRED)
-  find_package(mavros_msgs REQUIRED)
-  find_package(mav_msgs REQUIRED)
   find_package(geometry_msgs REQUIRED)
   find_package(roscpp REQUIRED)
   find_package(sensor_msgs REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -320,12 +320,6 @@ if (BUILD_ROS_INTERFACE)
     ${sensor_msgs_INCLUDE_DIRS}
   )
 
-  add_dependencies(gazebo_motor_failure_plugin
-    ${catkin_EXPORTED_TARGETS}
-    ${mavros_EXPORTED_TARGETS}
-    ${mavros_msgs_EXPORTED_TARGETS}
-  )
-
   target_link_libraries(gazebo_motor_failure_plugin
     ${catkin_LIBRARIES}
     ${mavros_LIBRARIES}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -316,11 +316,9 @@ if (BUILD_ROS_INTERFACE)
 
   include_directories(
     include
-    ${mavros_msgs_INCLUDE_DIRS}
     ${geometry_msgs_INCLUDE_DIRS}
     ${sensor_msgs_INCLUDE_DIRS}
-    ${mav_msgs_INCLUDE_DIRS}
-    )
+  )
   add_executable(gazebo_motor_failure_node
     src/gazebo_motor_failure_plugin.cpp
   )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -322,11 +322,9 @@ if (BUILD_ROS_INTERFACE)
 
   target_link_libraries(gazebo_motor_failure_plugin
     ${catkin_LIBRARIES}
-    ${mavros_LIBRARIES}
     ${roscpp_LIBRARIES}
     ${GAZEBO_libraries}
   )
-  message(STATUS "adding gazebo_motor_failure_plugin to build")
 endif()
 
 if (GSTREAMER_FOUND)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -319,10 +319,6 @@ if (BUILD_ROS_INTERFACE)
     ${geometry_msgs_INCLUDE_DIRS}
     ${sensor_msgs_INCLUDE_DIRS}
   )
-  add_executable(gazebo_motor_failure_node
-    src/gazebo_motor_failure_plugin.cpp
-  )
-  target_link_libraries(gazebo_motor_failure_node ${catkin_LIBRARIES} ${roscpp_LIBRARIES} ${GAZEBO_libraries})
 
   add_dependencies(gazebo_motor_failure_plugin
     ${catkin_EXPORTED_TARGETS}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -324,9 +324,10 @@ if (BUILD_ROS_INTERFACE)
     ${sensor_msgs_INCLUDE_DIRS}
     ${mav_msgs_INCLUDE_DIRS}
     )
-  add_executable(gazebo_motor_failure_plugin
+  add_executable(gazebo_motor_failure_node
     src/gazebo_motor_failure_plugin.cpp
   )
+  target_link_libraries(gazebo_motor_failure_node ${catkin_LIBRARIES} ${roscpp_LIBRARIES} ${GAZEBO_libraries})
 
   add_dependencies(gazebo_motor_failure_plugin
     ${catkin_EXPORTED_TARGETS}
@@ -337,6 +338,8 @@ if (BUILD_ROS_INTERFACE)
   target_link_libraries(gazebo_motor_failure_plugin
     ${catkin_LIBRARIES}
     ${mavros_LIBRARIES}
+    ${roscpp_LIBRARIES}
+    ${GAZEBO_libraries}
   )
   message(STATUS "adding gazebo_motor_failure_plugin to build")
 endif()

--- a/include/gazebo_motor_failure_plugin.h
+++ b/include/gazebo_motor_failure_plugin.h
@@ -67,10 +67,13 @@ class GazeboMotorFailure : public ModelPlugin {
 
  private:
 
+  event::ConnectionPtr updateConnection_;
+
   std::string ROS_motor_num_sub_topic_;
   std::string motor_failure_num_pub_topic_;
   std::string namespace_;
 
+  transport::NodePtr node_handle_;
   transport::PublisherPtr motor_failure_pub_; /*!< Publish the motor_Failure_num to gazebo topic motor_failure_num_pub_topic_ */
 
   boost::thread callback_queue_thread_;
@@ -84,6 +87,7 @@ class GazeboMotorFailure : public ModelPlugin {
   }
 
   msgs::Int motor_failure_msg_;
+  int32_t motor_Failure_Number_;
 
   // ROS communication
   std::unique_ptr<ros::NodeHandle> rosNode;

--- a/include/gazebo_motor_failure_plugin.h
+++ b/include/gazebo_motor_failure_plugin.h
@@ -41,17 +41,9 @@ static const std::string kDefaultMotorFailureNumPubTopic = "/gazebo/motor_failur
 
 class GazeboMotorFailure : public ModelPlugin {
  public:
+  GazeboMotorFailure();
 
-  void motorFailNumCallBack(const std_msgs::Int32ConstPtr& _msg) {
-    this->motor_Failure_Number_ = _msg->data;
-    //std::cout << "[gazebo_motor_failure_plugin]: Subscribe to " << ROS_motor_num_sub_topic_ << std::endl;
-  }
-
-  GazeboMotorFailure()
-      : ModelPlugin(),
-	ROS_motor_num_sub_topic_(kDefaultROSMotorNumSubTopic),
-	motor_failure_num_pub_topic_(kDefaultMotorFailureNumPubTopic) {
-  }
+  void motorFailNumCallBack(const std_msgs::Int32ConstPtr& _msg);
 
   virtual ~GazeboMotorFailure();
   virtual void Publish_num();
@@ -61,11 +53,13 @@ class GazeboMotorFailure : public ModelPlugin {
   /// \brief Create subscription to ROS topic that triggers the motor failure
   /// \details Inits a rosnode in case there's not one and subscribes to ROS_motor_num_sub_topic_
   virtual void Load(physics::ModelPtr _model, sdf::ElementPtr _sdf);
-	
+
   /// \brief Updates and publishes the motor_Failure_Number_ to motor_failure_num_pub_topic_
   virtual void OnUpdate(const common::UpdateInfo & /*_info*/);
 
  private:
+
+  void QueueThread();
 
   event::ConnectionPtr updateConnection_;
 
@@ -77,14 +71,6 @@ class GazeboMotorFailure : public ModelPlugin {
   transport::PublisherPtr motor_failure_pub_; /*!< Publish the motor_Failure_num to gazebo topic motor_failure_num_pub_topic_ */
 
   boost::thread callback_queue_thread_;
-  void QueueThread()
-  {
-    static const double timeout = 0.01;
-    while (this->rosNode->ok())
-    {
-      this->rosQueue.callAvailable(ros::WallDuration(timeout));
-    }
-  }
 
   msgs::Int motor_failure_msg_;
   int32_t motor_Failure_Number_;


### PR DESCRIPTION
1. Original master doesn't build if you enable BUILD_ROS_INTERFACE with error:

> CMake Error at CMakeLists.txt:328 (add_executable):
  add_executable cannot create target "gazebo_motor_failure_plugin" because
  another target with the same name already exists.  The existing target is a
  shared library created in source directory
  "/home/elia/src/Firmware/Tools/sitl_gazebo".  See documentation for policy
  CMP0002 for more details.

2. If BUILD_ROS_INTERFACE is enabed, no plugins are built.
3. Some class members were not defined.
