### PR TITLE
iris worlds: remove uneven_ground as a default world model

### DIFF
--- a/worlds/iris.world
+++ b/worlds/iris.world
@@ -5,12 +5,17 @@
     <include>
       <uri>model://sun</uri>
     </include>
+    <!-- A ground plane -->
+    <include>
+      <uri>model://ground_plane</uri>
+    </include>
+    <!-- An asphalt plane -->
+    <include>
+      <uri>model://asphalt_plane</uri>
+    </include>
     <include>
       <uri>model://iris</uri>
       <pose>1.01 0.98 0.83 0 0 1.14</pose>
-    </include>
-    <include>
-      <uri>model://uneven_ground</uri>
     </include>
     <physics name='default_physics' default='0' type='ode'>
       <gravity>0 0 -9.8066</gravity>

--- a/worlds/iris_opt_flow.world
+++ b/worlds/iris_opt_flow.world
@@ -7,11 +7,15 @@
     </include>
     <!-- A ground plane -->
     <include>
-      <uri>model://iris_opt_flow</uri>
-      <pose>1.01 0.98 0.83 0 0 1.14</pose>
+      <uri>model://ground_plane</uri>
     </include>
+    <!-- An asphalt plane -->
     <include>
       <uri>model://asphalt_plane</uri>
+    </include>
+    <include>
+      <uri>model://iris_opt_flow</uri>
+      <pose>1.01 0.98 0.83 0 0 1.14</pose>
     </include>
     <physics name='default_physics' default='0' type='ode'>
       <gravity>0 0 -9.8066</gravity>

--- a/worlds/iris_rplidar.world
+++ b/worlds/iris_rplidar.world
@@ -9,11 +9,12 @@
     <include>
       <uri>model://ground_plane</uri>
     </include>
+    <!-- An asphalt plane -->
     <include>
-      <uri>model://iris_rplidar</uri>
+      <uri>model://asphalt_plane</uri>
     </include>
     <include>
-      <uri>model://uneven_ground</uri>
+      <uri>model://iris_rplidar</uri>
     </include>
     <physics name='default_physics' default='0' type='ode'>
       <gravity>0 0 -9.8066</gravity>

--- a/worlds/iris_vision.world
+++ b/worlds/iris_vision.world
@@ -7,11 +7,15 @@
     </include>
     <!-- A ground plane -->
     <include>
-      <uri>model://iris_vision</uri>
-      <pose>1.01 0.98 0.83 0 0 1.14</pose>
+      <uri>model://ground_plane</uri>
+    </include>
+    <!-- An asphalt plane -->
+    <include>
+      <uri>model://asphalt_plane</uri>
     </include>
     <include>
-      <uri>model://uneven_ground</uri>
+      <uri>model://iris_vision</uri>
+      <pose>1.01 0.98 0.83 0 0 1.14</pose>
     </include>
     <physics name='default_physics' default='0' type='ode'>
       <gravity>0 0 -9.8066</gravity>


### PR DESCRIPTION
For SITL testing, currently, uneven ground seems to be too much for normal systems and oveloards the system processor and memory. The uneven ground should be kept as optional, and not defaulted.