### PR TITLE
pr-fix rpy sign init

### DIFF
--- a/include/gazebo_gimbal_controller_plugin.hh
+++ b/include/gazebo_gimbal_controller_plugin.hh
@@ -131,6 +131,10 @@ namespace gazebo
 
     private: std::string status;
 
+    private: double rDir;
+    private: double pDir;
+    private: double yDir;
+
     private: double pitchCommand;
     private: double yawCommand;
     private: double rollCommand;

--- a/include/gazebo_gimbal_controller_plugin.hh
+++ b/include/gazebo_gimbal_controller_plugin.hh
@@ -61,6 +61,11 @@ namespace gazebo
   static double kPIDYawCmdMax = 1.0;
   static double kPIDYawCmdMin = -1.0;
 
+  // Default rotation directions
+  static double kRollDir = -1.0;
+  static double kPitchDir = -1.0;
+  static double kYawDir = 1.0;
+
   typedef const boost::shared_ptr<const sensor_msgs::msgs::Imu> ImuPtr;
 
   class GAZEBO_VISIBLE GimbalControllerPlugin : public ModelPlugin

--- a/src/gazebo_gimbal_controller_plugin.cpp
+++ b/src/gazebo_gimbal_controller_plugin.cpp
@@ -115,7 +115,11 @@ void GimbalControllerPlugin::Load(physics::ModelPtr _model,
       if(sdfElem->HasElement("axis"))
       {
         // Rotation is found
+#if GAZEBO_MAJOR_VERSION >= 9
+        yDir = this->yawJoint->LocalAxis(0)[2];
+#else
         yDir = this->yawJoint->GetLocalAxis(0)[2];
+#endif
       }
       else
       {
@@ -164,7 +168,11 @@ void GimbalControllerPlugin::Load(physics::ModelPtr _model,
       if(sdfElem->HasElement("axis"))
       {
         // Rotation is found
+#if GAZEBO_MAJOR_VERSION >= 9
+        rDir = this->rollJoint->LocalAxis(0)[0];
+#else
         rDir = this->rollJoint->GetLocalAxis(0)[0];
+#endif
       }
       else
       {
@@ -213,7 +221,11 @@ void GimbalControllerPlugin::Load(physics::ModelPtr _model,
       if(sdfElem->HasElement("axis"))
       {
         // Rotation is found
+#if GAZEBO_MAJOR_VERSION >= 9
+        pDir = this->pitchJoint->LocalAxis(0)[1];
+#else
         pDir = this->pitchJoint->GetLocalAxis(0)[1];
+#endif
       }
       else
       {


### PR DESCRIPTION
This pr removes hardcoded rotation signs for gimbal and makes the latter depended only from `sdf` file.