### PR TITLE
Feature: make sending simulated vision estimation data optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,9 +20,11 @@ include(GNUInstallDirs)
 list(APPEND CMAKE_MODULE_PATH /usr/local/share/cmake/Modules)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 
-option(BUILD_GSTREAMER_PLUGIN "enable gstreamer plugin" "OFF")
+option(BUILD_GSTREAMER_PLUGIN "enable gstreamer plugin" OFF)
+option(BUILD_ROS_INTERFACE "Enable building ROS dependent plugins" OFF)
 
-option(BUILD_ROS_INTERFACE "Enable building ROS dependent plugins" "OFF")
+option(SEND_VISION_ESTIMATION_DATA "Send Mavlink VISION_POSITION_ESTIMATE msgs" OFF)
+option(SEND_ODOMETRY_DATA "Send Mavlink ODOMETRY msgs" OFF)
 
 ## System dependencies are found with CMake's conventions
 find_package(Boost 1.58 REQUIRED COMPONENTS system thread timer)
@@ -184,11 +186,24 @@ set(enable_camera "false")
 set(enable_wind "false")
 set(rotors_description_dir "${CMAKE_CURRENT_SOURCE_DIR}/models/rotors_description")
 set(scripts_dir "${CMAKE_CURRENT_SOURCE_DIR}/scripts")
+# set the vision estimation to be sent if set by the CMake option SEND_VISION_ESTIMATION_DATA
+set(send_vision_estimation "false")
+if (SEND_VISION_ESTIMATION_DATA)
+  set(send_vision_estimation "true")
+endif()
+
+# if SEND_ODOMETRY_DATA option is set, then full odometry data is sent instead of
+# only the visual pose estimate
+set(send_odometry "false")
+if (SEND_ODOMETRY_DATA)
+  set(send_odometry "true")
+  set(send_vision_estimation "false")
+endif()
 
 add_custom_command(OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/models/iris/iris.sdf
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   COMMAND rm -f ${CMAKE_CURRENT_SOURCE_DIR}/models/iris/iris.sdf
-  COMMAND ${PYTHON_EXECUTABLE} ${scripts_dir}/xacro.py -o  ${rotors_description_dir}/urdf/iris_base.urdf  ${rotors_description_dir}/urdf/iris_base.xacro enable_mavlink_interface:=${enable_mavlink_interface} enable_ground_truth:=${enable_ground_truth} enable_wind:=${enable_wind} enable_logging:=${enable_logging} rotors_description_dir:=${rotors_description_dir}
+  COMMAND ${PYTHON_EXECUTABLE} ${scripts_dir}/xacro.py -o  ${rotors_description_dir}/urdf/iris_base.urdf  ${rotors_description_dir}/urdf/iris_base.xacro enable_mavlink_interface:=${enable_mavlink_interface} enable_ground_truth:=${enable_ground_truth} enable_wind:=${enable_wind} enable_logging:=${enable_logging} rotors_description_dir:=${rotors_description_dir} send_vision_estimation:=${send_vision_estimation} send_odometry:=${send_odometry}
   COMMAND gz sdf -p  ${rotors_description_dir}/urdf/iris_base.urdf >> ${CMAKE_CURRENT_SOURCE_DIR}/models/iris/iris.sdf
   COMMAND rm -f ${rotors_description_dir}/urdf/iris_base.urdf
   DEPENDS ${rotors_description_dir}/urdf/iris.xacro

--- a/include/gazebo_mavlink_interface.h
+++ b/include/gazebo_mavlink_interface.h
@@ -127,7 +127,8 @@ public:
     use_left_elevon_pid_(false),
     use_right_elevon_pid_(false),
     vehicle_is_tailsitter_(false),
-    send_odometry_(true),
+    send_vision_estimation_(false),
+    send_odometry_(false),
     imu_sub_topic_(kDefaultImuTopic),
     opticalFlow_sub_topic_(kDefaultOpticalFlowTopic),
     lidar_sub_topic_(kDefaultLidarTopic),
@@ -212,6 +213,7 @@ private:
 
   bool vehicle_is_tailsitter_;
 
+  bool send_vision_estimation_;
   bool send_odometry_;
 
   std::vector<physics::JointPtr> joints_;

--- a/models/rotors_description/urdf/component_snippets.xacro
+++ b/models/rotors_description/urdf/component_snippets.xacro
@@ -135,7 +135,7 @@
   </xacro:macro>
 
   <!-- Macro to add the mavlink interface. -->
-  <xacro:macro name="mavlink_interface_macro" params="namespace imu_sub_topic gps_sub_topic mavlink_addr mavlink_udp_port serial_enabled serial_device baudrate qgc_addr qgc_udp_port hil_mode hil_state_level vehicle_is_tailsitter send_odometry">
+  <xacro:macro name="mavlink_interface_macro" params="namespace imu_sub_topic gps_sub_topic mavlink_addr mavlink_udp_port serial_enabled serial_device baudrate qgc_addr qgc_udp_port hil_mode hil_state_level vehicle_is_tailsitter send_vision_estimation send_odometry">
     <gazebo>
       <plugin name="mavlink_interface" filename="libgazebo_mavlink_interface.so">
         <robotNamespace>${namespace}</robotNamespace>
@@ -151,6 +151,7 @@
         <hil_mode>$(arg hil_mode)</hil_mode>
         <hil_state_level>$(arg hil_state_level)</hil_state_level>
         <vehicle_is_tailsitter>$(arg vehicle_is_tailsitter)</vehicle_is_tailsitter>
+        <send_vision_estimation>$(arg send_vision_estimation)</send_vision_estimation>
         <send_odometry>$(arg send_odometry)</send_odometry>
         <motorSpeedCommandPubTopic>/gazebo/command/motor_speed</motorSpeedCommandPubTopic>
         <control_channels>

--- a/models/rotors_description/urdf/iris_base.xacro
+++ b/models/rotors_description/urdf/iris_base.xacro
@@ -14,6 +14,7 @@
   <xacro:arg name='qgc_udp_port' default='14550' />
   <xacro:arg name='hil_mode' default='false' />
   <xacro:arg name='hil_state_level' default='false' />
+  <xacro:arg name='send_vision_estimation' default='false' />
   <xacro:arg name='send_odometry' default='false' />
   <xacro:arg name='vehicle_is_tailsitter' default='false' />
   <xacro:arg name='visual_material' default='DarkGrey' />
@@ -67,6 +68,7 @@
     hil_mode="$(arg hil_mode)"
     hil_state_level="$(arg hil_state_level)"
     vehicle_is_tailsitter="$(arg vehicle_is_tailsitter)"
+    send_vision_estimation="$(arg send_vision_estimation)"
     send_odometry="$(arg send_odometry)"
     >
   </xacro:mavlink_interface_macro>

--- a/src/gazebo_mavlink_interface.cpp
+++ b/src/gazebo_mavlink_interface.cpp
@@ -309,6 +309,11 @@ void GazeboMavlinkInterface::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf
     vehicle_is_tailsitter_ = _sdf->GetElement("vehicle_is_tailsitter")->Get<bool>();
   }
 
+  if(_sdf->HasElement("send_vision_estimation"))
+  {
+    send_vision_estimation_ = _sdf->GetElement("send_vision_estimation")->Get<bool>();
+  }
+
   if(_sdf->HasElement("send_odometry"))
   {
     send_odometry_ = _sdf->GetElement("send_odometry")->Get<bool>();
@@ -846,7 +851,7 @@ void GazeboMavlinkInterface::VisionCallback(OdomPtr& odom_message) {
     mavlink_msg_odometry_encode_chan(1, 200, MAVLINK_COMM_0, &msg, &odom);
     send_mavlink_message(&msg);
   }
-  else {
+  else if (send_vision_estimation_) {
     // send VISION_POSITION_ESTIMATE Mavlink msg
     mavlink_vision_position_estimate_t vision;
 


### PR DESCRIPTION
By default, we were sending `VISION_POSITION_ESTIMATE` msgs from the simulated environment. This represented a problem to people that want to test their VIO pipelines against simulated camera data and send that same data through MAVROS (for example) to the FCU. This PR addresses that same matter, by allowing setting the visual data to be sent or not depending on a Cmake option - it's like this rather than directly changing the parameter on an SDF given that the `iris.sdf` is generated by xacro on build time.