### PR TITLE
Feature: add ROS NavSatFix and PoseWithCovarianceStamped topic publishers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,7 +78,7 @@ install:
     brew install px4-dev;
     brew tap osrf/simulation;
     brew install opencv ${GAZEBO_VERSION};
-    brew link --overwrite numpy;
+    brew link --overwrite numpy gcc;
     brew cask reinstall xquartz java;
     sudo -H pip2 install --upgrade pip setuptools;
     sudo -H pip2 install rospkg pyserial empy toml numpy pandas jinja2;

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -325,10 +325,11 @@ target_link_libraries(gazebo_opticalflow_plugin ${OpticalFlow_LIBS})
 # If BUILD_ROS_INTERFACE set to ON, build plugins that have ROS dependencies
 # Current plugins that can be used with ROS interface: gazebo_motor_failure_plugin
 if (BUILD_ROS_INTERFACE)
+  # gazebo_motor_failure_plugin only builds with a ROS interface
   add_library(gazebo_motor_failure_plugin SHARED src/gazebo_motor_failure_plugin.cpp)
   target_link_libraries(gazebo_motor_failure_plugin ${GAZEBO_libraries} ${roscpp_LIBRARIES})
   list(APPEND plugins gazebo_motor_failure_plugin)
-  message(STATUS "adding gazebo_motor_failure_plugin to build")
+  message(STATUS "ROS:\tAdding gazebo_motor_failure_plugin to build...")
 
   include_directories(
     include
@@ -341,6 +342,17 @@ if (BUILD_ROS_INTERFACE)
     ${roscpp_LIBRARIES}
     ${GAZEBO_libraries}
   )
+
+  # gazebo_gps_plugin can be built with ROS interface
+  message(STATUS "\tBuilding gazebo_gps_plugin with ROS interface...")
+  target_link_libraries(gazebo_gps_plugin
+    ${catkin_LIBRARIES}
+    ${roscpp_LIBRARIES}
+  )
+  target_compile_definitions(gazebo_gps_plugin PUBLIC BUILD_ROS_INTERFACE=TRUE)
+else()
+  target_compile_definitions(gazebo_gps_plugin PUBLIC BUILD_ROS_INTERFACE=FALSE)
+  message(STATUS "Building gazebo_gps_plugin without ROS interface...")
 endif()
 
 if (GSTREAMER_FOUND)

--- a/include/gazebo_gps_plugin.h
+++ b/include/gazebo_gps_plugin.h
@@ -92,7 +92,7 @@ private:
   /// \brief The default GPS fix data topic
   static constexpr auto kDefaultRosGPSFixPubTopic = "/gps/fix";
   /// \brief A mutex to lock access to fields are used in message callbacks
-  private: boost::mutex lock_;
+  boost::mutex lock_;
   /// \brief Prevents blocking
   PubMultiQueue pmq_;
   /// \brief Fix pub custom queue

--- a/include/gazebo_gps_plugin.h
+++ b/include/gazebo_gps_plugin.h
@@ -183,9 +183,9 @@ private:
   double epv_;     // meters
   std::default_random_engine rand_;
   std::normal_distribution<float> randn_;
-  static constexpr double _gps_corellation_time = 60.0;    // s
-  static constexpr double _gps_xy_random_walk = 0.02;      // (m/s) / sqrt(hz)
-  static constexpr double _gps_z_random_walk = 0.04;       // (m/s) / sqrt(hz)
+  static constexpr double _gps_corellation_time = 30.0;    // s
+  static constexpr double _gps_xy_random_walk = 0.025;     // (m/s) / sqrt(hz)
+  static constexpr double _gps_z_random_walk = 0.05;       // (m/s) / sqrt(hz)
   static constexpr double _gps_xy_noise_density = 2e-4;    // (m) / sqrt(hz)
   static constexpr double _gps_z_noise_density = 4e-4;     // (m) / sqrt(hz)
   static constexpr double _gps_vxy_noise_density = 2e-1;   // (m/s) / sqrt(hz)

--- a/src/gazebo_gps_plugin.cpp
+++ b/src/gazebo_gps_plugin.cpp
@@ -34,7 +34,17 @@ GpsPlugin::GpsPlugin() : ModelPlugin()
 
 GpsPlugin::~GpsPlugin()
 {
-  updateConnection_->~Connection();
+  this->updateConnection_.reset();
+#if BUILD_ROS_INTERFACE
+  this->fix_queue_.clear();
+  this->pose_queue_.clear();
+  this->fix_queue_.disable();
+  this->pose_queue_.disable();
+  this->rosnode_->shutdown();
+  this->pose_callback_queue_thread_.join();
+  this->fix_callback_queue_thread_.join();
+  this->rosnode_.reset();
+#endif
 }
 
 void GpsPlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf)
@@ -63,6 +73,37 @@ void GpsPlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf)
     gps_noise_ = false;
   }
 
+  // Get horizontal std deviation, in the case one doesn't want to use the computed random walk std dev
+  if (_sdf->HasElement("eph")) {
+    getSdfParam<double>(_sdf, "eph", eph_, eph_);
+  } else {
+    eph_ = kDefaultEPH;
+    gzwarn << "[gazebo_gps_plugin] Using default EPH of " << eph_ << "\n";
+  }
+
+  // Get vertical std deviation, in the case one doesn't want to use the computed random walk std dev
+  if (_sdf->HasElement("epv")) {
+    getSdfParam<double>(_sdf, "eph", eph_, eph_);
+  } else {
+    epv_ = kDefaultEPH;
+    gzwarn << "[gazebo_gps_plugin] Using default EPV of " << epv_ << "\n";
+  }
+
+#if BUILD_ROS_INTERFACE
+  if(_sdf->HasElement("rosGPSENUPubTopic")) {
+    this->ros_gps_pose_pub_topic_ = _sdf->GetElement("rosGPSENUPubTopic")->Get<std::string>();
+  } else {
+    this->ros_gps_pose_pub_topic_ = kDefaultRosGPSENUPubTopic;
+    ROS_INFO_NAMED("gazebo_gps", "Using default ROS PoseWithCovarianceStamped subscription to topic %s", this->ros_gps_pose_pub_topic_.c_str());
+  }
+  if(_sdf->HasElement("rosGPSFixPubTopic")) {
+    this->ros_gps_fix_pub_topic_ = _sdf->GetElement("rosGPSENUPubTopic")->Get<std::string>();
+  } else {
+    this->ros_gps_fix_pub_topic_ = kDefaultRosGPSFixPubTopic;
+    ROS_INFO_NAMED("gazebo_gps", "Using default ROS NavSatFix subscription to topic %s", this->ros_gps_fix_pub_topic_.c_str());
+  }
+#endif
+
   if (env_lat) {
     gzmsg << "Home latitude is set to " << env_lat << ".\n";
     lat_home = std::stod(env_lat) * M_PI / 180.0;
@@ -76,15 +117,64 @@ void GpsPlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf)
     alt_home = std::stod(env_alt);
   }
 
-  namespace_.clear();
+  this->namespace_.clear();
   if (_sdf->HasElement("robotNamespace")) {
-    namespace_ = _sdf->GetElement("robotNamespace")->Get<std::string>();
+    this->namespace_ = _sdf->GetElement("robotNamespace")->Get<std::string>();
   } else {
     gzerr << "[gazebo_gps_plugin] Please specify a robotNamespace.\n";
   }
 
-  node_handle_ = transport::NodePtr(new transport::Node());
-  node_handle_->Init(namespace_);
+  this->node_handle_ = transport::NodePtr(new transport::Node());
+  this->node_handle_->Init(namespace_);
+
+#if BUILD_ROS_INTERFACE
+  // Initialize ros, if it has not already been initialized.
+  if (!ros::isInitialized())
+  {
+    int argc = 0;
+    char **argv = NULL;
+    ros::init(argc, argv, "gazebo_client", ros::init_options::NoSigintHandler);
+  }
+
+  // Create our ROS node. This acts in a similar manner to the Gazebo node
+  this->rosnode_.reset(new ros::NodeHandle("gazebo_client"));
+
+  // Publish multi queue
+  this->pmq_.startServiceThread();
+
+  // if topic name specified as empty, do not publish
+  if (this->ros_gps_fix_pub_topic_ != "")
+  {
+    this->fix_pub_queue_ = this->pmq_.addPub<sensor_msgs::NavSatFix>();
+    this->gps_fix_pub_ = this->rosnode_->advertise<sensor_msgs::NavSatFix>(this->ros_gps_fix_pub_topic_, 1);
+
+    // advertise services on the custom queues
+    ros::AdvertiseServiceOptions nav_sat_aso =
+      ros::AdvertiseServiceOptions::create<std_srvs::Empty>(
+      this->ros_gps_pose_pub_topic_, boost::bind(&GpsPlugin::ServiceCallback,
+      this, _1, _2), ros::VoidPtr(), &this->fix_queue_);
+    this->pose_srv_ = this->rosnode_->advertiseService(nav_sat_aso);
+  }
+
+  if (this->ros_gps_pose_pub_topic_ != "")
+  {
+    this->pose_pub_queue_ = this->pmq_.addPub<geometry_msgs::PoseWithCovarianceStamped>();
+    this->gps_pose_pub_ = this->rosnode_->advertise<geometry_msgs::PoseWithCovarianceStamped>(this->ros_gps_pose_pub_topic_, 1);
+
+    // advertise services on the custom queues
+    ros::AdvertiseServiceOptions pose_aso =
+      ros::AdvertiseServiceOptions::create<std_srvs::Empty>(
+      this->ros_gps_fix_pub_topic_, boost::bind(&GpsPlugin::ServiceCallback,
+      this, _1, _2), ros::VoidPtr(), &this->pose_queue_);
+    this->fix_srv_ = this->rosnode_->advertiseService(pose_aso);
+  }
+
+  ROS_INFO_NAMED("gazebo_gps", "Starting ENU pose data publishing (ns = %s)", this->namespace_.c_str() );
+  this->pose_callback_queue_thread_ = boost::thread(boost::bind(&GpsPlugin::PoseQueueThread, this));
+
+  ROS_INFO_NAMED("gazebo_gps", "Starting GPS fix data publishing (ns = %s)", this->namespace_.c_str() );
+  this->fix_callback_queue_thread_= boost::thread(boost::bind(&GpsPlugin::FixQueueThread, this));
+#endif
 
   // Listen to the update event. This event is broadcast every simulation iteration.
   updateConnection_ = event::Events::ConnectWorldUpdateBegin(
@@ -95,6 +185,14 @@ void GpsPlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf)
   gps_pub_ = node_handle_->Advertise<sensor_msgs::msgs::SITLGps>("~/" + model_->GetName() + "/gps", 10);
   gt_pub_ = node_handle_->Advertise<sensor_msgs::msgs::Groundtruth>("~/" + model_->GetName() + "/groundtruth", 10);
 }
+
+#if BUILD_ROS_INTERFACE
+// returns true always
+bool GpsPlugin::ServiceCallback(std_srvs::Empty::Request &req, std_srvs::Empty::Response &res)
+{
+  return true;
+}
+#endif
 
 void GpsPlugin::OnUpdate(const common::UpdateInfo&){
 #if GAZEBO_MAJOR_VERSION >= 9
@@ -125,49 +223,45 @@ void GpsPlugin::OnUpdate(const common::UpdateInfo&){
   velocity_current_W_xy.Z() = 0;
 
   // update noise parameters if gps_noise_ is set
-  if (gps_noise_) {
-    noise_gps_pos.X() = gps_xy_noise_density * sqrt(dt) * randn_(rand_);
-    noise_gps_pos.Y() = gps_xy_noise_density * sqrt(dt) * randn_(rand_);
-    noise_gps_pos.Z() = gps_z_noise_density * sqrt(dt) * randn_(rand_);
-    noise_gps_vel.X() = gps_vxy_noise_density * sqrt(dt) * randn_(rand_);
-    noise_gps_vel.Y() = gps_vxy_noise_density * sqrt(dt) * randn_(rand_);
-    noise_gps_vel.Z() = gps_vz_noise_density * sqrt(dt) * randn_(rand_);
-    random_walk_gps.X() = gps_xy_random_walk * sqrt(dt) * randn_(rand_);
-    random_walk_gps.Y() = gps_xy_random_walk * sqrt(dt) * randn_(rand_);
-    random_walk_gps.Z() = gps_z_random_walk * sqrt(dt) * randn_(rand_);
-  }
-  else {
-    noise_gps_pos.X() = 0.0;
-    noise_gps_pos.Y() = 0.0;
-    noise_gps_pos.Z() = 0.0;
-    noise_gps_vel.X() = 0.0;
-    noise_gps_vel.Y() = 0.0;
-    noise_gps_vel.Z() = 0.0;
-    random_walk_gps.X() = 0.0;
-    random_walk_gps.Y() = 0.0;
-    random_walk_gps.Z() = 0.0;
-  }
+  noise_gps_pos.X() = gps_noise_ ? _gps_xy_noise_density * sqrt(dt) * randn_(rand_) : 0.0;
+  noise_gps_pos.Y() = gps_noise_ ? _gps_xy_noise_density * sqrt(dt) * randn_(rand_) : 0.0;
+  noise_gps_pos.Z() = gps_noise_ ? _gps_z_noise_density * sqrt(dt) * randn_(rand_) : 0.0;
+  noise_gps_vel.X() = gps_noise_ ? _gps_vxy_noise_density * sqrt(dt) * randn_(rand_) : 0.0;
+  noise_gps_vel.Y() = gps_noise_ ? _gps_vxy_noise_density * sqrt(dt) * randn_(rand_) : 0.0;
+  noise_gps_vel.Z() = gps_noise_ ? _gps_vz_noise_density * sqrt(dt) * randn_(rand_) : 0.0;
+  random_walk_gps.X() = gps_noise_ ? _gps_xy_random_walk * sqrt(dt) * randn_(rand_) : 0.0;
+  random_walk_gps.Y() = gps_noise_ ? _gps_xy_random_walk * sqrt(dt) * randn_(rand_) : 0.0;
+  random_walk_gps.Z() = gps_noise_ ? _gps_z_random_walk * sqrt(dt) * randn_(rand_) : 0.0;
 
   // gps bias integration
-  gps_bias.X() += random_walk_gps.X() * dt - gps_bias.X() / gps_corellation_time;
-  gps_bias.Y() += random_walk_gps.Y() * dt - gps_bias.Y() / gps_corellation_time;
-  gps_bias.Z() += random_walk_gps.Z() * dt - gps_bias.Z() / gps_corellation_time;
+  gps_bias.X() += random_walk_gps.X() * dt - gps_bias.X() / _gps_corellation_time;
+  gps_bias.Y() += random_walk_gps.Y() * dt - gps_bias.Y() / _gps_corellation_time;
+  gps_bias.Z() += random_walk_gps.Z() * dt - gps_bias.Z() / _gps_corellation_time;
 
   // reproject position with noise into geographic coordinates
   auto pos_with_noise = pos_W_I + noise_gps_pos + gps_bias;
   auto latlon = reproject(pos_with_noise);
 
-  // standard deviation TODO: add a way of computing this
-  std_xy = 1.0;
-  std_z = 1.0;
+  // standard deviation of random walk
+  _std_x = random_walk_gps.X() * _gps_corellation_time / sqrtf(2 * _gps_corellation_time - 1);
+  _std_y = random_walk_gps.Y() * _gps_corellation_time / sqrtf(2 * _gps_corellation_time - 1);
+  _std_z = random_walk_gps.Z() * _gps_corellation_time / sqrtf(2 * _gps_corellation_time - 1);
 
   // fill SITLGps msg
   gps_msg.set_time_usec(current_time.Double() * 1e6);
   gps_msg.set_latitude_deg(latlon.first * 180.0 / M_PI);
   gps_msg.set_longitude_deg(latlon.second * 180.0 / M_PI);
   gps_msg.set_altitude(pos_W_I.Z() + alt_home + noise_gps_pos.Z() + gps_bias.Z());
-  gps_msg.set_eph(std_xy);
-  gps_msg.set_epv(std_z);
+  if (eph_ == kDefaultEPH && gps_noise_) {
+    gps_msg.set_eph(std::min(_std_x + _gps_xy_noise_density * _gps_xy_noise_density, _std_y + _gps_xy_noise_density * _gps_xy_noise_density));
+  }
+  if (epv_ == kDefaultEPV && gps_noise_) {
+    gps_msg.set_epv(_std_z + _gps_z_noise_density);
+  }
+  if (eph_ != kDefaultEPH && epv_ != kDefaultEPV) {
+    gps_msg.set_eph(eph_);
+    gps_msg.set_epv(epv_);
+  }
   gps_msg.set_velocity(velocity_current_W_xy.Length());
   gps_msg.set_velocity_east(velocity_current_W.X() + noise_gps_vel.Y());
   gps_msg.set_velocity_north(velocity_current_W.Y() + noise_gps_vel.X());
@@ -175,6 +269,73 @@ void GpsPlugin::OnUpdate(const common::UpdateInfo&){
 
   // add msg to buffer
   gps_delay_buffer.push(gps_msg);
+
+#if BUILD_ROS_INTERFACE
+  // fill ROS NavSatFix msg
+  auto fix_msg = boost::make_shared<sensor_msgs::NavSatFix>();
+
+  fix_msg->header.frame_id = "map";
+  fix_msg->header.stamp.sec = current_time.sec;
+  fix_msg->header.stamp.nsec = current_time.nsec;
+
+  fix_msg->latitude = latlon.first * 180.0 / M_PI;
+  fix_msg->longitude = latlon.second * 180.0 / M_PI;
+  fix_msg->altitude = pos_W_I.Z() + alt_home + noise_gps_pos.Z() + gps_bias.Z();
+
+  fix_msg->status.service = sensor_msgs::NavSatStatus::SERVICE_GPS;
+  fix_msg->status.status = sensor_msgs::NavSatStatus::STATUS_FIX;
+
+  if (eph_ == kDefaultEPH && gps_noise_) {
+    fix_msg->position_covariance[0] = fix_msg->position_covariance[4] = std::pow(_std_x + _gps_xy_noise_density, 2);
+    fix_msg->position_covariance[4] = fix_msg->position_covariance[4] = std::pow(_std_y + _gps_xy_noise_density, 2);
+  }
+  if (epv_ == kDefaultEPV && gps_noise_) {
+    fix_msg->position_covariance[8] = std::pow(_std_z + _gps_z_noise_density, 2);
+  }
+  if (eph_ != kDefaultEPH && epv_ != kDefaultEPV) {
+    fix_msg->position_covariance[0] = fix_msg->position_covariance[4] = eph_ * eph_;
+    fix_msg->position_covariance[8] = epv_ * epv_;
+  }
+
+  fix_msg->position_covariance_type = sensor_msgs::NavSatFix::COVARIANCE_TYPE_APPROXIMATED;
+
+  // fill ROS PoseWithCovarianceStamped msg
+  auto pose_msg = boost::make_shared<geometry_msgs::PoseWithCovarianceStamped>();
+
+  pose_msg->header.frame_id = "map";
+  pose_msg->header.stamp.sec = current_time.sec;
+  pose_msg->header.stamp.nsec = current_time.nsec;
+
+  pose_msg->pose.pose.position.x = pos_with_noise.X();
+  pose_msg->pose.pose.position.y = pos_with_noise.Y();
+  pose_msg->pose.pose.position.z = pos_with_noise.Z();
+
+  ignition::math::Quaterniond& rot_W_I = T_W_I.Rot();   // model orientation WRT world
+  pose_msg->pose.pose.orientation.x = rot_W_I.X();
+  pose_msg->pose.pose.orientation.y = rot_W_I.Y();
+  pose_msg->pose.pose.orientation.z = rot_W_I.Z();
+  pose_msg->pose.pose.orientation.w = rot_W_I.W();
+
+  for (int i = 0; i < 36; i++){
+    switch (i){
+      // principal diagonal = the variance of the random variables
+      case 0:
+        pose_msg->pose.covariance[i] = std::pow(_std_x + _gps_xy_noise_density, 2);
+        break;
+      case 7:
+        pose_msg->pose.covariance[i] = std::pow(_std_y + _gps_xy_noise_density, 2);
+        break;
+      case 14:
+        pose_msg->pose.covariance[i] = std::pow(_std_z * _gps_xy_noise_density, 2);
+        break;
+      case 21: case 28: case 35:
+        pose_msg->pose.covariance[i] = 0.01;
+        break;
+      default:
+        pose_msg->pose.covariance[i] = 0.0;
+    }
+  }
+#endif
 
   // apply GPS delay
   if ((current_time - last_gps_time_).Double() > gps_update_interval_) {
@@ -200,6 +361,22 @@ void GpsPlugin::OnUpdate(const common::UpdateInfo&){
     }
     // publish SITLGps msg at 5hz
     gps_pub_->Publish(gps_msg);
+
+#if BUILD_ROS_INTERFACE
+    {
+      boost::mutex::scoped_lock lock(this->lock_);
+      // publish local ENU data as a PoseWithCovarianceStamped ROS topic
+      if (this->gps_pose_pub_.getNumSubscribers() > 0 && this->ros_gps_pose_pub_topic_ != "")
+      {
+        this->pose_pub_queue_->push(*pose_msg, this->gps_pose_pub_);
+      }
+      // publish projected GPS fix data as a NavSatFix ROS topic
+      if (this->gps_fix_pub_.getNumSubscribers() > 0 && this->ros_gps_fix_pub_topic_ != "")
+      {
+        this->fix_pub_queue_->push(*fix_msg, this->gps_fix_pub_);
+      }
+    }
+#endif
   }
 
   // fill Groundtruth msg
@@ -237,4 +414,26 @@ std::pair<double, double> GpsPlugin::reproject(ignition::math::Vector3d& pos)
 
   return std::make_pair (lat_rad, lon_rad);
 }
+
+#if BUILD_ROS_INTERFACE
+void GpsPlugin::PoseQueueThread()
+{
+  static const double timeout = 0.01;
+
+  while (this->rosnode_->ok())
+  {
+    this->pose_queue_.callAvailable(ros::WallDuration(timeout));
+  }
+}
+
+void GpsPlugin::FixQueueThread()
+{
+  static const double timeout = 0.01;
+
+  while (this->rosnode_->ok())
+  {
+    this->fix_queue_.callAvailable(ros::WallDuration(timeout));
+  }
+}
+#endif
 } // namespace gazebo

--- a/src/gazebo_gps_plugin.cpp
+++ b/src/gazebo_gps_plugin.cpp
@@ -252,13 +252,11 @@ void GpsPlugin::OnUpdate(const common::UpdateInfo&){
   gps_msg.set_latitude_deg(latlon.first * 180.0 / M_PI);
   gps_msg.set_longitude_deg(latlon.second * 180.0 / M_PI);
   gps_msg.set_altitude(pos_W_I.Z() + alt_home + noise_gps_pos.Z() + gps_bias.Z());
-  if (eph_ == kDefaultEPH && gps_noise_) {
+  if (gps_noise_) {
     gps_msg.set_eph(std::min(_std_x + _gps_xy_noise_density * _gps_xy_noise_density, _std_y + _gps_xy_noise_density * _gps_xy_noise_density));
-  }
-  if (epv_ == kDefaultEPV && gps_noise_) {
     gps_msg.set_epv(_std_z + _gps_z_noise_density);
   }
-  if (eph_ != kDefaultEPH && epv_ != kDefaultEPV) {
+  else {
     gps_msg.set_eph(eph_);
     gps_msg.set_epv(epv_);
   }
@@ -285,14 +283,12 @@ void GpsPlugin::OnUpdate(const common::UpdateInfo&){
   fix_msg->status.service = sensor_msgs::NavSatStatus::SERVICE_GPS;
   fix_msg->status.status = sensor_msgs::NavSatStatus::STATUS_FIX;
 
-  if (eph_ == kDefaultEPH && gps_noise_) {
-    fix_msg->position_covariance[0] = fix_msg->position_covariance[4] = std::pow(_std_x + _gps_xy_noise_density, 2);
-    fix_msg->position_covariance[4] = fix_msg->position_covariance[4] = std::pow(_std_y + _gps_xy_noise_density, 2);
-  }
-  if (epv_ == kDefaultEPV && gps_noise_) {
+  if (gps_noise_) {
+    fix_msg->position_covariance[0] = std::pow(_std_x + _gps_xy_noise_density, 2);
+    fix_msg->position_covariance[4] = std::pow(_std_y + _gps_xy_noise_density, 2);
     fix_msg->position_covariance[8] = std::pow(_std_z + _gps_z_noise_density, 2);
   }
-  if (eph_ != kDefaultEPH && epv_ != kDefaultEPV) {
+  else {
     fix_msg->position_covariance[0] = fix_msg->position_covariance[4] = eph_ * eph_;
     fix_msg->position_covariance[8] = epv_ * epv_;
   }


### PR DESCRIPTION
This PR adds optional publishing of ROS `sensor_msgs/NavSatFix` and `geometry_msgs/PoseWithCovarianceStamped` msgs to be used on the ROS side. This is part of a project that I am working on which uses the simulated GPS data on a SLAM framework before VIO data to the FCU, so I assume this can be also useful for other people that want to bring the simulated GPS data into the ROS side to be processed.
I also bring a fix to the computation of the std deviation of the random walk and now it also allows, or to set the EPH and EPV manually by an SDF element, or by computing it using the noise parameters.
To use this functionality, you need to build `sitl_gazebo` with `BUILD_ROS_INTERFACE` option set to `ON` - `mkdir build; cd build; cmake .. -DBUILD_ROS_INTERFACE=ON; make`, or if already in a `catkin` workspace, `catkin build -DBUILD_ROS_INTERFACE=ON`.