### PR TITLE
gazebo_mavlink_interface: vision: fix attitude rotation

### DIFF
--- a/src/gazebo_mavlink_interface.cpp
+++ b/src/gazebo_mavlink_interface.cpp
@@ -764,20 +764,18 @@ void GazeboMavlinkInterface::VisionCallback(OdomPtr& odom_message) {
     odom_message->position().y(),
     odom_message->position().z()));
 
-  // q_gr is the quaternion that represents a rotation from ENU earth/local
-  // frame to XYZ body FLU frame
+  // q_gr is the quaternion that represents the orientation of the vehicle
+  // the ENU earth/local
   ignition::math::Quaterniond q_gr = ignition::math::Quaterniond(
     odom_message->orientation().w(),
     odom_message->orientation().x(),
     odom_message->orientation().y(),
     odom_message->orientation().z());
 
-  // transform orientation from local ENU to body FLU frame
-  ignition::math::Quaterniond q_gb = q_gr * q_br.Inverse();
-  // transform orientation from body FLU to body FRD frame:
-  // q_nb is the quaternion that represents a rotation from NED earth/local
-  // frame to XYZ body FRD frame
-  ignition::math::Quaterniond q_nb = q_ng * q_gb;
+  // transform the vehicle orientation from the ENU to the NED frame
+  // q_nb is the quaternion that represents the orientation of the vehicle
+  // the NED earth/local
+  ignition::math::Quaterniond q_nb = q_ng * q_gr * q_ng.Inverse();
 
   // transform linear velocity from local ENU to body FRD frame
   ignition::math::Vector3d linear_velocity = q_ng.RotateVector(


### PR DESCRIPTION
Further testing with the `iris_vision` model lead me to find that the rotation for the attitude was wrong. This fixes it.

As examples, here's a test with LPE+AEQ: https://review.px4.io/plot_app?log=bcc69b12-26ec-4428-af66-da464aa58c5c. Same for EKF2, with vision position and heading fusion: https://review.px4.io/plot_app?log=17246819-f0ff-47b2-9819-3e66ab6c2945

This also supports the change in https://github.com/PX4/Firmware/pull/10872.

@LorenzMeier can you review? Thanks!