### PR TITLE
Update opencv includes

### DIFF
--- a/include/gazebo_geotagged_images_plugin.h
+++ b/include/gazebo_geotagged_images_plugin.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <string>
+#include <opencv2/opencv.hpp>
 #include <mavlink/v2.0/common/mavlink.h>
 #include <gazebo/common/Plugin.hh>
 #include <gazebo/sensors/CameraSensor.hh>

--- a/src/gazebo_geotagged_images_plugin.cpp
+++ b/src/gazebo_geotagged_images_plugin.cpp
@@ -21,10 +21,6 @@
 #include <string>
 #include <iostream>
 #include <boost/filesystem.hpp>
-
-#include <cv.h>
-#include <highgui.h>
-
 #include <opencv2/opencv.hpp>
 
 using namespace std;
@@ -192,7 +188,7 @@ void GeotaggedImagesPlugin::OnNewFrame(const unsigned char * image)
     Mat frame    = Mat(_height, _width, CV_8UC3);
     Mat frameBGR = Mat(_height, _width, CV_8UC3);
     frame.data   = (uchar*)image; //frame has not the right color format yet -> convert
-    cvtColor(frame, frameBGR, CV_RGB2BGR);
+    cvtColor(frame, frameBGR, COLOR_RGB2BGR);
 
     char file_name[256];
     snprintf(file_name, sizeof(file_name), "%s/DSC%05i.jpg", _storageDir.c_str(), _imageCounter);

--- a/src/gazebo_irlock_plugin.cpp
+++ b/src/gazebo_irlock_plugin.cpp
@@ -23,7 +23,7 @@
 #include "gazebo/sensors/DepthCameraSensor.hh"
 #include "gazebo_irlock_plugin.h"
 
-#include <highgui.h>
+#include <opencv2/opencv.hpp>
 #include <math.h>
 #include <string>
 #include <iostream>

--- a/src/gazebo_opticalflow_plugin.cpp
+++ b/src/gazebo_opticalflow_plugin.cpp
@@ -23,7 +23,6 @@
 #include "gazebo/sensors/DepthCameraSensor.hh"
 #include "gazebo_opticalflow_plugin.h"
 
-#include <highgui.h>
 #include <math.h>
 #include <string>
 #include <iostream>


### PR DESCRIPTION
Starting with opencv 4.0 the include cv.h is no longer available.
Therefore, the deprecated includes are removed and replaced with the opencv2 includes.

Also, one the define RGB2BGR needed updating.