### PR TITLE
Add lockstep

### DIFF
--- a/include/gazebo_imu_plugin.h
+++ b/include/gazebo_imu_plugin.h
@@ -148,5 +148,7 @@ class GazeboImuPlugin : public ModelPlugin {
   Eigen::Vector3d accelerometer_turn_on_bias_;
 
   ImuParameters imu_parameters_;
+
+  uint64_t seq_ = 0;
 };
 }

--- a/include/gazebo_mavlink_interface.h
+++ b/include/gazebo_mavlink_interface.h
@@ -118,7 +118,7 @@ enum class Framing : uint8_t {
 class GazeboMavlinkInterface : public ModelPlugin {
 public:
   GazeboMavlinkInterface() : ModelPlugin(),
-    received_first_referenc_(false),
+    received_first_actuator_(false),
     namespace_(kDefaultNamespace),
     protocol_version_(2.0),
     motor_velocity_reference_pub_topic_(kDefaultMotorVelocityReferencePubTopic),
@@ -179,7 +179,7 @@ protected:
   void OnUpdate(const common::UpdateInfo&  /*_info*/);
 
 private:
-  bool received_first_referenc_;
+  bool received_first_actuator_;
   Eigen::VectorXd input_reference_;
 
   float protocol_version_;

--- a/include/gazebo_mavlink_interface.h
+++ b/include/gazebo_mavlink_interface.h
@@ -237,8 +237,11 @@ private:
   void IRLockCallback(IRLockPtr& irlock_msg);
   void VisionCallback(OdomPtr& odom_msg);
   void send_mavlink_message(const mavlink_message_t *message, const int destination_port = 0);
-  void handle_message(mavlink_message_t *msg);
-  void pollForMAVLinkMessages(double _dt, uint32_t _timeoutMs);
+  void handle_message(mavlink_message_t *msg, bool &received_actuator);
+  void pollForMAVLinkMessages();
+  void SendSensorMessages();
+  void handle_control(double _dt);
+
 
   // Serial interface
   void open();
@@ -280,6 +283,7 @@ private:
   std::string groundtruth_sub_topic_;
   std::string vision_sub_topic_;
 
+  sensor_msgs::msgs::Imu last_imu_message_;
   common::Time last_time_;
   common::Time last_imu_time_;
   common::Time last_actuator_time_;
@@ -288,9 +292,7 @@ private:
   double groundtruth_lon_rad;
   double groundtruth_altitude;
 
-  double imu_update_interval_ = 0.004;
-
-  void handle_control(double _dt);
+  double imu_update_interval_ = 0.004; ///< Used for non-lockstep
 
   ignition::math::Vector3d gravity_W_;
   ignition::math::Vector3d velocity_prev_W_;
@@ -318,6 +320,10 @@ private:
 
   in_addr_t qgc_addr_;
   int qgc_udp_port_;
+
+  bool enable_lockstep_ = false;
+  double speed_factor_ = 1.0;
+  int64_t previous_imu_seq_ = 0;
 
   // Serial interface
   mavlink_status_t m_status;

--- a/include/gazebo_mavlink_interface.h
+++ b/include/gazebo_mavlink_interface.h
@@ -70,6 +70,7 @@
 #include <geo_mag_declination.h>
 
 static const uint32_t kDefaultMavlinkUdpPort = 14560;
+static const uint32_t kDefaultMavlinkTcpPort = 4560;
 static const uint32_t kDefaultQGCUdpPort = 14550;
 
 using lock_guard = std::lock_guard<std::recursive_mutex>;
@@ -154,6 +155,9 @@ public:
     groundtruth_lon_rad(0.0),
     groundtruth_altitude(0.0),
     mavlink_udp_port_(kDefaultMavlinkUdpPort),
+    mavlink_tcp_port_(kDefaultMavlinkTcpPort),
+    tcp_client_fd_(0),
+    use_tcp_(false),
     qgc_udp_port_(kDefaultQGCUdpPort),
     serial_enabled_(false),
     tx_q {},
@@ -297,19 +301,20 @@ private:
 
   int _fd;
   struct sockaddr_in _myaddr;     ///< The locally bound address
+  socklen_t _myaddr_len;
   struct sockaddr_in _srcaddr;    ///< SITL instance
-  socklen_t _addrlen;
+  socklen_t _srcaddr_len;
   unsigned char _buf[65535];
-  struct pollfd fds[1];
+  struct pollfd fds_[1];
 
-  struct sockaddr_in _srcaddr_2;  ///< MAVROS
-
-  //so we dont have to do extra callbacks
   double optflow_distance;
   double sonar_distance;
 
   in_addr_t mavlink_addr_;
   int mavlink_udp_port_;
+  int mavlink_tcp_port_;
+  int tcp_client_fd_;
+  bool use_tcp_;
 
   in_addr_t qgc_addr_;
   int qgc_udp_port_;

--- a/include/gazebo_mavlink_interface.h
+++ b/include/gazebo_mavlink_interface.h
@@ -40,6 +40,7 @@
 #include <math.h>
 #include <cstdlib>
 #include <string>
+#include <future>
 #include <sys/socket.h>
 #include <netinet/in.h>
 

--- a/include/gazebo_mavlink_interface.h
+++ b/include/gazebo_mavlink_interface.h
@@ -241,6 +241,7 @@ private:
   void pollForMAVLinkMessages();
   void SendSensorMessages();
   void handle_control(double _dt);
+  bool IsRunning();
 
 
   // Serial interface

--- a/include/gazebo_mavlink_interface.h
+++ b/include/gazebo_mavlink_interface.h
@@ -27,6 +27,7 @@
 #include <memory>
 #include <sstream>
 #include <cassert>
+#include <memory>
 #include <stdexcept>
 #include <boost/asio.hpp>
 #include <boost/bind.hpp>
@@ -285,6 +286,8 @@ private:
   std::string vision_sub_topic_;
 
   sensor_msgs::msgs::Imu last_imu_message_;
+  std::unique_ptr<std::promise<void>> imu_message_ready_promise_;
+  std::future<void> imu_message_ready_future_;
   common::Time last_time_;
   common::Time last_imu_time_;
   common::Time last_actuator_time_;

--- a/include/gazebo_mavlink_interface.h
+++ b/include/gazebo_mavlink_interface.h
@@ -249,8 +249,6 @@ private:
   static const unsigned n_out_max = 16;
   double alt_home = 488.0;   // meters
 
-  unsigned _rotor_count;
-
   double input_offset_[n_out_max];
   double input_scaling_[n_out_max];
   std::string joint_control_type_[n_out_max];
@@ -336,6 +334,5 @@ private:
   // state variables for baro pressure sensor random noise generator
   double baro_rnd_y2_;
   bool baro_rnd_use_last_;
-
   };
 }

--- a/models/hippocampus/hippocampus.sdf
+++ b/models/hippocampus/hippocampus.sdf
@@ -707,6 +707,8 @@
       <qgc_udp_port>14550</qgc_udp_port>
       <hil_mode>false</hil_mode>
       <hil_state_level>false</hil_state_level>
+      <enable_lockstep>true</enable_lockstep>
+      <use_tcp>true</use_tcp>
       <motorSpeedCommandPubTopic>/gazebo/command/motor_speed</motorSpeedCommandPubTopic>
 
       <!-- control channels, this way for every channel different settings can be realized -->

--- a/models/matrice_100/matrice_100.sdf.jinja
+++ b/models/matrice_100/matrice_100.sdf.jinja
@@ -293,6 +293,8 @@
       <hil_state_level>false</hil_state_level>
       <opticalFlowSubTopic>/px4flow/link/opticalFlow</opticalFlowSubTopic>
       <lidarSubTopic>/sf10a/link/lidar</lidarSubTopic>
+      <enable_lockstep>true</enable_lockstep>
+      <use_tcp>true</use_tcp>
       <motorSpeedCommandPubTopic>/gazebo/command/motor_speed</motorSpeedCommandPubTopic>
     </plugin>
 

--- a/models/plane/plane.sdf
+++ b/models/plane/plane.sdf
@@ -470,6 +470,8 @@
       <qgc_udp_port>14550</qgc_udp_port>
       <hil_mode>false</hil_mode>
       <hil_state_level>false</hil_state_level>
+      <enable_lockstep>true</enable_lockstep>
+      <use_tcp>true</use_tcp>
       <motorSpeedCommandPubTopic>/gazebo/command/motor_speed</motorSpeedCommandPubTopic>
       <control_channels>
         <channel name="rotor4">

--- a/models/rotors_description/urdf/component_snippets.xacro
+++ b/models/rotors_description/urdf/component_snippets.xacro
@@ -135,7 +135,7 @@
   </xacro:macro>
 
   <!-- Macro to add the mavlink interface. -->
-  <xacro:macro name="mavlink_interface_macro" params="namespace imu_sub_topic gps_sub_topic mavlink_addr mavlink_udp_port serial_enabled serial_device baudrate qgc_addr qgc_udp_port hil_mode hil_state_level vehicle_is_tailsitter send_vision_estimation send_odometry">
+  <xacro:macro name="mavlink_interface_macro" params="namespace imu_sub_topic gps_sub_topic mavlink_addr mavlink_udp_port serial_enabled serial_device baudrate qgc_addr qgc_udp_port hil_mode hil_state_level vehicle_is_tailsitter send_vision_estimation send_odometry enable_lockstep use_tcp">
     <gazebo>
       <plugin name="mavlink_interface" filename="libgazebo_mavlink_interface.so">
         <robotNamespace>${namespace}</robotNamespace>
@@ -153,6 +153,8 @@
         <vehicle_is_tailsitter>$(arg vehicle_is_tailsitter)</vehicle_is_tailsitter>
         <send_vision_estimation>$(arg send_vision_estimation)</send_vision_estimation>
         <send_odometry>$(arg send_odometry)</send_odometry>
+        <enable_lockstep>$(arg enable_lockstep)</enable_lockstep>
+        <use_tcp>$(arg use_tcp)</use_tcp>
         <motorSpeedCommandPubTopic>/gazebo/command/motor_speed</motorSpeedCommandPubTopic>
         <control_channels>
           <channel name="rotor1">

--- a/models/rotors_description/urdf/iris_base.xacro
+++ b/models/rotors_description/urdf/iris_base.xacro
@@ -16,6 +16,8 @@
   <xacro:arg name='hil_state_level' default='false' />
   <xacro:arg name='send_vision_estimation' default='false' />
   <xacro:arg name='send_odometry' default='false' />
+  <xacro:arg name='enable_lockstep' default='true' />
+  <xacro:arg name='use_tcp' default='true' />
   <xacro:arg name='vehicle_is_tailsitter' default='false' />
   <xacro:arg name='visual_material' default='DarkGrey' />
   <xacro:arg name='enable_mavlink_interface' default='true' />
@@ -70,6 +72,8 @@
     vehicle_is_tailsitter="$(arg vehicle_is_tailsitter)"
     send_vision_estimation="$(arg send_vision_estimation)"
     send_odometry="$(arg send_odometry)"
+    enable_lockstep="$(arg enable_lockstep)"
+    use_tcp="$(arg use_tcp)"
     >
   </xacro:mavlink_interface_macro>
   </xacro:if>

--- a/models/rover/model.sdf
+++ b/models/rover/model.sdf
@@ -881,6 +881,8 @@
       <qgc_udp_port>14550</qgc_udp_port>
       <hil_mode>false</hil_mode>
       <hil_state_level>false</hil_state_level>
+      <enable_lockstep>true</enable_lockstep>
+      <use_tcp>true</use_tcp>
       <motorSpeedCommandPubTopic>/gazebo/command/motor_speed</motorSpeedCommandPubTopic>
       <control_channels>
         <!--

--- a/models/solo/solo.sdf
+++ b/models/solo/solo.sdf
@@ -440,6 +440,8 @@
       <qgc_udp_port>14550</qgc_udp_port>
       <hil_mode>false</hil_mode>
       <hil_state_level>false</hil_state_level>
+      <enable_lockstep>true</enable_lockstep>
+      <use_tcp>true</use_tcp>
       <motorSpeedCommandPubTopic>/gazebo/command/motor_speed</motorSpeedCommandPubTopic>
       <control_channels>
         <channel name='rotor1'>

--- a/models/standard_vtol/standard_vtol.sdf
+++ b/models/standard_vtol/standard_vtol.sdf
@@ -881,6 +881,8 @@
       <qgc_udp_port>14550</qgc_udp_port>
       <hil_mode>false</hil_mode>
       <hil_state_level>false</hil_state_level>
+      <enable_lockstep>true</enable_lockstep>
+      <use_tcp>true</use_tcp>
       <motorSpeedCommandPubTopic>/gazebo/command/motor_speed</motorSpeedCommandPubTopic>
       <control_channels>
         <channel name="rotor0">

--- a/models/tailsitter/tailsitter.sdf
+++ b/models/tailsitter/tailsitter.sdf
@@ -667,6 +667,8 @@
       <qgc_udp_port>14550</qgc_udp_port>
       <hil_mode>false</hil_mode>
       <hil_state_level>false</hil_state_level>
+      <enable_lockstep>true</enable_lockstep>
+      <use_tcp>true</use_tcp>
       <vehicle_is_tailsitter>true</vehicle_is_tailsitter>
       <motorSpeedCommandPubTopic>/gazebo/command/motor_speed</motorSpeedCommandPubTopic>
       <control_channels>

--- a/models/tiltrotor/tiltrotor.sdf
+++ b/models/tiltrotor/tiltrotor.sdf
@@ -1020,6 +1020,8 @@
       <qgc_udp_port>14550</qgc_udp_port>
       <hil_mode>false</hil_mode>
       <hil_state_level>false</hil_state_level>
+      <enable_lockstep>true</enable_lockstep>
+      <use_tcp>true</use_tcp>
       <motorSpeedCommandPubTopic>/gazebo/command/motor_speed</motorSpeedCommandPubTopic>
       <control_channels>
         <channel name="rotor0">

--- a/models/typhoon_h480/typhoon_h480.sdf
+++ b/models/typhoon_h480/typhoon_h480.sdf
@@ -1345,8 +1345,9 @@
       <qgc_udp_port>14550</qgc_udp_port>
       <hil_mode>false</hil_mode>
       <hil_state_level>false</hil_state_level>
+      <enable_lockstep>true</enable_lockstep>
+      <use_tcp>true</use_tcp>
       <motorSpeedCommandPubTopic>/gazebo/command/motor_speed</motorSpeedCommandPubTopic>
-
       <control_channels>
         <channel name="rotor0">
           <input_index>0</input_index>

--- a/msgs/Imu.proto
+++ b/msgs/Imu.proto
@@ -11,4 +11,6 @@ message Imu
   repeated float   angular_velocity_covariance = 4 [packed=true];
   required gazebo.msgs.Vector3d linear_acceleration = 5;
   repeated float   linear_acceleration_covariance = 6 [packed=true];
+  required int64 time_usec = 7;
+  required int64 seq = 8;
 }

--- a/src/gazebo_imu_plugin.cpp
+++ b/src/gazebo_imu_plugin.cpp
@@ -106,7 +106,7 @@ void GazeboImuPlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf) {
       event::Events::ConnectWorldUpdateBegin(
           boost::bind(&GazeboImuPlugin::OnUpdate, this, _1));
 
-  imu_pub_ = node_handle_->Advertise<sensor_msgs::msgs::Imu>("~/" + model_->GetName() + imu_topic_, 1);
+  imu_pub_ = node_handle_->Advertise<sensor_msgs::msgs::Imu>("~/" + model_->GetName() + imu_topic_, 10);
 
   // Fill imu message.
   // imu_message_.header.frame_id = frame_id_; TODO Add header

--- a/src/gazebo_imu_plugin.cpp
+++ b/src/gazebo_imu_plugin.cpp
@@ -266,13 +266,6 @@ void GazeboImuPlugin::OnUpdate(const common::UpdateInfo& _info) {
   orientation->set_z(C_W_I.Z());
   orientation->set_w(C_W_I.W());
 
-
-
-
-
-
-
-
 #if GAZEBO_MAJOR_VERSION < 5
   ignition::math::Vector3d velocity_current_W = link_->GetWorldLinearVel();
   // link_->RelativeLinearAccel() does not work sometimes with old gazebo versions.
@@ -333,7 +326,6 @@ void GazeboImuPlugin::OnUpdate(const common::UpdateInfo& _info) {
   imu_message_.set_allocated_linear_acceleration(linear_acceleration);
   imu_message_.set_allocated_angular_velocity(angular_velocity);
 
-  // gzerr << "publishing: " << imu_message_.linear_acceleration().z() << "\n";
   imu_pub_->Publish(imu_message_);
 }
 

--- a/src/gazebo_imu_plugin.cpp
+++ b/src/gazebo_imu_plugin.cpp
@@ -320,6 +320,8 @@ void GazeboImuPlugin::OnUpdate(const common::UpdateInfo& _info) {
   // ADD HEaders
   // imu_message_.header.stamp.sec = current_time.sec;
   // imu_message_.header.stamp.nsec = current_time.nsec;
+  imu_message_.set_time_usec(_info.simTime.sec * 1000000 + _info.simTime.nsec / 1000);
+  imu_message_.set_seq(seq_++);
 
   // TODO(burrimi): Add orientation estimator.
   // imu_message_.orientation.w = 1;

--- a/src/gazebo_mavlink_interface.cpp
+++ b/src/gazebo_mavlink_interface.cpp
@@ -756,7 +756,7 @@ void GazeboMavlinkInterface::SendSensorMessages()
   hil_state_quat.yacc = accel_true_b.Y() * 1000;
   hil_state_quat.zacc = accel_true_b.Z() * 1000;
 
-  if (!hil_mode_ || (hil_mode_ && !hil_state_level_)) {
+  if (!hil_mode_ || (hil_mode_ && hil_state_level_)) {
     mavlink_message_t msg;
     mavlink_msg_hil_state_quaternion_encode_chan(1, 200, MAVLINK_COMM_0, &msg, &hil_state_quat);
     send_mavlink_message(&msg);

--- a/src/gazebo_mavlink_interface.cpp
+++ b/src/gazebo_mavlink_interface.cpp
@@ -221,10 +221,10 @@ void GazeboMavlinkInterface::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf
     const double correct_real_time_update_rate = 250.0;
     if (real_time_update_rate != correct_real_time_update_rate)
     {
-      gzerr << "real_time_update_rate is set to " << real_time_update_rate
-            << " instead of " << correct_real_time_update_rate
-            << ", check your world file, aborting\n";
-      abort();
+      gzwarn << "real_time_update_rate is set to " << real_time_update_rate
+             << " instead of " << correct_real_time_update_rate
+			       << ", the param will be overwritten.\n";
+      presetManager->SetCurrentProfileParam("real_time_update_rate", correct_real_time_update_rate);
     }
 
     presetManager->GetCurrentProfileParam("max_step_size", param);
@@ -232,10 +232,11 @@ void GazeboMavlinkInterface::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf
     const double correct_max_step_size = 0.004;
     if (max_step_size != correct_max_step_size)
     {
-      gzerr << "max_step_size is set to " << max_step_size
-            << " instead of " << correct_max_step_size
-            << ", check your world file, aborting\n";
-      abort();
+      gzwarn << "max_step_size is set to " << max_step_size
+             << " instead of " << correct_max_step_size
+			       << ", the param will be overwritten.\n";
+
+      presetManager->SetCurrentProfileParam("max_step_size", correct_max_step_size);
     }
 
     // Adapt the real_time_update_rate according to the speed

--- a/src/gazebo_mavlink_interface.cpp
+++ b/src/gazebo_mavlink_interface.cpp
@@ -221,10 +221,9 @@ void GazeboMavlinkInterface::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf
     const double correct_real_time_update_rate = 250.0;
     if (real_time_update_rate != correct_real_time_update_rate)
     {
-      gzwarn << "real_time_update_rate is set to " << real_time_update_rate
-             << " instead of " << correct_real_time_update_rate
-			       << ", the param will be overwritten.\n";
-      presetManager->SetCurrentProfileParam("real_time_update_rate", correct_real_time_update_rate);
+      gzerr << "real_time_update_rate is set to " << real_time_update_rate
+            << " instead of " << correct_real_time_update_rate << ", aborting.\n";
+      abort();
     }
 
     presetManager->GetCurrentProfileParam("max_step_size", param);
@@ -232,11 +231,9 @@ void GazeboMavlinkInterface::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf
     const double correct_max_step_size = 0.004;
     if (max_step_size != correct_max_step_size)
     {
-      gzwarn << "max_step_size is set to " << max_step_size
-             << " instead of " << correct_max_step_size
-			       << ", the param will be overwritten.\n";
-
-      presetManager->SetCurrentProfileParam("max_step_size", correct_max_step_size);
+      gzerr << "max_step_size is set to " << max_step_size
+            << " instead of " << correct_max_step_size << ", aborting.\n";
+      abort();
     }
 
     // Adapt the real_time_update_rate according to the speed

--- a/src/gazebo_mavlink_interface.cpp
+++ b/src/gazebo_mavlink_interface.cpp
@@ -208,7 +208,7 @@ void GazeboMavlinkInterface::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf
     }
     gzmsg << "Speed factor set to: " << speed_factor_ << "\n";
 
-		boost::any param;
+    boost::any param;
     physics::PresetManagerPtr presetManager = world_->PresetMgr();
     presetManager->CurrentProfile("default_physics");
 
@@ -567,51 +567,51 @@ void GazeboMavlinkInterface::ImuCallback(ImuPtr& imu_message)
 
 void GazeboMavlinkInterface::SendSensorMessages()
 {
-	ignition::math::Quaterniond q_gr = ignition::math::Quaterniond(
-		last_imu_message_.orientation().w(),
-		last_imu_message_.orientation().x(),
-		last_imu_message_.orientation().y(),
-		last_imu_message_.orientation().z());
+  ignition::math::Quaterniond q_gr = ignition::math::Quaterniond(
+    last_imu_message_.orientation().w(),
+    last_imu_message_.orientation().x(),
+    last_imu_message_.orientation().y(),
+    last_imu_message_.orientation().z());
 
-	ignition::math::Quaterniond q_gb = q_gr*q_br.Inverse();
-	ignition::math::Quaterniond q_nb = q_ng*q_gb;
-
-#if GAZEBO_MAJOR_VERSION >= 9
-	ignition::math::Vector3d pos_g = model_->WorldPose().Pos();
-#else
-	ignition::math::Vector3d pos_g = ignitionFromGazeboMath(model_->GetWorldPose().pos);
-#endif
-	ignition::math::Vector3d pos_n = q_ng.RotateVector(pos_g);
-
-	float declination = get_mag_declination(groundtruth_lat_rad, groundtruth_lon_rad);
-
-	ignition::math::Quaterniond q_dn(0.0, 0.0, declination);
-	ignition::math::Vector3d mag_n = q_dn.RotateVector(mag_d_);
+  ignition::math::Quaterniond q_gb = q_gr*q_br.Inverse();
+  ignition::math::Quaterniond q_nb = q_ng*q_gb;
 
 #if GAZEBO_MAJOR_VERSION >= 9
-	ignition::math::Vector3d vel_b = q_br.RotateVector(model_->RelativeLinearVel());
-	ignition::math::Vector3d vel_n = q_ng.RotateVector(model_->WorldLinearVel());
-	ignition::math::Vector3d omega_nb_b = q_br.RotateVector(model_->RelativeAngularVel());
+  ignition::math::Vector3d pos_g = model_->WorldPose().Pos();
 #else
-	ignition::math::Vector3d vel_b = q_br.RotateVector(ignitionFromGazeboMath(model_->GetRelativeLinearVel()));
-	ignition::math::Vector3d vel_n = q_ng.RotateVector(ignitionFromGazeboMath(model_->GetWorldLinearVel()));
-	ignition::math::Vector3d omega_nb_b = q_br.RotateVector(ignitionFromGazeboMath(model_->GetRelativeAngularVel()));
+  ignition::math::Vector3d pos_g = ignitionFromGazeboMath(model_->GetWorldPose().pos);
+#endif
+  ignition::math::Vector3d pos_n = q_ng.RotateVector(pos_g);
+
+  float declination = get_mag_declination(groundtruth_lat_rad, groundtruth_lon_rad);
+
+  ignition::math::Quaterniond q_dn(0.0, 0.0, declination);
+  ignition::math::Vector3d mag_n = q_dn.RotateVector(mag_d_);
+
+#if GAZEBO_MAJOR_VERSION >= 9
+  ignition::math::Vector3d vel_b = q_br.RotateVector(model_->RelativeLinearVel());
+  ignition::math::Vector3d vel_n = q_ng.RotateVector(model_->WorldLinearVel());
+  ignition::math::Vector3d omega_nb_b = q_br.RotateVector(model_->RelativeAngularVel());
+#else
+  ignition::math::Vector3d vel_b = q_br.RotateVector(ignitionFromGazeboMath(model_->GetRelativeLinearVel()));
+  ignition::math::Vector3d vel_n = q_ng.RotateVector(ignitionFromGazeboMath(model_->GetWorldLinearVel()));
+  ignition::math::Vector3d omega_nb_b = q_br.RotateVector(ignitionFromGazeboMath(model_->GetRelativeAngularVel()));
 #endif
 
-	ignition::math::Vector3d mag_noise_b(
-		0.01 * randn_(rand_),
-		0.01 * randn_(rand_),
-		0.01 * randn_(rand_));
+  ignition::math::Vector3d mag_noise_b(
+    0.01 * randn_(rand_),
+    0.01 * randn_(rand_),
+    0.01 * randn_(rand_));
 
-	ignition::math::Vector3d accel_b = q_br.RotateVector(ignition::math::Vector3d(
-		last_imu_message_.linear_acceleration().x(),
-		last_imu_message_.linear_acceleration().y(),
-		last_imu_message_.linear_acceleration().z()));
-	ignition::math::Vector3d gyro_b = q_br.RotateVector(ignition::math::Vector3d(
-		last_imu_message_.angular_velocity().x(),
-		last_imu_message_.angular_velocity().y(),
-		last_imu_message_.angular_velocity().z()));
-	ignition::math::Vector3d mag_b = q_nb.RotateVectorReverse(mag_n) + mag_noise_b;
+  ignition::math::Vector3d accel_b = q_br.RotateVector(ignition::math::Vector3d(
+    last_imu_message_.linear_acceleration().x(),
+    last_imu_message_.linear_acceleration().y(),
+    last_imu_message_.linear_acceleration().z()));
+  ignition::math::Vector3d gyro_b = q_br.RotateVector(ignition::math::Vector3d(
+    last_imu_message_.angular_velocity().x(),
+    last_imu_message_.angular_velocity().y(),
+    last_imu_message_.angular_velocity().z()));
+  ignition::math::Vector3d mag_b = q_nb.RotateVectorReverse(mag_n) + mag_noise_b;
 
   bool should_send_imu = false;
   if (!enable_lockstep_) {

--- a/src/gazebo_mavlink_interface.cpp
+++ b/src/gazebo_mavlink_interface.cpp
@@ -378,7 +378,7 @@ void GazeboMavlinkInterface::OnUpdate(const common::UpdateInfo&  /*_info*/) {
 
   handle_control(dt);
 
-  if (received_first_referenc_) {
+  if (received_first_actuator_) {
     mav_msgs::msgs::CommandMotorSpeed turning_velocities_msg;
 
     for (int i = 0; i < input_reference_.size(); i++) {
@@ -937,7 +937,7 @@ void GazeboMavlinkInterface::handle_message(mavlink_message_t *msg)
       }
     }
 
-    received_first_referenc_ = true;
+    received_first_actuator_ = true;
     break;
   }
 }

--- a/worlds/delta_wing.world
+++ b/worlds/delta_wing.world
@@ -28,9 +28,9 @@
           <contact_surface_layer>0.001</contact_surface_layer>
         </constraints>
       </ode>
-      <max_step_size>0.002</max_step_size>
+      <max_step_size>0.004</max_step_size>
       <real_time_factor>1</real_time_factor>
-      <real_time_update_rate>500</real_time_update_rate>
+      <real_time_update_rate>250</real_time_update_rate>
       <magnetic_field>6.0e-6 2.3e-5 -4.2e-5</magnetic_field>
     </physics>
     <!--

--- a/worlds/empty.world
+++ b/worlds/empty.world
@@ -28,9 +28,9 @@
           <contact_surface_layer>0.001</contact_surface_layer>
         </constraints>
       </ode>
-      <max_step_size>0.002</max_step_size>
+      <max_step_size>0.004</max_step_size>
       <real_time_factor>1</real_time_factor>
-      <real_time_update_rate>500</real_time_update_rate>
+      <real_time_update_rate>250</real_time_update_rate>
       <magnetic_field>6.0e-6 2.3e-5 -4.2e-5</magnetic_field>
     </physics>
   </world>

--- a/worlds/hippocampus.world
+++ b/worlds/hippocampus.world
@@ -40,9 +40,9 @@
           <contact_surface_layer>0.001</contact_surface_layer>
         </constraints>
       </ode>
-      <max_step_size>0.002</max_step_size>
+      <max_step_size>0.004</max_step_size>
       <real_time_factor>1</real_time_factor>
-      <real_time_update_rate>500</real_time_update_rate>
+      <real_time_update_rate>250</real_time_update_rate>
       <magnetic_field>6.0e-6 2.3e-5 -4.2e-5</magnetic_field>
     </physics>
   </world>

--- a/worlds/iris.world
+++ b/worlds/iris.world
@@ -33,9 +33,9 @@
           <contact_surface_layer>0.001</contact_surface_layer>
         </constraints>
       </ode>
-      <max_step_size>0.002</max_step_size>
+      <max_step_size>0.004</max_step_size>
       <real_time_factor>1</real_time_factor>
-      <real_time_update_rate>500</real_time_update_rate>
+      <real_time_update_rate>250</real_time_update_rate>
       <magnetic_field>6.0e-6 2.3e-5 -4.2e-5</magnetic_field>
     </physics>
     <gui fullscreen='0'>

--- a/worlds/iris_fpv_cam.world
+++ b/worlds/iris_fpv_cam.world
@@ -28,9 +28,9 @@
           <contact_surface_layer>0.001</contact_surface_layer>
         </constraints>
       </ode>
-      <max_step_size>0.002</max_step_size>
+      <max_step_size>0.004</max_step_size>
       <real_time_factor>1</real_time_factor>
-      <real_time_update_rate>500</real_time_update_rate>
+      <real_time_update_rate>250</real_time_update_rate>
       <magnetic_field>6.0e-6 2.3e-5 -4.2e-5</magnetic_field>
     </physics>
     <gui fullscreen='0'>

--- a/worlds/iris_irlock.world
+++ b/worlds/iris_irlock.world
@@ -32,9 +32,9 @@
           <contact_surface_layer>0.001</contact_surface_layer>
         </constraints>
       </ode>
-      <max_step_size>0.002</max_step_size>
+      <max_step_size>0.004</max_step_size>
       <real_time_factor>1</real_time_factor>
-      <real_time_update_rate>500</real_time_update_rate>
+      <real_time_update_rate>250</real_time_update_rate>
       <magnetic_field>6.0e-6 2.3e-5 -4.2e-5</magnetic_field>
     </physics>
 

--- a/worlds/iris_opt_flow.world
+++ b/worlds/iris_opt_flow.world
@@ -33,9 +33,9 @@
           <contact_surface_layer>0.001</contact_surface_layer>
         </constraints>
       </ode>
-      <max_step_size>0.002</max_step_size>
+      <max_step_size>0.004</max_step_size>
       <real_time_factor>1</real_time_factor>
-      <real_time_update_rate>500</real_time_update_rate>
+      <real_time_update_rate>250</real_time_update_rate>
       <magnetic_field>6.0e-6 2.3e-5 -4.2e-5</magnetic_field>
     </physics>
     <gui fullscreen='0'>

--- a/worlds/iris_rplidar.world
+++ b/worlds/iris_rplidar.world
@@ -32,9 +32,9 @@
           <contact_surface_layer>0.001</contact_surface_layer>
         </constraints>
       </ode>
-      <max_step_size>0.002</max_step_size>
+      <max_step_size>0.004</max_step_size>
       <real_time_factor>1</real_time_factor>
-      <real_time_update_rate>500</real_time_update_rate>
+      <real_time_update_rate>250</real_time_update_rate>
       <magnetic_field>6.0e-6 2.3e-5 -4.2e-5</magnetic_field>
     </physics>
     <!--

--- a/worlds/iris_vision.world
+++ b/worlds/iris_vision.world
@@ -33,9 +33,9 @@
           <contact_surface_layer>0.001</contact_surface_layer>
         </constraints>
       </ode>
-      <max_step_size>0.002</max_step_size>
+      <max_step_size>0.004</max_step_size>
       <real_time_factor>1</real_time_factor>
-      <real_time_update_rate>500</real_time_update_rate>
+      <real_time_update_rate>250</real_time_update_rate>
       <magnetic_field>6.0e-6 2.3e-5 -4.2e-5</magnetic_field>
     </physics>
     <gui fullscreen='0'>

--- a/worlds/matrice_100.world
+++ b/worlds/matrice_100.world
@@ -28,9 +28,9 @@
           <contact_surface_layer>0.001</contact_surface_layer>
         </constraints>
       </ode>
-      <max_step_size>0.002</max_step_size>
+      <max_step_size>0.004</max_step_size>
       <real_time_factor>1</real_time_factor>
-      <real_time_update_rate>500</real_time_update_rate>
+      <real_time_update_rate>250</real_time_update_rate>
       <magnetic_field>6.0e-6 2.3e-5 -4.2e-5</magnetic_field>
     </physics>
   </world>

--- a/worlds/matrice_100_opt_flow.world
+++ b/worlds/matrice_100_opt_flow.world
@@ -28,9 +28,9 @@
           <contact_surface_layer>0.001</contact_surface_layer>
         </constraints>
       </ode>
-      <max_step_size>0.002</max_step_size>
+      <max_step_size>0.004</max_step_size>
       <real_time_factor>1</real_time_factor>
-      <real_time_update_rate>500</real_time_update_rate>
+      <real_time_update_rate>250</real_time_update_rate>
       <magnetic_field>6.0e-6 2.3e-5 -4.2e-5</magnetic_field>
     </physics>
   </world>

--- a/worlds/rover.world
+++ b/worlds/rover.world
@@ -31,9 +31,9 @@
           <contact_surface_layer>0.001</contact_surface_layer>
         </constraints>
       </ode>
-      <max_step_size>0.002</max_step_size>
+      <max_step_size>0.004</max_step_size>
       <real_time_factor>1</real_time_factor>
-      <real_time_update_rate>500</real_time_update_rate>
+      <real_time_update_rate>250</real_time_update_rate>
       <magnetic_field>6.0e-6 2.3e-5 -4.2e-5</magnetic_field>
     </physics>
     <gui fullscreen='0'>

--- a/worlds/solo.world
+++ b/worlds/solo.world
@@ -31,9 +31,9 @@
           <contact_surface_layer>0.001</contact_surface_layer>
         </constraints>
       </ode>
-      <max_step_size>0.002</max_step_size>
+      <max_step_size>0.004</max_step_size>
       <real_time_factor>1</real_time_factor>
-      <real_time_update_rate>500</real_time_update_rate>
+      <real_time_update_rate>250</real_time_update_rate>
       <magnetic_field>6.0e-6 2.3e-5 -4.2e-5</magnetic_field>
     </physics>
     <!--

--- a/worlds/standard_vtol.world
+++ b/worlds/standard_vtol.world
@@ -28,9 +28,9 @@
           <contact_surface_layer>0.001</contact_surface_layer>
         </constraints>
       </ode>
-      <max_step_size>0.00125</max_step_size>
+      <max_step_size>0.004</max_step_size>
       <real_time_factor>1</real_time_factor>
-      <real_time_update_rate>800</real_time_update_rate>
+      <real_time_update_rate>250</real_time_update_rate>
       <magnetic_field>6.0e-6 2.3e-5 -4.2e-5</magnetic_field>
     </physics>
     <!--

--- a/worlds/tiltrotor.world
+++ b/worlds/tiltrotor.world
@@ -28,9 +28,9 @@
           <contact_surface_layer>0.001</contact_surface_layer>
         </constraints>
       </ode>
-      <max_step_size>0.00125</max_step_size>
+      <max_step_size>0.004</max_step_size>
       <real_time_factor>1</real_time_factor>
-      <real_time_update_rate>800</real_time_update_rate>
+      <real_time_update_rate>250</real_time_update_rate>
       <magnetic_field>6.0e-6 2.3e-5 -4.2e-5</magnetic_field>
     </physics>
   </world>

--- a/worlds/typhoon_h480.world
+++ b/worlds/typhoon_h480.world
@@ -34,9 +34,9 @@
           <contact_surface_layer>0.001</contact_surface_layer>
         </constraints>
       </ode>
-      <max_step_size>0.002</max_step_size>
+      <max_step_size>0.004</max_step_size>
       <real_time_factor>1</real_time_factor>
-      <real_time_update_rate>500</real_time_update_rate>
+      <real_time_update_rate>250</real_time_update_rate>
       <magnetic_field>6.0e-6 2.3e-5 -4.2e-5</magnetic_field>
     </physics>
   </world>

--- a/worlds/uneven.world
+++ b/worlds/uneven.world
@@ -25,9 +25,9 @@
           <contact_surface_layer>0.001</contact_surface_layer>
         </constraints>
       </ode>
-      <max_step_size>0.002</max_step_size>
+      <max_step_size>0.004</max_step_size>
       <real_time_factor>1</real_time_factor>
-      <real_time_update_rate>500</real_time_update_rate>
+      <real_time_update_rate>250</real_time_update_rate>
       <magnetic_field>6.0e-6 2.3e-5 -4.2e-5</magnetic_field>
     </physics>
   </world>

--- a/worlds/warehouse.world
+++ b/worlds/warehouse.world
@@ -28,9 +28,9 @@
           <contact_surface_layer>0.001</contact_surface_layer>
         </constraints>
       </ode>
-      <max_step_size>0.002</max_step_size>
+      <max_step_size>0.004</max_step_size>
       <real_time_factor>1</real_time_factor>
-      <real_time_update_rate>500</real_time_update_rate>
+      <real_time_update_rate>250</real_time_update_rate>
       <magnetic_field>6.0e-6 2.3e-5 -4.2e-5</magnetic_field>
     </physics>
 


### PR DESCRIPTION
These are the changes required to get lockstep running with PX4.
https://github.com/PX4/Firmware/pull/10648

This adds the option for lockstep simulation. Lockstep is off be default
unless `enable_lockstep` is set to true in the vehicle's SDF file.

Basically, lockstep means that PX4 is "stepped" forward by each
hil_sensor MAVLink message containing a timestamp which is then the time
set for PX4. Then, this plugin waits for the actuator_control message
coming back from PX4. Once that has arrived, we move on which means we
resume the simulation to get a new IMU sample.

Therefore there are two locations where we wait:
1. In `OnUpdate` we wait for the next IMU sample in case the callback
   for the IMU message subscription has not triggered yet.
2. Then later in `OnUpdate` we wait for the actuator control message to
   come back from PX4. Basically we use `poll` and `recv` until we have
   parsed the message that we're looking for.

Note that we "freewheel", so we send hil_sensor messages without waiting
for actuator_control messages for initialization until PX4 starts
sending actuator_control messages. Once we have received the first
control message, we start the "lockstepping".