### PR TITLE
gazebo_mavlink_interface: don't abort on timeout

### DIFF
--- a/src/gazebo_mavlink_interface.cpp
+++ b/src/gazebo_mavlink_interface.cpp
@@ -1015,8 +1015,7 @@ void GazeboMavlinkInterface::pollForMAVLinkMessages()
     int ret = ::poll(&fds_[0], 1, timeout_ms);
 
     if (ret == 0 && timeout_ms > 0) {
-      gzerr << "poll timeout, aborting\n";
-      abort();
+      gzerr << "poll timeout\n";
     }
 
     if (ret < 0) {


### PR DESCRIPTION
It was probably not a good idea to abort on timeout. This lead to CI failures when the startup was slower than expected and the timeout would get triggered.

Should fix https://github.com/PX4/Firmware/issues/11144.