### PR TITLE
Fix building on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ option(BUILD_GSTREAMER_PLUGIN "enable gstreamer plugin" "OFF")
 option(BUILD_ROS_INTERFACE "Enable building ROS dependent plugins" "OFF")
 
 ## System dependencies are found with CMake's conventions
-find_package(Boost 1.58 REQUIRED COMPONENTS system thread timer)
+find_package(Boost 1.58 REQUIRED COMPONENTS system thread timer filesystem)
 find_package(gazebo REQUIRED)
 find_package(PkgConfig REQUIRED)
 find_program(px4 REQUIRED)


### PR DESCRIPTION
When I do `make posix_sitl_default gazebo` in PX4 on macOS Mojave, I get:

```
  "boost::filesystem::detail::remove_all(boost::filesystem::path const&, boost::system::error_code*)", referenced from:
      boost::filesystem::remove_all(boost::filesystem::path const&) in gazebo_geotagged_images_plugin.cpp.o
  "boost::filesystem::detail::create_directory(boost::filesystem::path const&, boost::system::error_code*)", referenced from:
      boost::filesystem::create_directory(boost::filesystem::path const&) in gazebo_geotagged_images_plugin.cpp.o
  "boost::filesystem::detail::space(boost::filesystem::path const&, boost::system::error_code*)", referenced from:
      boost::filesystem::space(boost::filesystem::path const&) in gazebo_geotagged_images_plugin.cpp.o
ld: symbol(s) not found for architecture x86_64
```

This commit fixes it.