### PR TITLE
turn on video streaming plugin by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ include(GNUInstallDirs)
 list(APPEND CMAKE_MODULE_PATH /usr/local/share/cmake/Modules)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 
-option(BUILD_GSTREAMER_PLUGIN "enable gstreamer plugin" OFF)
+option(BUILD_GSTREAMER_PLUGIN "enable gstreamer plugin" ON)
 option(BUILD_ROS_INTERFACE "Enable building ROS dependent plugins" OFF)
 
 option(SEND_VISION_ESTIMATION_DATA "Send Mavlink VISION_POSITION_ESTIMATE msgs" OFF)

--- a/models/fpv_cam/fpv_cam.sdf
+++ b/models/fpv_cam/fpv_cam.sdf
@@ -84,6 +84,12 @@
             <distortionT1>0.0</distortionT1>
             <distortionT2>0.0</distortionT2>
           </plugin>
+          <!-- GStreamer camera plugin (needs a lot of CPU! Consider lowering the
+             camera image size) -->
+          <plugin name="GstCameraPlugin" filename="libgazebo_gst_camera_plugin.so">
+            <robotNamespace></robotNamespace>
+            <udpPort>5600</udpPort>
+          </plugin>
         </sensor>
         <self_collide>0</self_collide>
         <kinematic>0</kinematic>

--- a/models/geotagged_cam/geotagged_cam.sdf
+++ b/models/geotagged_cam/geotagged_cam.sdf
@@ -35,6 +35,10 @@
         <always_on>1</always_on>
         <update_rate>5</update_rate>
         <visualize>false</visualize>
+        <plugin name="GstCameraPlugin" filename="libgazebo_gst_camera_plugin.so">
+            <robotNamespace></robotNamespace>
+            <udpPort>5600</udpPort>
+        </plugin>
         <plugin name="GeotaggedImagesPlugin" filename="libgazebo_geotagged_images_plugin.so">
           <robotNamespace></robotNamespace>
           <interval>1</interval>

--- a/package.xml
+++ b/package.xml
@@ -42,6 +42,7 @@
   <build_depend>eigen</build_depend>
   <build_depend>gazebo_ros</build_depend>
   <build_depend>geometry_msgs</build_depend>
+  <build_depend>libgstreamer-plugins-base1.0-dev</build_depend>
   <build_depend>mavlink</build_depend>
   <build_depend>mavros</build_depend>
   <build_depend>mavros_msgs</build_depend>
@@ -54,6 +55,9 @@
   <run_depend>eigen</run_depend>
   <run_depend>gazebo_ros</run_depend>
   <run_depend>geometry_msgs</run_depend>
+  <run_depend>gstreamer1.0-plugins-bad</run_depend>
+  <run_depend>gstreamer1.0-plugins-good</run_depend>
+  <run_depend>gstreamer1.0-plugins-ugly</run_depend>
   <run_depend>mavlink</run_depend>
   <run_depend>mavros</run_depend>
   <run_depend>mavros_msgs</run_depend>

--- a/worlds/typhoon_h480.world
+++ b/worlds/typhoon_h480.world
@@ -1,9 +1,9 @@
 <?xml version="1.0" ?>
 <sdf version="1.5">
   <world name="default">
-    <!--<gui>
+    <gui>
       <plugin name="video_widget" filename="libgazebo_video_stream_widget.so"/>
-    </gui>-->
+    </gui>
     <!-- A global light source -->
     <include>
       <uri>model://sun</uri>


### PR DESCRIPTION
This is a restoration of the "temporary" removal in https://github.com/PX4/sitl_gazebo/pull/148

turn on gui streaming buttons

add gstreamer plugins as a declared dependency

I added the necessary dependencies into the package.xml dependencies but there might be somewhere that this needs to be baked into the CI images if they don't used rosdep automatically.