### PR TITLE
models: plane: split up, adding plane_cam

### DIFF
--- a/models/geotagged_cam/geotagged_cam.sdf
+++ b/models/geotagged_cam/geotagged_cam.sdf
@@ -1,0 +1,47 @@
+<?xml version="1.0"?>
+<sdf version="1.5">
+  <model name="geotagged_cam">
+    <link name="camera_link">
+      <inertial>
+        <!-- place holder -->
+        <pose>-0.041 0 -0.162 0 0 0</pose>
+        <mass>0.1</mass>
+        <inertia>
+          <ixx>0.001</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>0.001</iyy>
+          <iyz>0</iyz>
+          <izz>0.001</izz>
+        </inertia>
+      </inertial>
+      <sensor name="camera_imu" type="imu">
+        <always_on>1</always_on>
+      </sensor>
+      <sensor name="camera" type="camera">
+        <pose>-0.051 0 -0.162 0 0 3.14159</pose>
+        <camera>
+          <horizontal_fov>1.0</horizontal_fov>
+          <image>
+            <format>R8G8B8</format>
+            <width>640</width>
+            <height>360</height>
+          </image>
+          <clip>
+            <near>0.05</near>
+            <far>15000</far>
+          </clip>
+        </camera>
+        <always_on>1</always_on>
+        <update_rate>5</update_rate>
+        <visualize>false</visualize>
+        <plugin name="GeotaggedImagesPlugin" filename="libgazebo_geotagged_images_plugin.so">
+          <robotNamespace></robotNamespace>
+          <interval>1</interval>
+          <width>3840</width>
+          <height>2160</height>
+        </plugin>
+      </sensor>
+    </link>
+  </model>
+</sdf>

--- a/models/geotagged_cam/model.config
+++ b/models/geotagged_cam/model.config
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<model>
+  <name>geotagged_cam</name>
+  <version>1.0</version>
+  <sdf version="1.5">geotagged_cam.sdf</sdf>
+  <description>
+    Camera with geotagged images plugin
+  </description>
+</model>

--- a/models/plane/plane.sdf
+++ b/models/plane/plane.sdf
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <sdf version='1.5'>
   <model name='plane'>
     <pose>0 0 0.246 0 0 0</pose>
@@ -86,48 +87,6 @@
         <use_parent_model_frame>1</use_parent_model_frame>
       </axis>
     </joint>
-    <link name="camera_link">
-      <inertial>
-        <!-- place holder -->
-        <pose>-0.041 0 -0.162 0 0 0</pose>
-        <mass>0.1</mass>
-        <inertia>
-          <ixx>0.001</ixx>
-          <ixy>0</ixy>
-          <ixz>0</ixz>
-          <iyy>0.001</iyy>
-          <iyz>0</iyz>
-          <izz>0.001</izz>
-        </inertia>
-      </inertial>
-      <sensor name="camera_imu" type="imu">
-        <always_on>1</always_on>
-      </sensor>
-      <sensor name="camera" type="camera">
-        <pose>-0.051 0 -0.162 0 0 3.14159</pose>
-        <camera>
-          <horizontal_fov>1.0</horizontal_fov>
-          <image>
-            <format>R8G8B8</format>
-            <width>640</width>
-            <height>360</height>
-          </image>
-          <clip>
-            <near>0.05</near>
-            <far>15000</far>
-          </clip>
-        </camera>
-        <always_on>1</always_on>
-        <update_rate>5</update_rate>
-        <visualize>false</visualize>
-        <plugin name="GeotaggedImagesPlugin" filename="libgazebo_geotagged_images_plugin.so">
-            <robotNamespace></robotNamespace>
-            <interval>1</interval>
-            <width>3840</width>
-            <height>2160</height>
-        </plugin>
-      </sensor>
-    </link>
     <link name='rotor_puller'>
       <pose>0.3 0 0.0 0 1.57 0</pose>
       <inertial>

--- a/models/plane_cam/model.config
+++ b/models/plane_cam/model.config
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<model>
+  <name>plane_cam</name>
+  <version>1.0</version>
+  <sdf version='1.5'>plane_cam.sdf</sdf>
+  <description>
+    This is a model of a standard plane with a camera
+  </description>  
+</model>

--- a/models/plane_cam/plane_cam.sdf
+++ b/models/plane_cam/plane_cam.sdf
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<sdf version='1.5'>
+  <model name='plane_cam'>
+    <include>
+      <uri>model://plane</uri>
+    </include>
+    <!--geotagged images camera-->
+    <include>
+      <uri>model://geotagged_cam</uri>
+      <pose>0 0 0 0 0 0</pose>
+    </include>
+    <joint name="geotagged_cam_joint" type="fixed">
+      <parent>plane::base_link</parent>
+      <child>geotagged_cam::camera_link</child>
+    </joint>
+  </model>
+</sdf>


### PR DESCRIPTION
See #269. 

What I did:
- Broke the camera out into its own model, `geotagged_cam` (if you have a better name, let me know)
- Removed the camera from the plane model
- Added a new model for the plane with a camera -- creatively named `plane_cam`. This model inherits from `plane` and includes the `geotagged_cam`.

It loads and flies. I'm not familiar with the plugin or how to use it (`gazebo_geotagged_images_plugin`). I have no experience with imaging sensors in Gazebo. It would be great to get someone who does to look at this.