### PR TITLE
CMakeLists: install package.xml

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -401,6 +401,8 @@ install(FILES ${worlds_list} DESTINATION ${RESOURCE_PATH}/worlds)
 configure_file(src/setup.sh.in "${CMAKE_CURRENT_BINARY_DIR}/setup.sh" @ONLY)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/setup.sh DESTINATION ${RESOURCE_PATH})
 
+install(FILES ${PROJECT_SOURCE_DIR}/package.xml DESTINATION ${RESOURCE_PATH})
+
 #############
 ## Testing ##
 #############


### PR DESCRIPTION
Addresses https://github.com/colcon/colcon-ros/issues/46#issuecomment-459783679. This fixes the install process of `sitl_gazebo` and allows to use the package correctly inside a ROS context.