### PR TITLE
create a plane_cam world

### DIFF
--- a/worlds/plane_cam.world
+++ b/worlds/plane_cam.world
@@ -1,0 +1,50 @@
+<?xml version="1.0" ?>
+<sdf version="1.5">
+  <world name="default">
+    <!-- A global light source -->
+    <include>
+      <uri>model://sun</uri>
+    </include>
+    <!-- A ground plane -->
+    <include>
+      <uri>model://ground_plane</uri>
+    </include>
+    <include>
+      <uri>model://plane_cam</uri>
+    </include>
+    <physics name='default_physics' default='0' type='ode'>
+      <gravity>0 0 -9.8066</gravity>
+      <ode>
+        <solver>
+          <type>quick</type>
+          <iters>10</iters>
+          <sor>1.3</sor>
+          <use_dynamic_moi_rescaling>0</use_dynamic_moi_rescaling>
+        </solver>
+        <constraints>
+          <cfm>0</cfm>
+          <erp>0.2</erp>
+          <contact_max_correcting_vel>100</contact_max_correcting_vel>
+          <contact_surface_layer>0.001</contact_surface_layer>
+        </constraints>
+      </ode>
+      <max_step_size>0.004</max_step_size>
+      <real_time_factor>1</real_time_factor>
+      <real_time_update_rate>250</real_time_update_rate>
+      <magnetic_field>6.0e-6 2.3e-5 -4.2e-5</magnetic_field>
+    </physics>
+    <!--
+    <gui fullscreen='0'>
+      <camera name='user_camera'>
+        <pose>5.4634 -5.46339 2.17586 0 0.275643 2.35619</pose>
+        <view_controller>orbit</view_controller>
+        <projection_type>perspective</projection_type>
+        <track_visual>
+          <name>plane</name>
+          <use_model_frame>1</use_model_frame>
+        </track_visual>
+      </camera>
+    </gui>
+  -->
+  </world>
+</sdf>


### PR DESCRIPTION
This is following up #273 and I would say resolves #269 
Having the world makes it much easier to test out the plane with the camera.

This is an exact copy of the plane world with the plane_cam substituted.