### PR TITLE
Move compass to imu plugin

### DIFF
--- a/include/gazebo_imu_plugin.h
+++ b/include/gazebo_imu_plugin.h
@@ -33,6 +33,8 @@
 
 #include "common.h"
 
+#include <geo_mag_declination.h>
+
 namespace gazebo {
 //typedef const boost::shared_ptr<const sensor_msgs::msgs::Imu> ImuPtr;
 typedef const boost::shared_ptr<const sensor_msgs::msgs::Groundtruth> GtPtr;
@@ -156,6 +158,8 @@ class GazeboImuPlugin : public ModelPlugin {
 
   Eigen::Vector3d gyroscope_turn_on_bias_;
   Eigen::Vector3d accelerometer_turn_on_bias_;
+
+  Eigen::Vector3d mag_noise_;
 
   ImuParameters imu_parameters_;
 

--- a/include/gazebo_imu_plugin.h
+++ b/include/gazebo_imu_plugin.h
@@ -21,7 +21,8 @@
 #include <random>
 
 #include <Eigen/Core>
-#include "Imu.pb.h"
+#include <Groundtruth.pb.h>
+#include <Imu.pb.h>
 #include <gazebo/common/common.hh>
 #include <gazebo/common/Plugin.hh>
 #include <gazebo/gazebo.hh>
@@ -34,6 +35,7 @@
 
 namespace gazebo {
 //typedef const boost::shared_ptr<const sensor_msgs::msgs::Imu> ImuPtr;
+typedef const boost::shared_ptr<const sensor_msgs::msgs::Groundtruth> GtPtr;
 
 // Default values for use with ADIS16448 IMU
 static constexpr double kDefaultAdisGyroscopeNoiseDensity =
@@ -113,14 +115,21 @@ class GazeboImuPlugin : public ModelPlugin {
       const double dt);
 
   void OnUpdate(const common::UpdateInfo&);
+  void GroundtruthCallback(GtPtr&);
 
  private:
   std::string namespace_;
   std::string imu_topic_;
   transport::NodePtr node_handle_;
   transport::PublisherPtr imu_pub_;
+  transport::SubscriberPtr gt_sub_;
   std::string frame_id_;
   std::string link_name_;
+  std::string gt_sub_topic_;
+
+  double groundtruth_lat_rad;
+  double groundtruth_lon_rad;
+  double groundtruth_altitude;
 
   std::default_random_engine random_generator_;
   std::normal_distribution<double> standard_normal_distribution_;
@@ -137,6 +146,7 @@ class GazeboImuPlugin : public ModelPlugin {
   common::Time last_time_;
 
   sensor_msgs::msgs::Imu imu_message_;
+  sensor_msgs::msgs::Groundtruth gt_message_;
 
   ignition::math::Vector3d gravity_W_;
   ignition::math::Vector3d velocity_prev_W_;

--- a/include/gazebo_mavlink_interface.h
+++ b/include/gazebo_mavlink_interface.h
@@ -68,8 +68,6 @@
 #include <mavlink/v2.0/common/mavlink.h>
 #include "msgbuffer.h"
 
-#include <geo_mag_declination.h>
-
 static const uint32_t kDefaultMavlinkUdpPort = 14560;
 static const uint32_t kDefaultMavlinkTcpPort = 4560;
 static const uint32_t kDefaultQGCUdpPort = 14550;
@@ -300,7 +298,6 @@ private:
 
   ignition::math::Vector3d gravity_W_;
   ignition::math::Vector3d velocity_prev_W_;
-  ignition::math::Vector3d mag_d_;
 
   std::default_random_engine rand_;
   std::normal_distribution<float> randn_;

--- a/msgs/Imu.proto
+++ b/msgs/Imu.proto
@@ -11,6 +11,7 @@ message Imu
   repeated float   angular_velocity_covariance = 4 [packed=true];
   required gazebo.msgs.Vector3d linear_acceleration = 5;
   repeated float   linear_acceleration_covariance = 6 [packed=true];
-  required int64 time_usec = 7;
-  required int64 seq = 8;
+  required gazebo.msgs.Vector3d magnetic_field = 7;
+  required int64 time_usec = 8;
+  required int64 seq = 9;
 }


### PR DESCRIPTION
This is proposition to move calculation of magnetic field from `gazebo_mavlink_interface` to `gazebo_imu_plugin` which seems logical and consistent with `pixhawk` internal compass arrangement.
The downside is that compass measurements from imu now depends on `gazebo_gps_plugin`. 
However from [this discussion](https://github.com/PX4/ecl/issues/397) looks like if we don't use GPS we almost sure don't use mag (We use VPE instead)