### PR TITLE
remove shadows

### DIFF
--- a/worlds/delta_wing.world
+++ b/worlds/delta_wing.world
@@ -33,6 +33,9 @@
       <real_time_update_rate>250</real_time_update_rate>
       <magnetic_field>6.0e-6 2.3e-5 -4.2e-5</magnetic_field>
     </physics>
+    <scene>
+      <shadows>false</shadows>
+    </scene>
     <!--
     <gui fullscreen='0'>
       <camera name='user_camera'>

--- a/worlds/empty.world
+++ b/worlds/empty.world
@@ -33,5 +33,8 @@
       <real_time_update_rate>250</real_time_update_rate>
       <magnetic_field>6.0e-6 2.3e-5 -4.2e-5</magnetic_field>
     </physics>
+    <scene>
+      <shadows>false</shadows>
+    </scene>
   </world>
 </sdf>

--- a/worlds/hippocampus.world
+++ b/worlds/hippocampus.world
@@ -45,5 +45,8 @@
       <real_time_update_rate>250</real_time_update_rate>
       <magnetic_field>6.0e-6 2.3e-5 -4.2e-5</magnetic_field>
     </physics>
+    <scene>
+      <shadows>false</shadows>
+    </scene>
   </world>
 </sdf>

--- a/worlds/iris.world
+++ b/worlds/iris.world
@@ -38,6 +38,9 @@
       <real_time_update_rate>250</real_time_update_rate>
       <magnetic_field>6.0e-6 2.3e-5 -4.2e-5</magnetic_field>
     </physics>
+    <scene>
+      <shadows>false</shadows>
+    </scene>
     <gui fullscreen='0'>
       <camera name='user_camera'>
         <pose>-10 0 6 0 0.3 0</pose>

--- a/worlds/iris_fpv_cam.world
+++ b/worlds/iris_fpv_cam.world
@@ -33,6 +33,9 @@
       <real_time_update_rate>250</real_time_update_rate>
       <magnetic_field>6.0e-6 2.3e-5 -4.2e-5</magnetic_field>
     </physics>
+    <scene>
+      <shadows>false</shadows>
+    </scene>
     <gui fullscreen='0'>
       <camera name='user_camera'>
         <pose>-10 0 6 0 0.3 0</pose>

--- a/worlds/iris_irlock.world
+++ b/worlds/iris_irlock.world
@@ -37,6 +37,9 @@
       <real_time_update_rate>250</real_time_update_rate>
       <magnetic_field>6.0e-6 2.3e-5 -4.2e-5</magnetic_field>
     </physics>
+    <scene>
+      <shadows>false</shadows>
+    </scene>
 
     <model name="irlock_beacon">
       <pose>0.5 1.5 0.06 0 0 0</pose>

--- a/worlds/iris_opt_flow.world
+++ b/worlds/iris_opt_flow.world
@@ -38,6 +38,9 @@
       <real_time_update_rate>250</real_time_update_rate>
       <magnetic_field>6.0e-6 2.3e-5 -4.2e-5</magnetic_field>
     </physics>
+    <scene>
+      <shadows>false</shadows>
+    </scene>
     <gui fullscreen='0'>
       <camera name='user_camera'>
         <pose>-10 0 6 0 0.3 0</pose>

--- a/worlds/iris_rplidar.world
+++ b/worlds/iris_rplidar.world
@@ -37,6 +37,9 @@
       <real_time_update_rate>250</real_time_update_rate>
       <magnetic_field>6.0e-6 2.3e-5 -4.2e-5</magnetic_field>
     </physics>
+    <scene>
+      <shadows>false</shadows>
+    </scene>
     <!--
     <gui fullscreen='0'>
       <camera name='user_camera'>

--- a/worlds/iris_vision.world
+++ b/worlds/iris_vision.world
@@ -38,6 +38,9 @@
       <real_time_update_rate>250</real_time_update_rate>
       <magnetic_field>6.0e-6 2.3e-5 -4.2e-5</magnetic_field>
     </physics>
+    <scene>
+      <shadows>false</shadows>
+    </scene>
     <gui fullscreen='0'>
       <camera name='user_camera'>
         <pose>-10 0 6 0 0.3 0</pose>

--- a/worlds/matrice_100.world
+++ b/worlds/matrice_100.world
@@ -33,5 +33,8 @@
       <real_time_update_rate>250</real_time_update_rate>
       <magnetic_field>6.0e-6 2.3e-5 -4.2e-5</magnetic_field>
     </physics>
+    <scene>
+      <shadows>false</shadows>
+    </scene>
   </world>
 </sdf>

--- a/worlds/matrice_100_opt_flow.world
+++ b/worlds/matrice_100_opt_flow.world
@@ -33,5 +33,8 @@
       <real_time_update_rate>250</real_time_update_rate>
       <magnetic_field>6.0e-6 2.3e-5 -4.2e-5</magnetic_field>
     </physics>
+    <scene>
+      <shadows>false</shadows>
+    </scene>
   </world>
 </sdf>

--- a/worlds/plane.world
+++ b/worlds/plane.world
@@ -33,6 +33,9 @@
       <real_time_update_rate>250</real_time_update_rate>
       <magnetic_field>6.0e-6 2.3e-5 -4.2e-5</magnetic_field>
     </physics>
+    <scene>
+      <shadows>false</shadows>
+    </scene>
     <!--
     <gui fullscreen='0'>
       <camera name='user_camera'>

--- a/worlds/plane_cam.world
+++ b/worlds/plane_cam.world
@@ -33,6 +33,9 @@
       <real_time_update_rate>250</real_time_update_rate>
       <magnetic_field>6.0e-6 2.3e-5 -4.2e-5</magnetic_field>
     </physics>
+    <scene>
+      <shadows>false</shadows>
+    </scene>
     <!--
     <gui fullscreen='0'>
       <camera name='user_camera'>

--- a/worlds/rover.world
+++ b/worlds/rover.world
@@ -36,6 +36,9 @@
       <real_time_update_rate>250</real_time_update_rate>
       <magnetic_field>6.0e-6 2.3e-5 -4.2e-5</magnetic_field>
     </physics>
+    <scene>
+      <shadows>false</shadows>
+    </scene>
     <gui fullscreen='0'>
       <camera name='user_camera'>
         <pose>5.4634 -5.46339 2.17586 0 0.275643 2.35619</pose>

--- a/worlds/solo.world
+++ b/worlds/solo.world
@@ -36,6 +36,9 @@
       <real_time_update_rate>250</real_time_update_rate>
       <magnetic_field>6.0e-6 2.3e-5 -4.2e-5</magnetic_field>
     </physics>
+    <scene>
+      <shadows>false</shadows>
+    </scene>
     <!--
     <gui fullscreen='0'>
       <camera name='user_camera'>

--- a/worlds/standard_vtol.world
+++ b/worlds/standard_vtol.world
@@ -33,6 +33,9 @@
       <real_time_update_rate>250</real_time_update_rate>
       <magnetic_field>6.0e-6 2.3e-5 -4.2e-5</magnetic_field>
     </physics>
+    <scene>
+      <shadows>false</shadows>
+    </scene>
     <!--
     <gui fullscreen='0'>
       <camera name='user_camera'>

--- a/worlds/tailsitter.world
+++ b/worlds/tailsitter.world
@@ -33,6 +33,9 @@
       <real_time_update_rate>250</real_time_update_rate>
       <magnetic_field>6.0e-6 2.3e-5 -4.2e-5</magnetic_field>
     </physics>
+    <scene>
+      <shadows>false</shadows>
+    </scene>
     <!--
     <gui fullscreen='0'>
       <camera name='user_camera'>

--- a/worlds/tiltrotor.world
+++ b/worlds/tiltrotor.world
@@ -33,5 +33,8 @@
       <real_time_update_rate>250</real_time_update_rate>
       <magnetic_field>6.0e-6 2.3e-5 -4.2e-5</magnetic_field>
     </physics>
+    <scene>
+      <shadows>false</shadows>
+    </scene>
   </world>
 </sdf>

--- a/worlds/typhoon_h480.world
+++ b/worlds/typhoon_h480.world
@@ -39,5 +39,8 @@
       <real_time_update_rate>250</real_time_update_rate>
       <magnetic_field>6.0e-6 2.3e-5 -4.2e-5</magnetic_field>
     </physics>
+    <scene>
+      <shadows>false</shadows>
+    </scene>
   </world>
 </sdf>

--- a/worlds/uneven.world
+++ b/worlds/uneven.world
@@ -30,5 +30,8 @@
       <real_time_update_rate>250</real_time_update_rate>
       <magnetic_field>6.0e-6 2.3e-5 -4.2e-5</magnetic_field>
     </physics>
+    <scene>
+      <shadows>false</shadows>
+    </scene>
   </world>
 </sdf>

--- a/worlds/warehouse.world
+++ b/worlds/warehouse.world
@@ -33,6 +33,9 @@
       <real_time_update_rate>250</real_time_update_rate>
       <magnetic_field>6.0e-6 2.3e-5 -4.2e-5</magnetic_field>
     </physics>
+    <scene>
+      <shadows>false</shadows>
+    </scene>
 
     <!-- SHELVES -->
     <include>


### PR DESCRIPTION
Fix for https://github.com/PX4/sitl_gazebo/issues/266

I noticed that the world `rubble` is not working. @TSC21 do you know where it's used?
Another thing I noticed is that there are quite a few gazebo core dump when launching from ros. Error in the log:

```bash
(1551081994 550255675) [Err] [gazebo_mavlink_interface.cpp:416] bind failed: Address already in use, aborting
```

@julianoes could it be lockstep related?