### PR TITLE
Add MAVLink forwarding for SDK/MAVROS for Gazebo HITL

### DIFF
--- a/include/gazebo_mavlink_interface.h
+++ b/include/gazebo_mavlink_interface.h
@@ -163,7 +163,8 @@ public:
     groundtruth_altitude(0.0),
     mavlink_udp_port_(kDefaultMavlinkUdpPort),
     mavlink_tcp_port_(kDefaultMavlinkTcpPort),
-    tcp_client_fd_(0),
+    simulator_socket_fd_(0),
+    simulator_tcp_client_fd_(0),
     use_tcp_(false),
     qgc_udp_port_(kDefaultQGCUdpPort),
     serial_enabled_(false),
@@ -317,7 +318,6 @@ private:
   std::default_random_engine random_generator_;
   std::normal_distribution<float> standard_normal_distribution_;
 
-  int _fd;
   struct sockaddr_in local_simulator_addr_;
   socklen_t local_simulator_addr_len_;
   struct sockaddr_in remote_simulator_addr_;
@@ -331,11 +331,10 @@ private:
   in_addr_t mavlink_addr_;
   int mavlink_udp_port_;
   int mavlink_tcp_port_;
-  int tcp_client_fd_;
-  bool use_tcp_ = false;
 
-  in_addr_t qgc_addr_;
-  int qgc_udp_port_;
+  int simulator_socket_fd_;
+  int simulator_tcp_client_fd_;
+  bool use_tcp_ = false;
 
   bool enable_lockstep_ = false;
   double speed_factor_ = 1.0;

--- a/include/gazebo_mavlink_interface.h
+++ b/include/gazebo_mavlink_interface.h
@@ -318,10 +318,10 @@ private:
   std::normal_distribution<float> standard_normal_distribution_;
 
   int _fd;
-  struct sockaddr_in _myaddr;     ///< The locally bound address
-  socklen_t _myaddr_len;
-  struct sockaddr_in _srcaddr;    ///< SITL instance
-  socklen_t _srcaddr_len;
+  struct sockaddr_in local_simulator_addr_;
+  socklen_t local_simulator_addr_len_;
+  struct sockaddr_in remote_simulator_addr_;
+  socklen_t remote_simulator_addr_len_;
   unsigned char _buf[65535];
   struct pollfd fds_[1];
 

--- a/include/gazebo_mavlink_interface.h
+++ b/include/gazebo_mavlink_interface.h
@@ -360,8 +360,8 @@ private:
   int simulator_socket_fd_;
   int simulator_tcp_client_fd_;
 
-  int qgc_socket_fd_;
-  int sdk_socket_fd_;
+  int qgc_socket_fd_ {-1};
+  int sdk_socket_fd_ {-1};
 
   bool enable_lockstep_ = false;
   double speed_factor_ = 1.0;

--- a/include/gazebo_mavlink_interface.h
+++ b/include/gazebo_mavlink_interface.h
@@ -239,6 +239,7 @@ private:
 
   /// \brief Pointer to the update event connection.
   event::ConnectionPtr updateConnection_;
+  event::ConnectionPtr sigIntConnection_;
 
   boost::thread callback_queue_thread_;
   void QueueThread();
@@ -260,6 +261,7 @@ private:
   void SendSensorMessages();
   void handle_control(double _dt);
   bool IsRunning();
+  void onSigInt();
 
   // Serial interface
   void open();
@@ -381,5 +383,7 @@ private:
 
   bool hil_mode_;
   bool hil_state_level_;
+
+  std::atomic<bool> gotSigInt_ {false};
 };
 }

--- a/models/plane/plane.sdf
+++ b/models/plane/plane.sdf
@@ -442,6 +442,8 @@
       <baudRate>921600</baudRate>
       <qgc_addr>INADDR_ANY</qgc_addr>
       <qgc_udp_port>14550</qgc_udp_port>
+      <sdk_addr>INADDR_ANY</sdk_addr>
+      <sdk_udp_port>14540</sdk_udp_port>
       <hil_mode>false</hil_mode>
       <hil_state_level>false</hil_state_level>
       <enable_lockstep>true</enable_lockstep>

--- a/models/rotors_description/urdf/component_snippets.xacro
+++ b/models/rotors_description/urdf/component_snippets.xacro
@@ -160,7 +160,7 @@
   </xacro:macro>
 
   <!-- Macro to add the mavlink interface. -->
-  <xacro:macro name="mavlink_interface_macro" params="namespace imu_sub_topic gps_sub_topic mag_sub_topic baro_sub_topic mavlink_addr mavlink_udp_port mavlink_tcp_port serial_enabled serial_device baudrate qgc_addr qgc_udp_port hil_mode hil_state_level vehicle_is_tailsitter send_vision_estimation send_odometry enable_lockstep use_tcp">
+  <xacro:macro name="mavlink_interface_macro" params="namespace imu_sub_topic gps_sub_topic mag_sub_topic baro_sub_topic mavlink_addr mavlink_udp_port mavlink_tcp_port serial_enabled serial_device baudrate qgc_addr qgc_udp_port sdk_addr sdk_udp_port hil_mode hil_state_level vehicle_is_tailsitter send_vision_estimation send_odometry enable_lockstep use_tcp">
     <gazebo>
       <plugin name="mavlink_interface" filename="libgazebo_mavlink_interface.so">
         <robotNamespace>${namespace}</robotNamespace>
@@ -176,6 +176,8 @@
         <baudRate>$(arg baudrate)</baudRate>
         <qgc_addr>$(arg qgc_addr)</qgc_addr>
         <qgc_udp_port>$(arg qgc_udp_port)</qgc_udp_port>
+        <sdk_addr>$(arg sdk_addr)</sdk_addr>
+        <sdk_udp_port>$(arg sdk_udp_port)</sdk_udp_port>
         <hil_mode>$(arg hil_mode)</hil_mode>
         <hil_state_level>$(arg hil_state_level)</hil_state_level>
         <vehicle_is_tailsitter>$(arg vehicle_is_tailsitter)</vehicle_is_tailsitter>

--- a/models/rotors_description/urdf/iris_base.xacro
+++ b/models/rotors_description/urdf/iris_base.xacro
@@ -13,6 +13,8 @@
   <xacro:arg name='baudrate' default='921600' />
   <xacro:arg name='qgc_addr' default='INADDR_ANY' />
   <xacro:arg name='qgc_udp_port' default='14550' />
+  <xacro:arg name='sdk_addr' default='INADDR_ANY' />
+  <xacro:arg name='sdk_udp_port' default='14540' />
   <xacro:arg name='hil_mode' default='false' />
   <xacro:arg name='hil_state_level' default='false' />
   <xacro:arg name='send_vision_estimation' default='false' />
@@ -90,6 +92,8 @@
     baudrate="$(arg baudrate)"
     qgc_addr="$(arg qgc_addr)"
     qgc_udp_port="$(arg qgc_udp_port)"
+    sdk_addr="$(arg sdk_addr)"
+    sdk_udp_port="$(arg sdk_udp_port)"
     hil_mode="$(arg hil_mode)"
     hil_state_level="$(arg hil_state_level)"
     vehicle_is_tailsitter="$(arg vehicle_is_tailsitter)"

--- a/models/standard_vtol/standard_vtol.sdf
+++ b/models/standard_vtol/standard_vtol.sdf
@@ -897,6 +897,8 @@
       <baudRate>921600</baudRate>
       <qgc_addr>INADDR_ANY</qgc_addr>
       <qgc_udp_port>14550</qgc_udp_port>
+      <sdk_addr>INADDR_ANY</sdk_addr>
+      <sdk_udp_port>14540</sdk_udp_port>
       <hil_mode>false</hil_mode>
       <hil_state_level>false</hil_state_level>
       <enable_lockstep>true</enable_lockstep>

--- a/models/tailsitter/tailsitter.sdf
+++ b/models/tailsitter/tailsitter.sdf
@@ -680,6 +680,8 @@
       <baudRate>921600</baudRate>
       <qgc_addr>INADDR_ANY</qgc_addr>
       <qgc_udp_port>14550</qgc_udp_port>
+      <sdk_addr>INADDR_ANY</sdk_addr>
+      <sdk_udp_port>14540</sdk_udp_port>
       <hil_mode>false</hil_mode>
       <hil_state_level>false</hil_state_level>
       <enable_lockstep>true</enable_lockstep>

--- a/models/tiltrotor/tiltrotor.sdf
+++ b/models/tiltrotor/tiltrotor.sdf
@@ -1033,6 +1033,8 @@
       <baudRate>921600</baudRate>
       <qgc_addr>INADDR_ANY</qgc_addr>
       <qgc_udp_port>14550</qgc_udp_port>
+      <sdk_addr>INADDR_ANY</sdk_addr>
+      <sdk_udp_port>14540</sdk_udp_port>
       <hil_mode>false</hil_mode>
       <hil_state_level>false</hil_state_level>
       <enable_lockstep>true</enable_lockstep>

--- a/models/typhoon_h480/typhoon_h480.sdf
+++ b/models/typhoon_h480/typhoon_h480.sdf
@@ -1358,6 +1358,8 @@
       <baudRate>921600</baudRate>
       <qgc_addr>INADDR_ANY</qgc_addr>
       <qgc_udp_port>14550</qgc_udp_port>
+      <sdk_addr>INADDR_ANY</sdk_addr>
+      <sdk_udp_port>14540</sdk_udp_port>
       <hil_mode>false</hil_mode>
       <hil_state_level>false</hil_state_level>
       <enable_lockstep>true</enable_lockstep>

--- a/src/gazebo_mavlink_interface.cpp
+++ b/src/gazebo_mavlink_interface.cpp
@@ -618,18 +618,22 @@ void GazeboMavlinkInterface::forward_mavlink_message(const mavlink_message_t *me
 
   uint8_t buffer[MAVLINK_MAX_PACKET_LEN];
   int packetlen = mavlink_msg_to_send_buffer(buffer, message);
+  ssize_t len;
+  if (qgc_socket_fd_ > 0) {
+    len = sendto(qgc_socket_fd_, buffer, packetlen, 0, (struct sockaddr *)&remote_qgc_addr_, remote_qgc_addr_len_);
 
-  ssize_t len = sendto(qgc_socket_fd_, buffer, packetlen, 0, (struct sockaddr *)&remote_qgc_addr_, remote_qgc_addr_len_);
-
-  if (len <= 0)
-  {
-    gzerr << "Failed sending mavlink message to QGC: " << strerror(errno) << "\n";
+    if (len <= 0)
+    {
+      gzerr << "Failed sending mavlink message to QGC: " << strerror(errno) << "\n";
+    }
   }
 
-  len = sendto(sdk_socket_fd_, buffer, packetlen, 0, (struct sockaddr *)&remote_sdk_addr_, remote_sdk_addr_len_);
-  if (len <= 0)
-  {
-    gzerr << "Failed sending mavlink message to SDK: " << strerror(errno) << "\n";
+  if (sdk_socket_fd_ > 0) {
+    len = sendto(sdk_socket_fd_, buffer, packetlen, 0, (struct sockaddr *)&remote_sdk_addr_, remote_sdk_addr_len_);
+    if (len <= 0)
+    {
+      gzerr << "Failed sending mavlink message to SDK: " << strerror(errno) << "\n";
+    }
   }
 }
 

--- a/src/gazebo_mavlink_interface.cpp
+++ b/src/gazebo_mavlink_interface.cpp
@@ -442,6 +442,16 @@ void GazeboMavlinkInterface::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf
         abort();
       }
 
+      struct linger nolinger {};
+      nolinger.l_onoff = 1;
+      nolinger.l_linger = 0;
+
+      result = setsockopt(simulator_socket_fd_, SOL_SOCKET, SO_LINGER, &nolinger, sizeof(nolinger));
+      if (result != 0) {
+        gzerr << "setsockopt failed: " << strerror(errno) << ", aborting\n";
+        abort();
+      }
+
       if (bind(simulator_socket_fd_, (struct sockaddr *)&local_simulator_addr_, local_simulator_addr_len_) < 0) {
         gzerr << "bind failed: " << strerror(errno) << ", aborting\n";
         abort();

--- a/src/gazebo_mavlink_interface.cpp
+++ b/src/gazebo_mavlink_interface.cpp
@@ -523,10 +523,10 @@ void GazeboMavlinkInterface::OnUpdate(const common::UpdateInfo&  /*_info*/) {
 
   SendSensorMessages();
 
-  if (!serial_enabled_) {
-    pollForMAVLinkMessages();
-  } else {
+  if (serial_enabled_) {
     pollFromQgcAndSdk();
+  } else {
+    pollForMAVLinkMessages();
   }
 
   handle_control(dt);


### PR DESCRIPTION
This enables MAVLink forwarding on UDP port 14540 for Gazebo HITL.

~The current state is working but has quite a bit of duplication, so I'm planning to refactor this a bit and clean it up.~
I think for the sake of not having too much churn I suggest to merge this as is, and maybe refactor it later.

With this PR Gazebo HITL actually works as described in the docs already :smile:, FYI @hamishwillee.

Also, this disables the `TCP TIME_WAIT` state on gzserver shutdown and resolves #289.