### PR TITLE
Calculate iris inertia from the body colision parameters

### DIFF
--- a/models/rotors_description/urdf/iris.xacro
+++ b/models/rotors_description/urdf/iris.xacro
@@ -31,7 +31,11 @@
 
   <!-- Property Blocks -->
   <xacro:property name="body_inertia">
-    <inertia ixx="0.0347563" ixy="0.0" ixz="0.0" iyy="0.0458929" iyz="0.0" izz="0.0977" /> <!-- [kg.m^2] [kg.m^2] [kg.m^2] [kg.m^2] [kg.m^2] [kg.m^2] -->
+    <inertia 
+    ixx="${1/12 * mass * (body_height * body_height + body_width * body_width)}"
+    iyy="${1/12 * mass * (body_height * body_height + body_width * body_width)}"
+    izz="${1/12 * mass * (body_width * body_width + body_width * body_width)}"    
+    ixy="0.0" ixz="0.0" iyz="0.0" /> <!-- [kg.m^2] [kg.m^2] [kg.m^2] [kg.m^2] [kg.m^2] [kg.m^2] -->
   </xacro:property>
 
   <!-- inertia of a single rotor, assuming it is a cuboid. Height=3mm, width=15mm -->


### PR DESCRIPTION
assuming that the body is homogenic cube.
that fixes impossible inertia matrix as explaned in (question/bug)-possible error on iris inertia matrix #280
that might be not the real inertia, but its better