### PR TITLE
Extend Sonar Model

### DIFF
--- a/models/sonar/model.sdf
+++ b/models/sonar/model.sdf
@@ -25,7 +25,7 @@
         </material>
       </visual>
       <sensor name="sonar" type="sonar">
-        <pose>0 0 0 1.5707 -1.5707 1.5707</pose>
+        <pose>0 0 0 0 1.57 0</pose>
           <sonar>
             <min>0.02</min>
             <max>5.0</max>

--- a/models/sonar/model.sdf
+++ b/models/sonar/model.sdf
@@ -25,7 +25,7 @@
         </material>
       </visual>
       <sensor name="sonar" type="sonar">
-        <pose>0 0 0 0 1.57 0</pose>
+        <pose>0 0 0 0 1.57 0 </pose>
           <sonar>
             <min>0.02</min>
             <max>5.0</max>

--- a/msgs/Range.proto
+++ b/msgs/Range.proto
@@ -1,10 +1,14 @@
 syntax = "proto2";
 package sensor_msgs.msgs;
+import "quaternion.proto";
 
 message Range
 {
   required int64 time_usec       	= 1;
   required float min_distance      	= 2;
   required float max_distance  	 	= 3;
-  required float current_distance     	= 4;
+  required float current_distance   = 4;
+  optional float h_fov 				= 5;
+  optional float v_fov				= 6;
+  optional gazebo.msgs.Quaternion orientation    = 7;
 }

--- a/msgs/Range.proto
+++ b/msgs/Range.proto
@@ -4,11 +4,11 @@ import "quaternion.proto";
 
 message Range
 {
-  required int64 time_usec       	= 1;
-  required float min_distance      	= 2;
-  required float max_distance  	 	= 3;
-  required float current_distance   = 4;
-  optional float h_fov 				= 5;
-  optional float v_fov				= 6;
-  optional gazebo.msgs.Quaternion orientation    = 7;
+  required int64 time_usec                    = 1;
+  required float min_distance                 = 2;
+  required float max_distance                 = 3;
+  required float current_distance             = 4;
+  optional float h_fov                        = 5;
+  optional float v_fov                        = 6;
+  optional gazebo.msgs.Quaternion orientation = 7;
 }

--- a/src/gazebo_mavlink_interface.cpp
+++ b/src/gazebo_mavlink_interface.cpp
@@ -891,15 +891,49 @@ void GazeboMavlinkInterface::OpticalFlowCallback(OpticalFlowPtr& opticalFlow_mes
 }
 
 void GazeboMavlinkInterface::SonarCallback(SonarPtr& sonar_message) {
-  mavlink_distance_sensor_t sensor_msg;
+  mavlink_distance_sensor_t sensor_msg = {};
   sensor_msg.time_boot_ms = sonar_message->time_usec() / 1e3;
   sensor_msg.min_distance = sonar_message->min_distance() * 100.0;
   sensor_msg.max_distance = sonar_message->max_distance() * 100.0;
   sensor_msg.current_distance = sonar_message->current_distance() * 100.0;
+  ignition::math::Quaterniond q_gr = ignition::math::Quaterniond(
+    sonar_message->orientation().w(),
+    sonar_message->orientation().x(),
+    sonar_message->orientation().y(),
+    sonar_message->orientation().z());
+
+  // rotation of the sensor with respect to the vehicle
+  ignition::math::Vector3d euler = q_gr.Euler();
+  int roll = static_cast<int>(round(GetDegrees360(euler.X())));
+  int pitch = static_cast<int>(round(GetDegrees360(euler.Y())));
+  int yaw = static_cast<int>(round(GetDegrees360(euler.Z())));
+  
+
+  if (roll == 0 && pitch == 0 && yaw == 0) {
+    sensor_msg.orientation = 25;  // downward facing
+  } else if (roll == 0 && pitch == 180 && yaw == 0) {
+    sensor_msg.orientation = 24;  // upward facing
+  } else if (roll == 0 && pitch == 90 && yaw == 180) {
+    sensor_msg.orientation = 12;  // backward facing
+  } else if (roll == 0 && pitch == 90  && yaw == 0) {
+    sensor_msg.orientation = 0;  // forward facing
+  } else if (roll == 0 && pitch == 90 && yaw == 90) {
+     sensor_msg.orientation = 6;  // left facing
+  } else if (roll == 0 && pitch == 90 && yaw == -90) {
+     sensor_msg.orientation = 2;  // right facing
+  } else {
+    sensor_msg.orientation = 100;  // custom orientation
+    sensor_msg.q[0] = sonar_message->orientation().w();
+    sensor_msg.q[1] = sonar_message->orientation().x();
+    sensor_msg.q[2] = sonar_message->orientation().y();
+    sensor_msg.q[3] = sonar_message->orientation().z();
+  }
+
   sensor_msg.type = 1;
   sensor_msg.id = 1;
-  sensor_msg.orientation = 0;  // forward facing
   sensor_msg.covariance = 0;
+  sensor_msg.h_fov = sonar_message->h_fov();
+  sensor_msg.v_fov = sonar_message->v_fov();
 
   mavlink_message_t msg;
   mavlink_msg_distance_sensor_encode_chan(1, 200, MAVLINK_COMM_0, &msg, &sensor_msg);

--- a/src/gazebo_mavlink_interface.cpp
+++ b/src/gazebo_mavlink_interface.cpp
@@ -907,7 +907,7 @@ void GazeboMavlinkInterface::SonarCallback(SonarPtr& sonar_message) {
   int roll = static_cast<int>(round(GetDegrees360(euler.X())));
   int pitch = static_cast<int>(round(GetDegrees360(euler.Y())));
   int yaw = static_cast<int>(round(GetDegrees360(euler.Z())));
-  
+
 
   if (roll == 0 && pitch == 0 && yaw == 0) {
     sensor_msg.orientation = 25;  // downward facing
@@ -919,21 +919,21 @@ void GazeboMavlinkInterface::SonarCallback(SonarPtr& sonar_message) {
     sensor_msg.orientation = 0;  // forward facing
   } else if (roll == 0 && pitch == 90 && yaw == 90) {
      sensor_msg.orientation = 6;  // left facing
-  } else if (roll == 0 && pitch == 90 && yaw == -90) {
+  } else if (roll == 0 && pitch == 90 && yaw == 270) {
      sensor_msg.orientation = 2;  // right facing
   } else {
     sensor_msg.orientation = 100;  // custom orientation
-    sensor_msg.q[0] = sonar_message->orientation().w();
-    sensor_msg.q[1] = sonar_message->orientation().x();
-    sensor_msg.q[2] = sonar_message->orientation().y();
-    sensor_msg.q[3] = sonar_message->orientation().z();
+    sensor_msg.quaternion[0] = sonar_message->orientation().w();
+    sensor_msg.quaternion[1] = sonar_message->orientation().x();
+    sensor_msg.quaternion[2] = sonar_message->orientation().y();
+    sensor_msg.quaternion[3] = sonar_message->orientation().z();
   }
 
   sensor_msg.type = 1;
   sensor_msg.id = 1;
   sensor_msg.covariance = 0;
-  sensor_msg.h_fov = sonar_message->h_fov();
-  sensor_msg.v_fov = sonar_message->v_fov();
+  sensor_msg.horizontal_fov = sonar_message->h_fov();
+  sensor_msg.vertical_fov = sonar_message->v_fov();
 
   mavlink_message_t msg;
   mavlink_msg_distance_sensor_encode_chan(1, 200, MAVLINK_COMM_0, &msg, &sensor_msg);

--- a/src/gazebo_sonar_plugin.cpp
+++ b/src/gazebo_sonar_plugin.cpp
@@ -98,5 +98,15 @@ void SonarPlugin::OnNewScans()
   sonar_message.set_max_distance(parentSensor->RangeMax());
   sonar_message.set_current_distance(parentSensor->Range());
 
+  sonar_message.set_h_fov(2.0f * atan(parentSensor->GetRadius() / parentSensor->RangeMax()));
+  sonar_message.set_v_fov(2.0f * atan(parentSensor->GetRadius() / parentSensor->RangeMax()));
+  ignition::math::Quaterniond pose_model_quaternion = parentSensor->Pose().Rot();
+  gazebo::msgs::Quaternion* orientation = new gazebo::msgs::Quaternion();
+  orientation->set_x(pose_model_quaternion.X());
+  orientation->set_y(pose_model_quaternion.Y());
+  orientation->set_z(pose_model_quaternion.Z());
+  orientation->set_w(pose_model_quaternion.W());
+  sonar_message.set_allocated_orientation(orientation);
+
   sonar_pub_->Publish(sonar_message);
 }

--- a/src/gazebo_sonar_plugin.cpp
+++ b/src/gazebo_sonar_plugin.cpp
@@ -98,8 +98,8 @@ void SonarPlugin::OnNewScans()
   sonar_message.set_max_distance(parentSensor->RangeMax());
   sonar_message.set_current_distance(parentSensor->Range());
 
-  sonar_message.set_h_fov(2.0f * atan(parentSensor->GetRadius() / parentSensor->RangeMax()));
-  sonar_message.set_v_fov(2.0f * atan(parentSensor->GetRadius() / parentSensor->RangeMax()));
+  sonar_message.set_h_fov(2.0f * atan(parentSensor->Radius() / parentSensor->RangeMax()));
+  sonar_message.set_v_fov(2.0f * atan(parentSensor->Radius() / parentSensor->RangeMax()));
   ignition::math::Quaterniond pose_model_quaternion = parentSensor->Pose().Rot();
   gazebo::msgs::Quaternion* orientation = new gazebo::msgs::Quaternion();
   orientation->set_x(pose_model_quaternion.X());


### PR DESCRIPTION
These changes enable to run Collision Prevention in simulation with the sonar on the Typhoon h480.
- get fov from sdf file to populate range message
- transform sensor orientation from quaternion into the enum in the mavlink message distance_sensor 