### PR TITLE
distance sensors: by default, get the topic name from the model name

### DIFF
--- a/include/gazebo_lidar_plugin.h
+++ b/include/gazebo_lidar_plugin.h
@@ -44,7 +44,6 @@ namespace gazebo
   static constexpr double kDefaultMinDistance = 0.2;
   static constexpr double kDefaultMaxDistance = 15.0;
   static constexpr double kDefaultFOV = 0.0523598776;   // standard 3 degrees
-  static constexpr auto kDefaultLidarTopic = "lidar";
 
   /// \brief A Ray Sensor Plugin
   class GAZEBO_VISIBLE RayPlugin : public SensorPlugin

--- a/include/gazebo_sonar_plugin.h
+++ b/include/gazebo_sonar_plugin.h
@@ -39,8 +39,6 @@
 
 namespace gazebo
 {
-  static constexpr auto kDefaultSonarTopic = "sonar";
-
   /// \brief A Ray Sensor Plugin
   class GAZEBO_VISIBLE SonarPlugin : public SensorPlugin
   {

--- a/src/gazebo_lidar_plugin.cpp
+++ b/src/gazebo_lidar_plugin.cpp
@@ -90,14 +90,6 @@ void RayPlugin::Load(sensors::SensorPtr _parent, sdf::ElementPtr _sdf)
     max_distance_ = kDefaultMaxDistance;
   }
 
-  // get lidar topic name
-  if(_sdf->HasElement("topic")) {
-    lidar_topic_ = parentSensor_->Topic();
-  } else {
-    lidar_topic_ = kDefaultLidarTopic;
-    gzwarn << "[gazebo_lidar_plugin] Using default lidar topic " << lidar_topic_ << "\n";
-  }
-
   node_handle_ = transport::NodePtr(new transport::Node());
   node_handle_->Init(namespace_);
 
@@ -119,6 +111,16 @@ void RayPlugin::Load(sensors::SensorPtr _parent, sdf::ElementPtr _sdf)
 
   // the second to the last name is the model name
   const std::string parentSensorModelName = names_splitted.rbegin()[1];
+
+  // get lidar topic name
+  if(_sdf->HasElement("topic")) {
+    lidar_topic_ = parentSensor_->Topic();
+  } else {
+    // if not set by parameter, get the topic name from the model name
+    lidar_topic_ = parentSensorModelName;
+    gzwarn << "[gazebo_lidar_plugin]: " + names_splitted.front() + "::" + names_splitted.rbegin()[1] +
+      " using lidar topic \"" << parentSensorModelName << "\"\n";
+  }
 
   // Get the sensor orientation
   const ignition::math::Quaterniond q_bs = getSensorOrientation(rootModel, parentSensorModelName, parentSensor_);

--- a/src/gazebo_sonar_plugin.cpp
+++ b/src/gazebo_sonar_plugin.cpp
@@ -68,14 +68,6 @@ void SonarPlugin::Load(sensors::SensorPtr _parent, sdf::ElementPtr _sdf)
   else
     gzwarn << "[gazebo_sonar_plugin] Please specify a robotNamespace.\n";
 
-  // get sonar topic name
-  if(_sdf->HasElement("topic")) {
-    sonar_topic_ = parentSensor_->Topic();
-  } else {
-    sonar_topic_ = kDefaultSonarTopic;
-    gzwarn << "[gazebo_sonar_plugin] Using default sonar topic " << sonar_topic_ << "\n";
-  }
-
   node_handle_ = transport::NodePtr(new transport::Node());
   node_handle_->Init(namespace_);
 
@@ -97,6 +89,16 @@ void SonarPlugin::Load(sensors::SensorPtr _parent, sdf::ElementPtr _sdf)
 
   // the second to the last name is the model name
   const std::string parentSensorModelName = names_splitted.rbegin()[1];
+
+  // get sonar topic name
+  if(_sdf->HasElement("topic")) {
+    sonar_topic_ = parentSensor_->Topic();
+  } else {
+    // if not set by parameter, get the topic name from the model name
+    sonar_topic_ = parentSensorModelName;
+    gzwarn << "[gazebo_sonar_plugin]: " + names_splitted.front() + "::" + names_splitted.rbegin()[1] +
+      " using sonar topic \"" << parentSensorModelName << "\"\n";
+  }
 
   // Get the sensor orientation
   const ignition::math::Quaterniond q_bs = getSensorOrientation(rootModel, parentSensorModelName, parentSensor_);


### PR DESCRIPTION
With this, if the topic is not set inside the SDF model, it is instead determined by the model name itself. This allows adding multiple sensors of the same type to the same vehicle. The only thing missing is to add the possibility of automatically subscribe to all of the sensor topics and use the same Subscriber Callback for them in the `gazebo_mavlink_interface`.

Example to add multiple sensors of the same type to a vehicle model:
```xml
    <!--lidar0-->
    <include>
      <uri>model://lidar</uri>
      <pose>0 0 -0.05 0 0 0</pose>
      <name>lidar0</name>
    </include>

    <joint name="lidar0_joint" type="fixed">
      <parent>iris::base_link</parent>
      <child>lidar0::link</child>
    </joint>

    <!--lidar1-->
    <include>
      <uri>model://lidar</uri>
      <pose>0 0 -0.15 0 0 0</pose>
      <name>lidar1</name>
    </include>

    <joint name="lidar1_joint" type="fixed">
      <parent>iris::base_link</parent>
      <child>lidar1::link</child>
    </joint>
```