### PR TITLE
Fix typhoon_h480 sonar child link name

### DIFF
--- a/models/typhoon_h480/typhoon_h480.sdf
+++ b/models/typhoon_h480/typhoon_h480.sdf
@@ -1143,7 +1143,7 @@
       <uri>model://sonar</uri>
     </include>
     <joint name="sonar_joint" type="revolute">
-      <child>sonar_model::link</child>
+      <child>sonar::link</child>
       <parent>typhoon_h480::base_link</parent>
       <axis>
         <xyz>0 0 1</xyz>


### PR DESCRIPTION
Currently the typhoon_h480 wasn't loading the sonar plugin due to a mistake in the child link name. This was recently changed in dae0fdeb754392f138563b69a84488f8e1668755 and merged in #339 but it appears to have slipped by. I believe this is the only vehicle using the sonar?

