### PR TITLE
Video stream widget update for Gazebo 9+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,13 +44,18 @@ if (BUILD_GSTREAMER_PLUGIN)
     if("${GAZEBO_VERSION}" VERSION_LESS "8.0")
       find_package (Qt4)
       include (${QT_USE_FILE})
+    else()
+      find_package(Qt5Widgets REQUIRED)
+      find_package(Qt5Core REQUIRED)
+      find_package(Protobuf REQUIRED)
+      find_package(gazebo REQUIRED)
     endif()
   endif()
 endif()
 
 pkg_check_modules(OGRE OGRE)
 
-include_directories(SYSTEM ${GAZEBO_INCLUDE_DIRS})
+include_directories(SYSTEM ${GAZEBO_INCLUDE_DIRS} ${Qt5Core_INCLUDE_DIRS})
 link_directories(${GAZEBO_LIBRARY_DIRS})
 
 add_subdirectory( external/OpticalFlow OpticalFlow )
@@ -367,6 +372,20 @@ if (GSTREAMER_FOUND)
       gazebo_video_stream_widget
     )
     message(STATUS "Found GStreamer: adding gst_video_stream_widget")
+  else()
+    QT5_WRAP_CPP(headers_MOC include/gazebo_video_stream_widget.h)
+    add_library(gazebo_video_stream_widget SHARED ${headers_MOC} src/gazebo_video_stream_widget.cpp)
+    target_link_libraries(gazebo_video_stream_widget ${GAZEBO_LIBRARIES}
+    ${Qt5Core_LIBRARIES}
+    ${Qt5Widgets_LIBRARIES}
+    ${PROTOBUF_LIBRARIES}
+    ${Qt5Test_LIBRARIES})
+    set(plugins
+      ${plugins}
+      gazebo_video_stream_widget
+    )
+    message(STATUS "Found GStreamer: adding gst_video_stream_widget")
+    message("Gazebo version: ${GAZEBO_VERSION}")
   endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,8 +47,6 @@ if (BUILD_GSTREAMER_PLUGIN)
     else()
       find_package(Qt5Widgets REQUIRED)
       find_package(Qt5Core REQUIRED)
-      find_package(Protobuf REQUIRED)
-      find_package(gazebo REQUIRED)
     endif()
   endif()
 endif()
@@ -375,17 +373,12 @@ if (GSTREAMER_FOUND)
   else()
     QT5_WRAP_CPP(headers_MOC include/gazebo_video_stream_widget.h)
     add_library(gazebo_video_stream_widget SHARED ${headers_MOC} src/gazebo_video_stream_widget.cpp)
-    target_link_libraries(gazebo_video_stream_widget ${GAZEBO_LIBRARIES}
-    ${Qt5Core_LIBRARIES}
-    ${Qt5Widgets_LIBRARIES}
-    ${PROTOBUF_LIBRARIES}
-    ${Qt5Test_LIBRARIES})
+    target_link_libraries(gazebo_video_stream_widget ${GAZEBO_LIBRARIES} ${Qt5Core_LIBRARIES} ${Qt5Widgets_LIBRARIES} ${PROTOBUF_LIBRARIES} ${Qt5Test_LIBRARIES})
     set(plugins
       ${plugins}
       gazebo_video_stream_widget
     )
     message(STATUS "Found GStreamer: adding gst_video_stream_widget")
-    message("Gazebo version: ${GAZEBO_VERSION}")
   endif()
 endif()
 

--- a/include/gazebo_video_stream_widget.h
+++ b/include/gazebo_video_stream_widget.h
@@ -19,10 +19,7 @@
 
 #include <gazebo/common/Plugin.hh>
 #include <gazebo/gui/GuiPlugin.hh>
-#ifndef Q_MOC_RUN  // See: https://bugreports.qt-project.org/browse/QTBUG-22829
-# include <gazebo/transport/transport.hh>
-# include <gazebo/gui/gui.hh>
-#endif
+#include <gazebo/transport/transport.hh>
 
 namespace gazebo
 {

--- a/include/gazebo_video_stream_widget.h
+++ b/include/gazebo_video_stream_widget.h
@@ -19,7 +19,14 @@
 
 #include <gazebo/common/Plugin.hh>
 #include <gazebo/gui/GuiPlugin.hh>
+#if GAZEBO_MAJOR_VERSION >= 9
 #include <gazebo/transport/transport.hh>
+#else
+#   ifndef Q_MOC_RUN  // See: https://bugreports.qt-project.org/browse/QTBUG-22829
+#include <gazebo/transport/transport.hh>
+#include <gazebo/gui/gui.hh>
+#   endif
+#endif
 
 namespace gazebo
 {


### PR DESCRIPTION
This PR makes possible the build of `gazebo_video_stream_widget` on gazebo `9` and above, when previously it was only being built for versions of Gazebo less than `8.0`.

It updates the `CMakeLists.txt` to include the required packages and links, as well as the header of `gazebo_video_stream_widget.h`.

Regarding this last part it is possible that it breaks this widget on older versions of gazebo (can't really test right now). Possible solutions would be to find a way to make it built able by all versions or deprecate it for older versions of Gazebo. I'm open to suggestions/help.

Thanks