### PR TITLE
Tune shakey typhoon_h480 gimbal

### DIFF
--- a/models/typhoon_h480/typhoon_h480.sdf
+++ b/models/typhoon_h480/typhoon_h480.sdf
@@ -1575,9 +1575,9 @@
       <control_gimbal_channels>
         <channel>
           <joint_control_pid>
-            <p>1.0</p>
+            <p>0.8</p>
             <i>0.1</i>
-            <d>0.0005</d>
+            <d>0.02</d>
             <iMax>0</iMax>
             <iMin>0</iMin>
             <cmdMax>1.0</cmdMax>


### PR DESCRIPTION
This PR tunes the gain of the gimbal controller so that it is less shakey on the yaw axis. The previous state was not usable to run any survey missions in SITL.

The change is visually observable as the following example where the vehicle is flown in position mode in SITL

After PR:
![after_change](https://user-images.githubusercontent.com/5248102/66855954-7b029880-ef84-11e9-8df6-18b0f037603e.gif)

Before PR:
![before_change](https://user-images.githubusercontent.com/5248102/66855961-7e961f80-ef84-11e9-9846-cdb6f7ebfc60.gif)
