### PR TITLE
Fix camera orientation and visualize camera for plane_cam

### DIFF
--- a/models/geotagged_cam/geotagged_cam.sdf
+++ b/models/geotagged_cam/geotagged_cam.sdf
@@ -34,7 +34,7 @@
         </camera>
         <always_on>1</always_on>
         <update_rate>5</update_rate>
-        <visualize>false</visualize>
+        <visualize>true</visualize>
         <plugin name="GstCameraPlugin" filename="libgazebo_gst_camera_plugin.so">
             <robotNamespace></robotNamespace>
             <udpPort>5600</udpPort>

--- a/models/plane_cam/plane_cam.sdf
+++ b/models/plane_cam/plane_cam.sdf
@@ -7,7 +7,7 @@
     <!--geotagged images camera-->
     <include>
       <uri>model://geotagged_cam</uri>
-      <pose>0 0 0 0 0 0</pose>
+      <pose>0 0 0 0 -1.571 0</pose>
     </include>
     <joint name="geotagged_cam_joint" type="fixed">
       <parent>plane::base_link</parent>


### PR DESCRIPTION
This PR fixes the orientation of the camera attached to the plane_cam model to a more sensible one(looking down) compared to the looking back camera. A camera on a fixed wing plane is more likely to look down for survey missions rather than looking back. 

Also, the visualization of the geotagged camera is turned on. This is to make it more visible to the user that the camera sensor is active, and be consistent with the camera sensor visualization on the `typhoon_h480`