### PR TITLE
Add vtol models with camera

### DIFF
--- a/models/standard_vtol_cam/model.config
+++ b/models/standard_vtol_cam/model.config
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<model>
+  <name>Standard VTOL Camera</name>
+  <version>1.0</version>
+  <sdf version='1.4'>standard_vtol_cam.sdf</sdf>
+
+  <author>
+   <name>Jaeyoung Lim</name>
+   <email>jaeyoung@auterion.com</email>
+  </author>
+
+  <description>
+    This is a model of a standard VTOL quad plane with camera.
+  </description>
+</model>

--- a/models/standard_vtol_cam/standard_vtol_cam.sdf
+++ b/models/standard_vtol_cam/standard_vtol_cam.sdf
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<sdf version='1.5'>
+  <model name='standard_vtol_cam'>
+    <include>
+      <uri>model://standard_vtol</uri>
+    </include>
+    <!--geotagged images camera-->
+    <include>
+      <uri>model://geotagged_cam</uri>
+      <pose>0 0 0.3 0 -1.571 0</pose>
+    </include>
+    <joint name="geotagged_cam_joint" type="fixed">
+      <parent>standard_vtol::base_link</parent>
+      <child>geotagged_cam::camera_link</child>
+    </joint>
+  </model>
+</sdf>

--- a/models/tailsitter_cam/model.config
+++ b/models/tailsitter_cam/model.config
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<model>
+  <name>tailsitter_cam</name>
+  <version>1.0</version>
+  <sdf version='1.4'>tailsitter_cam.sdf</sdf>
+
+  <author>
+   <name>Jaeyoung Lim</name>
+   <email>jaeyoung@auterion.com</email>
+  </author>
+
+  <description>
+    This is a model of a tailsitter with a camera
+  </description>
+</model>

--- a/models/tailsitter_cam/tailsitter_cam.sdf
+++ b/models/tailsitter_cam/tailsitter_cam.sdf
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<sdf version='1.5'>
+  <model name='tailsitter_cam'>
+    <include>
+      <uri>model://tailsitter</uri>
+    </include>
+    <!--geotagged images camera-->
+    <include>
+      <uri>model://geotagged_cam</uri>
+      <pose>0 0 0.6 0 0 0</pose>
+    </include>
+    <joint name="geotagged_cam_joint" type="fixed">
+      <parent>tailsitter::base_link</parent>
+      <child>geotagged_cam::camera_link</child>
+    </joint>
+  </model>
+</sdf>


### PR DESCRIPTION
This PR adds a camera using the `gst-camera-plgugin` on the `standard_vtol` and `tailsitter` vtol models for SITL. This is useful for simulating survey missions with the vehicles


![Screenshot from 2019-10-16 18-17-02](https://user-images.githubusercontent.com/5248102/66954133-16b50700-f060-11e9-84de-64438306ae3e.png)
