### PR TITLE
Fix for issue #359.

### DIFF
--- a/include/gazebo_mavlink_interface.h
+++ b/include/gazebo_mavlink_interface.h
@@ -200,6 +200,7 @@ protected:
 
 private:
   bool received_first_actuator_;
+  bool received_actuator_ = false;
   Eigen::VectorXd input_reference_;
 
   float protocol_version_;
@@ -363,7 +364,14 @@ private:
   socklen_t local_sdk_addr_len_;
 
   unsigned char _buf[65535];
+  enum FD_TYPES {
+    LISTEN_FD,
+    CONNECTION_FD,
+    N_FDS
+  };
+  struct pollfd fds_[N_FDS];
   bool use_tcp_ = false;
+  bool close_conn_ = false;
 
   double optflow_distance;
   double sonar_distance;

--- a/include/gazebo_mavlink_interface.h
+++ b/include/gazebo_mavlink_interface.h
@@ -200,7 +200,6 @@ protected:
 
 private:
   bool received_first_actuator_;
-  bool received_actuator_ = false;
   Eigen::VectorXd input_reference_;
 
   float protocol_version_;

--- a/include/gazebo_mavlink_interface.h
+++ b/include/gazebo_mavlink_interface.h
@@ -259,6 +259,7 @@ private:
   void send_mavlink_message(const mavlink_message_t *message);
   void forward_mavlink_message(const mavlink_message_t *message);
   void handle_message(mavlink_message_t *msg, bool &received_actuator);
+  void acceptConnections();
   void pollForMAVLinkMessages();
   void pollFromQgcAndSdk();
   void SendSensorMessages();

--- a/src/gazebo_mavlink_interface.cpp
+++ b/src/gazebo_mavlink_interface.cpp
@@ -600,11 +600,11 @@ void GazeboMavlinkInterface::OnUpdate(const common::UpdateInfo&  /*_info*/) {
     pollForMAVLinkMessages();
   }
 
-  if (close_conn_) {
+  SendSensorMessages();
+
+  if (close_conn_) { // close connection if required
     close();
   }
-
-  SendSensorMessages();
 
   handle_control(dt);
 

--- a/src/gazebo_mavlink_interface.cpp
+++ b/src/gazebo_mavlink_interface.cpp
@@ -1201,6 +1201,8 @@ void GazeboMavlinkInterface::pollForMAVLinkMessages()
     return;
   }
 
+  bool received_actuator = false;
+
   do {
     int timeout_ms = (received_first_actuator_ && enable_lockstep_) ? 1000 : 0;
     int ret = ::poll(&fds_[0], N_FDS, timeout_ms);
@@ -1252,12 +1254,12 @@ void GazeboMavlinkInterface::pollForMAVLinkMessages()
             if (hil_mode_) {
               send_mavlink_message(&msg);
             }
-            handle_message(&msg, received_actuator_);
+            handle_message(&msg, received_actuator);
           }
         }
       }
     }
-  } while (received_first_actuator_ && !received_actuator_ && enable_lockstep_ && IsRunning() && !gotSigInt_);
+  } while (received_first_actuator_ && !received_actuator && enable_lockstep_ && IsRunning() && !gotSigInt_);
 }
 
 void GazeboMavlinkInterface::acceptConnections()
@@ -1472,7 +1474,6 @@ void GazeboMavlinkInterface::close()
     fds_[CONNECTION_FD] = { 0, 0, 0 };
     fds_[CONNECTION_FD].fd = -1;
 
-    received_actuator_ = false;
     received_first_actuator_ = false;
 
   }

--- a/src/gazebo_mavlink_interface.cpp
+++ b/src/gazebo_mavlink_interface.cpp
@@ -1259,7 +1259,7 @@ void GazeboMavlinkInterface::pollForMAVLinkMessages()
         }
       }
     }
-  } while (received_first_actuator_ && !received_actuator && enable_lockstep_ && IsRunning() && !gotSigInt_);
+  } while (!close_conn_ && received_first_actuator_ && !received_actuator && enable_lockstep_ && IsRunning() && !gotSigInt_);
 }
 
 void GazeboMavlinkInterface::acceptConnections()

--- a/src/gazebo_mavlink_interface.cpp
+++ b/src/gazebo_mavlink_interface.cpp
@@ -514,7 +514,7 @@ void GazeboMavlinkInterface::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf
         abort();
       }
 
-      memset(fds_, 0 , sizeof(fds_));
+      memset(fds_, 0, sizeof(fds_));
       fds_[CONNECTION_FD].fd = simulator_socket_fd_;
       fds_[CONNECTION_FD].events = POLLIN;
     }
@@ -593,6 +593,7 @@ void GazeboMavlinkInterface::OnUpdate(const common::UpdateInfo&  /*_info*/) {
 #endif
   double dt = (current_time - last_time_).Double();
 
+  close_conn_ = false;
   if (hil_mode_) {
     pollFromQgcAndSdk();
   } else {
@@ -1225,7 +1226,6 @@ void GazeboMavlinkInterface::pollForMAVLinkMessages()
           fds_[CONNECTION_FD].events = POLLIN;
         } while (simulator_tcp_client_fd_ <= 0); // we only need one connection
       } else { // recv call
-        close_conn_ = false;
         int ret = recvfrom(fds_[i].fd, _buf, sizeof(_buf), 0, (struct sockaddr *)&remote_simulator_addr_, &remote_simulator_addr_len_);
         if (ret < 0) // disconnected from client
         {

--- a/src/gazebo_mavlink_interface.cpp
+++ b/src/gazebo_mavlink_interface.cpp
@@ -516,7 +516,7 @@ void GazeboMavlinkInterface::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf
 
       memset(fds_, 0, sizeof(fds_));
       fds_[CONNECTION_FD].fd = simulator_socket_fd_;
-      fds_[CONNECTION_FD].events = POLLIN | POLLOUT;
+      fds_[CONNECTION_FD].events = POLLIN | POLLOUT; // read/write
     }
   }
 
@@ -1275,7 +1275,7 @@ void GazeboMavlinkInterface::acceptConnections()
 
     // assign socket to connection descriptor on success
     fds_[CONNECTION_FD].fd = ret; // socket is replaced with latest connection
-    fds_[CONNECTION_FD].events = POLLIN | POLLOUT;
+    fds_[CONNECTION_FD].events = POLLIN | POLLOUT; // read/write
   } while (ret != -1);
 }
 

--- a/src/gazebo_mavlink_interface.cpp
+++ b/src/gazebo_mavlink_interface.cpp
@@ -502,14 +502,21 @@ void GazeboMavlinkInterface::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf
         abort();
       }
 
+      // set socket to non-blocking
+      int result = fcntl(simulator_socket_fd_, F_SETFL, O_NONBLOCK);
+      if (result == -1) {
+        gzerr << "setting socket to non-blocking failed: " << strerror(errno) << ", aborting\n";
+        abort();
+      }
+
       if (bind(simulator_socket_fd_, (struct sockaddr *)&local_simulator_addr_, local_simulator_addr_len_) < 0) {
         gzerr << "bind failed: " << strerror(errno) << ", aborting\n";
         abort();
       }
 
       memset(fds_, 0 , sizeof(fds_));
-      fds_[LISTEN_FD].fd = simulator_socket_fd_;
-      fds_[LISTEN_FD].events = POLLIN;
+      fds_[CONNECTION_FD].fd = simulator_socket_fd_;
+      fds_[CONNECTION_FD].events = POLLIN;
     }
   }
 

--- a/src/gazebo_mavlink_interface.cpp
+++ b/src/gazebo_mavlink_interface.cpp
@@ -1224,7 +1224,7 @@ void GazeboMavlinkInterface::pollForMAVLinkMessages()
 
       if (i == LISTEN_FD) { // if event is raised on the listening socket
         acceptConnections();
-      } else { // recv call
+      } else { // if event is raised on connection socket
         int ret = recvfrom(fds_[i].fd, _buf, sizeof(_buf), 0, (struct sockaddr *)&remote_simulator_addr_, &remote_simulator_addr_len_);
         if (ret < 0) {
           // all data is read if EWOULDBLOCK is raised
@@ -1473,7 +1473,6 @@ void GazeboMavlinkInterface::close()
     received_first_actuator_ = false;
 
   }
-  close_conn_ = false;
 }
 
 void GazeboMavlinkInterface::do_read(void)

--- a/src/gazebo_mavlink_interface.cpp
+++ b/src/gazebo_mavlink_interface.cpp
@@ -516,7 +516,7 @@ void GazeboMavlinkInterface::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf
 
       memset(fds_, 0, sizeof(fds_));
       fds_[CONNECTION_FD].fd = simulator_socket_fd_;
-      fds_[CONNECTION_FD].events = POLLIN;
+      fds_[CONNECTION_FD].events = POLLIN | POLLOUT;
     }
   }
 
@@ -1242,7 +1242,7 @@ void GazeboMavlinkInterface::pollForMAVLinkMessages()
 
     // assign socket to connection descriptor on success
     fds_[CONNECTION_FD].fd = ret; // socket is replaced with latest connection
-    fds_[CONNECTION_FD].events = POLLIN;
+    fds_[CONNECTION_FD].events = POLLIN | POLLOUT;
   } while (ret != -1);
       } else { // recv call
         int ret = recvfrom(fds_[i].fd, _buf, sizeof(_buf), 0, (struct sockaddr *)&remote_simulator_addr_, &remote_simulator_addr_len_);

--- a/src/gazebo_mavlink_interface.cpp
+++ b/src/gazebo_mavlink_interface.cpp
@@ -1218,10 +1218,8 @@ void GazeboMavlinkInterface::pollForMAVLinkMessages()
         continue;
       }
 
-      if(fds_[i].revents != POLLIN)
-      {
-        gzerr << "invalid events at fd:" << i << "\n";
-        return;
+      if (!(fds_[i].revents & POLLIN)) { 
+        continue;
       }
 
       if (i == LISTEN_FD) { // if event is raised on the listening socket


### PR DESCRIPTION
Fixed errors related to gazebo gettting stuck on spawning vehicle without px4 or crashing on vehicle respawn or disconnection with px4.

Changes made:
1) Removed accept call from model load() in gazebo.
2) Listening socket address/port both set to reusable.
3) Listening socket set to non-blocking.
4) Updated polling to include accept() for managing new connections on runtime. Polling was only used before for receiving messages and returning a status message.
5) Reset socket fds on close().

Notes:
1) Only tcp connection is checked and tested. If there is a way to test udp connection, please guide me on that so I can test the relevant code sections.
2) No changes made to HIL/serial_enabled.

Fixes #359