### PR TITLE
Set wind_pluggin to zero for Gazebo Plane model

### DIFF
--- a/models/plane/plane.sdf
+++ b/models/plane/plane.sdf
@@ -404,7 +404,20 @@
       <frameId>base_link</frameId>
       <linkName>base_link</linkName>
       <robotNamespace/>
-      <xyzOffset>0 0 0</xyzOffset>
+    <!-- Wind plugin deactivated as the wind plugin is not affecting the control surfaces lift and drag.
+         This requires an update on the lift/drag plugin as well. -->
+    <!-- <plugin name='wind_plugin' filename='libgazebo_wind_plugin.so'>
+      <frameId>base_link</frameId>
+      <linkName>base_link</linkName>
+      <robotNamespace/>
+      <xyzOffset>1 0 0</xyzOffset>
+      <windDirection>0 1 0</windDirection>
+      <windForceMean>0.7</windForceMean>
+      <windGustDirection>0 0 0</windGustDirection>
+      <windGustDuration>0</windGustDuration>
+      <windGustStart>0</windGustStart>
+      <windGustForceMean>0</windGustForceMean>
+    </plugin> -->
       <windDirection>0 0 0</windDirection>
       <windForceMean>0.0</windForceMean>
       <windGustDirection>0 0 0</windGustDirection>

--- a/models/plane/plane.sdf
+++ b/models/plane/plane.sdf
@@ -404,9 +404,9 @@
       <frameId>base_link</frameId>
       <linkName>base_link</linkName>
       <robotNamespace/>
-      <xyzOffset>1 0 0</xyzOffset>
-      <windDirection>0 1 0</windDirection>
-      <windForceMean>0.7</windForceMean>
+      <xyzOffset>0 0 0</xyzOffset>
+      <windDirection>0 0 0</windDirection>
+      <windForceMean>0.0</windForceMean>
       <windGustDirection>0 0 0</windGustDirection>
       <windGustDuration>0</windGustDuration>
       <windGustStart>0</windGustStart>

--- a/models/plane/plane.sdf
+++ b/models/plane/plane.sdf
@@ -418,13 +418,7 @@
       <windGustStart>0</windGustStart>
       <windGustForceMean>0</windGustForceMean>
     </plugin> -->
-      <windDirection>0 0 0</windDirection>
-      <windForceMean>0.0</windForceMean>
-      <windGustDirection>0 0 0</windGustDirection>
-      <windGustDuration>0</windGustDuration>
-      <windGustStart>0</windGustStart>
-      <windGustForceMean>0</windGustForceMean>
-    </plugin>
+
     <plugin name="gps_plugin" filename="libgazebo_gps_plugin.so">
         <robotNamespace></robotNamespace>
         <gpsNoise>true</gpsNoise>


### PR DESCRIPTION
As documented here https://github.com/PX4/sitl_gazebo/issues/287 the Gazebo wind_pluggin doesn't work properly for the Gazebo Plane model.  This PR sets the wind_pluggin values to zero for the Plane model so that it will fly correctly in simulation.

In the long term, we should figure out exactly why the wind_pluggin does not work properly with gazebo plane model.  I suspect it might have something to do with improper or incomplete modeling of the airplane aerodynamics as it relates to the wind_pluggin, but I don't have the coding skills to really figure this out for sure. 

Questions:
1) if this PR is viewed as too much a hack, feel free to reject it, or suggest improvements.
2) maybe there are other vehicle models that are also affected?  Should we fix it for them too?