### PR TITLE
Add element to set home location from sdf

### DIFF
--- a/src/gazebo_gps_plugin.cpp
+++ b/src/gazebo_gps_plugin.cpp
@@ -67,14 +67,24 @@ void GpsPlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf)
   if (env_lat) {
     gzmsg << "Home latitude is set to " << env_lat << ".\n";
     lat_home = std::stod(env_lat) * M_PI / 180.0;
+  } else if(_sdf->HasElement("homeLatitude")) {
+    double latitude;
+    getSdfParam<double>(_sdf, "homeLatitude", latitude, 47.397742);
+    lat_home = latitude * M_PI / 180.0;
   }
   if (env_lon) {
     gzmsg << "Home longitude is set to " << env_lon << ".\n";
     lon_home = std::stod(env_lon) * M_PI / 180.0;
+  } else if(_sdf->HasElement("homeLongitude")) {
+    double longitude;
+    getSdfParam<double>(_sdf, "homeLongitude", lon_home, 8.545594);
+    lon_home = longitude * M_PI / 180.0;
   }
   if (env_alt) {
     gzmsg << "Home altitude is set to " << env_alt << ".\n";
     alt_home = std::stod(env_alt);
+  } else if(_sdf->HasElement("homeAltitude")) {
+    getSdfParam<double>(_sdf, "homeAltitude", alt_home, alt_home);
   }
 
   namespace_.clear();


### PR DESCRIPTION
Previously it was only possible to set the home location in SITL using the environment variable
`PX4_HOME_LON`, `PX4_HOME_LAT`, `PX4_HOME_ALT`

This PR adds a sdf parameter to the gps plugin, so that the home location can be set in the sdf file. This can be useful if the simulation includes location specific models.

The home location can be set by the following.
```
    <plugin name="gps_plugin" filename="libgazebo_gps_plugin.so">
        <robotNamespace></robotNamespace>
        <gpsNoise>true</gpsNoise>
        <homeLongitude>47.397742</Longitude>
        <homeLatitude>8.545594</homeLatitude>
        <homeAltitude>488.0</homeAltitude>
    </plugin>
```
These parameters are overwritten by the previously used environment variables.