### PR TITLE
Add Iris RTPS model

### DIFF
--- a/models/iris_rtps/iris_rtps.sdf
+++ b/models/iris_rtps/iris_rtps.sdf
@@ -1,0 +1,8 @@
+<sdf version='1.6'>
+  <model name='iris_rtps'>
+    <include>
+      <uri>model://iris</uri>
+    </include>
+  </model>
+  <!-- This model will include in the future a RTPS/DDS interface plugin -->
+</sdf>

--- a/models/iris_rtps/model.config
+++ b/models/iris_rtps/model.config
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<model>
+  <name>3DR Iris for RTPS/DDS interfacing</name>
+  <version>1.0</version>
+  <sdf version='1.6'>iris_rtps.sdf</sdf>
+
+  <author>
+    <name>Nuno Marques</name>
+    <email>nuno.marques@dronesolutions.io</email>
+  </author>
+
+  <description>
+    This is a model of the 3DR Iris Quadrotor for usage in RTPS/DDS comms.
+  </description>
+
+  <!-- TODO Add RTPS/DDS interface plugin -->
+</model>

--- a/worlds/iris_rtps.world
+++ b/worlds/iris_rtps.world
@@ -1,0 +1,53 @@
+<?xml version="1.0" ?>
+<sdf version="1.5">
+  <world name="default">
+    <!-- A global light source -->
+    <include>
+      <uri>model://sun</uri>
+    </include>
+    <!-- A ground plane -->
+    <include>
+      <uri>model://ground_plane</uri>
+    </include>
+    <!-- An asphalt plane -->
+    <include>
+      <uri>model://asphalt_plane</uri>
+    </include>
+    <include>
+      <uri>model://iris</uri>
+      <pose>1.01 0.98 0.83 0 0 1.14</pose>
+    </include>
+    <physics name='default_physics' default='0' type='ode'>
+      <gravity>0 0 -9.8066</gravity>
+      <ode>
+        <solver>
+          <type>quick</type>
+          <iters>10</iters>
+          <sor>1.3</sor>
+          <use_dynamic_moi_rescaling>0</use_dynamic_moi_rescaling>
+        </solver>
+        <constraints>
+          <cfm>0</cfm>
+          <erp>0.2</erp>
+          <contact_max_correcting_vel>100</contact_max_correcting_vel>
+          <contact_surface_layer>0.001</contact_surface_layer>
+        </constraints>
+      </ode>
+      <max_step_size>0.004</max_step_size>
+      <real_time_factor>1</real_time_factor>
+      <real_time_update_rate>250</real_time_update_rate>
+      <magnetic_field>6.0e-6 2.3e-5 -4.2e-5</magnetic_field>
+    </physics>
+    <gui fullscreen='0'>
+      <camera name='user_camera'>
+        <pose>-10 0 6 0 0.3 0</pose>
+        <!-- <view_controller>orbit</view_controller>
+        <projection_type>perspective</projection_type>
+        <track_visual>
+          <name>iris</name>
+          <use_model_frame>1</use_model_frame>
+        </track_visual> -->
+      </camera>
+    </gui>
+  </world>
+</sdf>


### PR DESCRIPTION
This adds a model to be launch upstream to load the micro-RTPS bridge. Soon this model will also launch a RTPS/DDS interface to work in parallel with the Mavlink interface.