### PR TITLE
Set image storage directory from environment variable

### DIFF
--- a/src/gazebo_geotagged_images_plugin.cpp
+++ b/src/gazebo_geotagged_images_plugin.cpp
@@ -137,7 +137,14 @@ void GeotaggedImagesPlugin::Load(sensors::SensorPtr sensor, sdf::ElementPtr sdf)
 
     _gpsSub = _node_handle->Subscribe("~/" + _namespace + "/gps", &GeotaggedImagesPlugin::OnNewGpsPosition, this);
 
-    _storageDir = "frames";
+    
+    const char *storage_path = std::getenv("PX4_STORAGE_PATH");
+    if ( storage_path ) {
+        gzmsg << "Image storage path is set to " << storage_path << ".\n";
+       _storageDir = std::string(storage_path);
+    } else {
+       _storageDir = "frames";
+    }
     boost::filesystem::remove_all(_storageDir); //clear existing images
     boost::filesystem::create_directory(_storageDir);
 


### PR DESCRIPTION
This PR enables setting the path of the directory where the images taken by the `geotagged_camera_plugin` be saved in a path specified by a environment variable `PX4_STORAGE_PATH`

This is useful when putting images produced by SITL to be saved in user defined directories out side the firmware build directory.