### PR TITLE
Enable zooming for geotagged_images_plugin

### DIFF
--- a/include/gazebo_geotagged_images_plugin.h
+++ b/include/gazebo_geotagged_images_plugin.h
@@ -99,7 +99,7 @@ private:
     event::ConnectionPtr        _newFrameConnection;
     std::string                 _storageDir;
     ignition::math::Vector3d    _lastGpsPosition;
-    ignition::math::Angle       _hfov;      // Horizontal fov
+    ignition::math::Angle       _hfov;      ///< Horizontal fov
     transport::NodePtr          _node_handle;
     std::string                 _namespace;
     transport::SubscriberPtr    _gpsSub;

--- a/include/gazebo_geotagged_images_plugin.h
+++ b/include/gazebo_geotagged_images_plugin.h
@@ -62,6 +62,7 @@ private:
     void _handle_take_photo(const mavlink_message_t *pMsg, struct sockaddr* srcaddr);
     void _handle_stop_take_photo(const mavlink_message_t *pMsg, struct sockaddr* srcaddr);
     void _handle_request_camera_settings(const mavlink_message_t *pMsg, struct sockaddr* srcaddr);
+    void _handle_camera_zoom(const mavlink_message_t *pMsg, struct sockaddr* srcaddr);
     void _send_capture_status(struct sockaddr* srcaddr = NULL);
     void _send_cmd_ack(uint8_t target_sysid, uint8_t target_compid, uint16_t cmd, unsigned char result, struct sockaddr* srcaddr);
     void _send_heartbeat();
@@ -75,6 +76,8 @@ private:
     uint32_t    _depth;
     uint32_t    _destWidth;     ///< output size
     uint32_t    _destHeight;
+    float       _maxZoom;
+    float       _zoom;
     int         _captureCount;
     double      _captureInterval;
     int         _fd;
@@ -96,6 +99,7 @@ private:
     event::ConnectionPtr        _newFrameConnection;
     std::string                 _storageDir;
     ignition::math::Vector3d    _lastGpsPosition;
+    ignition::math::Angle       _hfov;      // Horizontal fov
     transport::NodePtr          _node_handle;
     std::string                 _namespace;
     transport::SubscriberPtr    _gpsSub;

--- a/models/typhoon_h480/typhoon_h480.sdf
+++ b/models/typhoon_h480/typhoon_h480.sdf
@@ -427,7 +427,7 @@
             <interval>1</interval>
             <width>3840</width>
             <height>2160</height>
-            <maximum_zoom>8</maximum_zoom>
+            <maximum_zoom>8.0</maximum_zoom>
         </plugin>
       </sensor>
     </link>

--- a/models/typhoon_h480/typhoon_h480.sdf
+++ b/models/typhoon_h480/typhoon_h480.sdf
@@ -427,6 +427,7 @@
             <interval>1</interval>
             <width>3840</width>
             <height>2160</height>
+            <maximum_zoom>8</maximum_zoom>
         </plugin>
       </sensor>
     </link>

--- a/src/gazebo_geotagged_images_plugin.cpp
+++ b/src/gazebo_geotagged_images_plugin.cpp
@@ -566,7 +566,7 @@ void GeotaggedImagesPlugin::_handle_request_camera_settings(const mavlink_messag
         &msg,
         0,                      // time_boot_ms
         CAMERA_MODE_IMAGE,      // Camera Mode
-        100.0 *(_zoom - 1.0)/ (_maxZoom - 1.0),                    // Zoom level //TODO: Output zoom
+        1.0E2 * (_zoom - 1.0)/ (_maxZoom - 1.0),                    // Zoom level
         NAN);                   // Focus level
     _send_mavlink_message(&msg, srcaddr);
 }
@@ -578,11 +578,8 @@ void GeotaggedImagesPlugin::_handle_camera_zoom(const mavlink_message_t *pMsg, s
     _send_cmd_ack(pMsg->sysid, pMsg->compid,
                   MAV_CMD_SET_CAMERA_ZOOM, MAV_RESULT_ACCEPTED, srcaddr);
 
-    _zoom += 0.1 * cmd.param2;
-    _zoom = std::max(std::min(_zoom, _maxZoom), 1.0f);
-
-    ignition::math::Angle zoom_fov = _hfov / _zoom;
-    _camera->SetHFOV(zoom_fov);
+    _zoom = std::max(std::min(float(_zoom + 0.1 * cmd.param2), _maxZoom), 1.0f);
+    _camera->SetHFOV(_hfov / _zoom);
 }
 
 void GeotaggedImagesPlugin::_send_capture_status(struct sockaddr* srcaddr)


### PR DESCRIPTION
This PR enables zooming for the `geotagged_images_plugin` by handling the mavlink message `MAV_CMD_SET_CAMERA_ZOOM`. This allows us to test GCS functionalities which involve zooming with cameras cameras.

This has been tested on the `typhoon_h480` model.