### PR TITLE
Incorporate wind in lift calculation and airspeed measurements

### DIFF
--- a/include/gazebo_mavlink_interface.h
+++ b/include/gazebo_mavlink_interface.h
@@ -67,6 +67,7 @@
 #include <Odometry.pb.h>
 #include <MagneticField.pb.h>
 #include <Pressure.pb.h>
+#include <Wind.pb.h>
 
 #include <mavlink/v2.0/common/mavlink.h>
 #include "msgbuffer.h"
@@ -101,6 +102,7 @@ typedef const boost::shared_ptr<const sensor_msgs::msgs::Range> LidarPtr;
 typedef const boost::shared_ptr<const sensor_msgs::msgs::SITLGps> GpsPtr;
 typedef const boost::shared_ptr<const sensor_msgs::msgs::MagneticField> MagnetometerPtr;
 typedef const boost::shared_ptr<const sensor_msgs::msgs::Pressure> BarometerPtr;
+typedef const boost::shared_ptr<const physics_msgs::msgs::Wind> WindPtr;
 
 typedef std::pair<const int, const ignition::math::Quaterniond> SensorIdRot_P;
 typedef std::map<transport::SubscriberPtr, SensorIdRot_P > Sensor_M;
@@ -119,6 +121,7 @@ static const std::string kDefaultGPSTopic = "/gps";
 static const std::string kDefaultVisionTopic = "/vision_odom";
 static const std::string kDefaultMagTopic = "/mag";
 static const std::string kDefaultBarometerTopic = "/baro";
+static const std::string kDefaultWindTopic = "/wind";
 
 //! Rx packer framing status. (same as @p mavlink::mavlink_framing_t)
 enum class Framing : uint8_t {
@@ -175,6 +178,7 @@ public:
     mag_sub_topic_(kDefaultMagTopic),
     baro_sub_topic_(kDefaultBarometerTopic),
     sensor_map_ {},
+    wind_sub_topic_(kDefaultWindTopic),
     model_ {},
     world_(nullptr),
     left_elevon_joint_(nullptr),
@@ -286,6 +290,7 @@ private:
   void VisionCallback(OdomPtr& odom_msg);
   void MagnetometerCallback(MagnetometerPtr& mag_msg);
   void BarometerCallback(BarometerPtr& baro_msg);
+  void WindVelocityCallback(WindPtr& msg);
   void send_mavlink_message(const mavlink_message_t *message);
   void forward_mavlink_message(const mavlink_message_t *message);
   void handle_message(mavlink_message_t *msg, bool &received_actuator);
@@ -349,6 +354,7 @@ private:
   transport::SubscriberPtr vision_sub_;
   transport::SubscriberPtr mag_sub_;
   transport::SubscriberPtr baro_sub_;
+  transport::SubscriberPtr wind_sub_;
 
   Sensor_M sensor_map_; // Map of sensor SubscriberPtr, IDs and orientations
 
@@ -360,6 +366,7 @@ private:
   std::string vision_sub_topic_;
   std::string mag_sub_topic_;
   std::string baro_sub_topic_;
+  std::string wind_sub_topic_;
 
   std::mutex last_imu_message_mutex_ {};
   std::condition_variable last_imu_message_cond_ {};
@@ -381,6 +388,7 @@ private:
   ignition::math::Vector3d gravity_W_;
   ignition::math::Vector3d velocity_prev_W_;
   ignition::math::Vector3d mag_n_;
+  ignition::math::Vector3d wind_vel_;
 
   double temperature_;
   double pressure_alt_;

--- a/include/gazebo_wind_plugin.h
+++ b/include/gazebo_wind_plugin.h
@@ -38,9 +38,9 @@ static const std::string kDefaultNamespace = "";
 static const std::string kDefaultFrameId = "world";
 static const std::string kDefaultLinkName = "base_link";
 
-static constexpr double kDefaultWindForceMean = 0.0;
-static constexpr double kDefaultWindForceMax = 100.0;
-static constexpr double kDefaultWindForceVariance = 0.0;
+static constexpr double kDefaultWindVelocityMean = 0.0;
+static constexpr double kDefaultWindVelocityMax = 100.0;
+static constexpr double kDefaultWindVelocityVariance = 0.0;
 static constexpr double kDefaultWindGustForceMean = 0.0;
 static constexpr double kDefaultWindGustForceMax = 100.0;
 static constexpr double kDefaultWindGustForceVariance = 0.0;
@@ -60,9 +60,9 @@ class GazeboWindPlugin : public ModelPlugin {
       : ModelPlugin(),
         namespace_(kDefaultNamespace),
         wind_pub_topic_("wind"),
-        wind_force_mean_(kDefaultWindForceMean),
-        wind_force_max_(kDefaultWindForceMax),
-        wind_force_variance_(kDefaultWindForceVariance),
+        wind_velocity_mean_(kDefaultWindVelocityMean),
+        wind_velocity_max_(kDefaultWindVelocityMax),
+        wind_velocity_variance_(kDefaultWindVelocityVariance),
         wind_gust_force_mean_(kDefaultWindGustForceMean),
         wind_gust_force_max_(kDefaultWindGustForceMax),
         wind_gust_force_variance_(kDefaultWindGustForceVariance),
@@ -100,14 +100,14 @@ class GazeboWindPlugin : public ModelPlugin {
   std::string link_name_;
   std::string wind_pub_topic_;
 
-  double wind_force_mean_;
-  double wind_force_max_;
-  double wind_force_variance_;
+  double wind_velocity_mean_;
+  double wind_velocity_max_;
+  double wind_velocity_variance_;
   double wind_gust_force_mean_;
   double wind_gust_force_max_;
   double wind_gust_force_variance_;
-  std::default_random_engine wind_force_generator_;
-  std::normal_distribution<double> wind_force_distribution_;
+  std::default_random_engine wind_velocity_generator_;
+  std::normal_distribution<double> wind_velocity_distribution_;
   std::default_random_engine wind_gust_force_generator_;
   std::normal_distribution<double> wind_gust_force_distribution_;
 

--- a/include/liftdrag_plugin/liftdrag_plugin.h
+++ b/include/liftdrag_plugin/liftdrag_plugin.h
@@ -19,11 +19,14 @@
 
 #include <string>
 #include <vector>
+#include <boost/bind.hpp>
 
 #include "gazebo/common/Plugin.hh"
 #include "gazebo/physics/physics.hh"
 #include "gazebo/transport/TransportTypes.hh"
 #include <ignition/math.hh>
+
+#include "Wind.pb.h"
 
 namespace gazebo
 {
@@ -132,6 +135,14 @@ namespace gazebo
 
     /// \brief SDF for this plugin;
     protected: sdf::ElementPtr sdf;
+
+    private: void WindVelocityCallback(const boost::shared_ptr<const physics_msgs::msgs::Wind> &msg);
+    
+    private: transport::NodePtr node_handle_;
+    private: transport::SubscriberPtr wind_sub_;
+    private: std::string namespace_;
+    private: std::string wind_sub_topic_;
+    private: ignition::math::Vector3d wind_vel_;
   };
 }
 #endif

--- a/models/plane/plane.sdf
+++ b/models/plane/plane.sdf
@@ -373,6 +373,8 @@
         left_elevon_joint
       </control_joint_name>
       <control_joint_rad_to_cl>-0.5</control_joint_rad_to_cl>
+      <robotNamespace></robotNamespace>
+      <windSubTopic>/wind</windSubTopic>
     </plugin>
     <plugin name="right_wing" filename="libLiftDragPlugin.so">
       <a0>0.05984281113</a0>
@@ -393,6 +395,8 @@
         right_elevon_joint
       </control_joint_name>
       <control_joint_rad_to_cl>-0.5</control_joint_rad_to_cl>
+      <robotNamespace></robotNamespace>
+      <windSubTopic>/wind</windSubTopic>
     </plugin>
     <plugin name="elevator" filename="libLiftDragPlugin.so">
       <a0>-0.2</a0>
@@ -413,6 +417,8 @@
         elevator_joint
       </control_joint_name>
       <control_joint_rad_to_cl>-4.0</control_joint_rad_to_cl>
+      <robotNamespace></robotNamespace>
+      <windSubTopic>/wind</windSubTopic>
     </plugin>
     <plugin name="rudder" filename="libLiftDragPlugin.so">
       <a0>0.0</a0>
@@ -429,6 +435,8 @@
       <forward>1 0 0</forward>
       <upward>0 1 0</upward>
       <link_name>base_link</link_name>
+      <robotNamespace></robotNamespace>
+      <windSubTopic>/wind</windSubTopic>
     </plugin>
     <plugin name='puller' filename='libgazebo_motor_model.so'>
       <robotNamespace></robotNamespace>
@@ -446,6 +454,8 @@
       <rollingMomentCoefficient>1e-06</rollingMomentCoefficient>
       <motorSpeedPubTopic>/motor_speed/4</motorSpeedPubTopic>
       <rotorVelocitySlowdownSim>10</rotorVelocitySlowdownSim>
+      <robotNamespace></robotNamespace>
+      <windSubTopic>/wind</windSubTopic>
     </plugin>
     <plugin name='gazebo_imu_plugin' filename='libgazebo_imu_plugin.so'>
       <robotNamespace></robotNamespace>
@@ -466,11 +476,12 @@
       <robotNamespace/>
       <xyzOffset>1 0 0</xyzOffset>
       <windDirection>0 1 0</windDirection>
-      <windForceMean>0.7</windForceMean>
+      <windVelocityMean>0.7</windVelocityMean>
       <windGustDirection>0 0 0</windGustDirection>
       <windGustDuration>0</windGustDuration>
       <windGustStart>0</windGustStart>
       <windGustForceMean>0</windGustForceMean>
+      <windPubTopic>/wind</windPubTopic>
     </plugin>
     <plugin name="gps_plugin" filename="libgazebo_gps_plugin.so">
         <robotNamespace></robotNamespace>

--- a/msgs/Wind.proto
+++ b/msgs/Wind.proto
@@ -7,4 +7,5 @@ message Wind
   required string frame_id = 1;
   required int64 time_usec = 2;
   required gazebo.msgs.Vector3d force = 3;
+  required gazebo.msgs.Vector3d velocity = 4;
 }


### PR DESCRIPTION
## Problem definition
Currently the wind plugin is designed so that it applied "force" to the vehicle. This might be a valid simplification for multirotors, but for fixed wing or airspeed sensors this makes the dynamics incorrect.

The issue has been observed in https://github.com/PX4/sitl_gazebo/issues/287 https://github.com/PX4/Firmware/issues/11116#issuecomment-452724619 https://github.com/PX4/Firmware/issues/11319 

The problem was due to the following
- Airspeed measurement is based on the body velocity
- Lift drag calcluation is also based on body velocity without wind
- Wind forces are applied as a force and there is no interaction with lift

## Solution
This PR enables the wind plugin to talk to other plugins such as the `mavlink_interface_plugin` and `liftdrag_plugin`as the following
- The wind velocity is generated and passed as a gazebo_msg
- The wind gust force acts as a force before
- Airspeed incorporates wind
- Lift and drag calculation uses wind velocity

## Tests


Before PR: [Log](https://review.px4.io/plot_app?log=c40ffcb1-3e8e-48f2-97f4-5cafa26fd891)
![Screenshot from 2019-11-23 06-58-19](https://user-images.githubusercontent.com/5248102/69474238-e2e7a280-0dbe-11ea-97ae-5c085688a81b.png)

After PR: [Log](https://review.px4.io/plot_app?log=eb239a5f-b4a0-481e-95eb-226f6abb0a8d)
![Screenshot from 2019-11-23 06-57-48](https://user-images.githubusercontent.com/5248102/69474240-e844ed00-0dbe-11ea-90f5-994042676b1b.png)

The test was done by making a wind blow in one direction [5m/s, 0, 0] and the drone moving upwind and downwind. From the airspeed and ground speed plots, It can be seen that the airspeed is constant, but the ground speed varies since it has a headwind / tailwind