### PR TITLE
Add rudder control to plane model

### DIFF
--- a/models/plane/plane.sdf
+++ b/models/plane/plane.sdf
@@ -341,8 +341,8 @@
         <xyz>0 0 1</xyz>
         <limit>
           <!-- -30/+30 deg. -->
-          <lower>-0.01</lower>
-          <upper>0.01</upper>
+          <lower>-0.53</lower>
+          <upper>0.53</upper>
         </limit>
         <dynamics>
           <damping>1.000</damping>

--- a/models/plane/plane.sdf
+++ b/models/plane/plane.sdf
@@ -338,7 +338,7 @@
       <child>rudder</child>
       <pose>-0.5 0 0.05 0.00 0 0.0</pose>
       <axis>
-        <xyz>1 0 0</xyz>
+        <xyz>0 0 1</xyz>
         <limit>
           <!-- -30/+30 deg. -->
           <lower>-0.01</lower>
@@ -510,6 +510,15 @@
       <use_tcp>true</use_tcp>
       <motorSpeedCommandPubTopic>/gazebo/command/motor_speed</motorSpeedCommandPubTopic>
       <control_channels>
+        <channel name="rudder">
+          <input_index>2</input_index>
+          <input_offset>0</input_offset>
+          <input_scaling>1</input_scaling>
+          <zero_position_disarmed>0</zero_position_disarmed>
+          <zero_position_armed>0</zero_position_armed>
+          <joint_control_type>position_kinematic</joint_control_type>
+          <joint_name>rudder_joint</joint_name>
+        </channel>
         <channel name="rotor4">
           <input_index>4</input_index>
           <input_offset>0</input_offset>


### PR DESCRIPTION
Although having a rudder link, the plane did not have rudder control in the sitl model of plane for the following reasons

- No control channel for rudder
- wrong joint axis (x-axis) for the rudder joint to move

This PR fixes the joint axis and adds the control channel for the fixedwing plane model in gazebo

The flight performance has minimum influence, without wind
- [Before PR](https://review.px4.io/plot_app?log=1330877d-dde3-4163-b613-0f5de900cd10)
- [After PR](https://review.px4.io/plot_app?log=31ba6a54-6a0f-424e-8548-5af68659fc56)