### PR TITLE
Support multi vehicle simulation for fixed wing in gazebo SITL 

### DIFF
--- a/models/rotors_description/urdf/component_snippets.xacro
+++ b/models/rotors_description/urdf/component_snippets.xacro
@@ -288,6 +288,84 @@
     </gazebo>
   </xacro:macro>
 
+  <!-- Macro to add the mavlink interface for a fixed-wing model. -->
+  <xacro:macro name="mavlink_interface_macro_fw" params="namespace imu_sub_topic gps_sub_topic mag_sub_topic baro_sub_topic mavlink_addr mavlink_udp_port mavlink_tcp_port serial_enabled serial_device baudrate qgc_addr qgc_udp_port sdk_addr sdk_udp_port hil_mode hil_state_level vehicle_is_tailsitter send_vision_estimation send_odometry enable_lockstep use_tcp">
+    <gazebo>
+      <plugin name="mavlink_interface" filename="libgazebo_mavlink_interface.so">
+        <robotNamespace>${namespace}</robotNamespace>
+        <imuSubTopic>${imu_sub_topic}</imuSubTopic>
+        <gpsSubTopic>${gps_sub_topic}</gpsSubTopic>
+        <magSubTopic>${mag_sub_topic}</magSubTopic>
+        <baroSubTopic>${baro_sub_topic}</baroSubTopic>
+        <mavlink_addr>$(arg mavlink_addr)</mavlink_addr>
+        <mavlink_udp_port>$(arg mavlink_udp_port)</mavlink_udp_port>
+        <mavlink_tcp_port>$(arg mavlink_tcp_port)</mavlink_tcp_port>
+        <serialEnabled>$(arg serial_enabled)</serialEnabled>
+        <serialDevice>$(arg serial_device)</serialDevice>
+        <baudRate>$(arg baudrate)</baudRate>
+        <qgc_addr>$(arg qgc_addr)</qgc_addr>
+        <qgc_udp_port>$(arg qgc_udp_port)</qgc_udp_port>
+        <sdk_addr>$(arg sdk_addr)</sdk_addr>
+        <sdk_udp_port>$(arg sdk_udp_port)</sdk_udp_port>
+        <hil_mode>$(arg hil_mode)</hil_mode>
+        <hil_state_level>$(arg hil_state_level)</hil_state_level>
+        <vehicle_is_tailsitter>$(arg vehicle_is_tailsitter)</vehicle_is_tailsitter>
+        <send_vision_estimation>$(arg send_vision_estimation)</send_vision_estimation>
+        <send_odometry>$(arg send_odometry)</send_odometry>
+        <enable_lockstep>$(arg enable_lockstep)</enable_lockstep>
+        <use_tcp>$(arg use_tcp)</use_tcp>
+        <motorSpeedCommandPubTopic>/gazebo/command/motor_speed</motorSpeedCommandPubTopic>
+        <control_channels>
+          <channel name="rudder">
+            <input_index>2</input_index>
+            <input_offset>0</input_offset>
+            <input_scaling>1</input_scaling>
+            <zero_position_disarmed>0</zero_position_disarmed>
+            <zero_position_armed>0</zero_position_armed>
+            <joint_control_type>position_kinematic</joint_control_type>
+            <joint_name>rudder_joint</joint_name>
+          </channel>
+          <channel name="rotor_4">
+            <input_index>4</input_index>
+            <input_offset>0</input_offset>
+            <input_scaling>3500</input_scaling>
+            <zero_position_disarmed>0</zero_position_disarmed>
+            <zero_position_armed>0</zero_position_armed>
+            <joint_control_type>velocity</joint_control_type>
+            <joint_name>rotor_4_joint</joint_name>
+          </channel>
+          <channel name="left_aileron">
+            <input_index>5</input_index>
+            <input_offset>0</input_offset>
+            <input_scaling>1</input_scaling>
+            <zero_position_disarmed>0</zero_position_disarmed>
+            <zero_position_armed>0</zero_position_armed>
+            <joint_control_type>position_kinematic</joint_control_type>
+            <joint_name>left_elevon_joint</joint_name>
+          </channel>
+          <channel name="right_aileron">
+            <input_index>6</input_index>
+            <input_offset>0</input_offset>
+            <input_scaling>1</input_scaling>
+            <zero_position_disarmed>0</zero_position_disarmed>
+            <zero_position_armed>0</zero_position_armed>
+            <joint_control_type>position_kinematic</joint_control_type>
+            <joint_name>right_elevon_joint</joint_name>
+          </channel>
+          <channel name="elevator">
+            <input_index>7</input_index>
+            <input_offset>0</input_offset>
+            <input_scaling>1</input_scaling>
+            <zero_position_disarmed>0</zero_position_disarmed>
+            <zero_position_armed>0</zero_position_armed>
+            <joint_control_type>position_kinematic</joint_control_type>
+            <joint_name>elevator_joint</joint_name>
+          </channel>
+        </control_channels>
+      </plugin>
+    </gazebo>
+  </xacro:macro>
+
   <!-- Macro to add an IMU. -->
   <xacro:macro name="imu_plugin_macro"
     params="namespace imu_suffix parent_link imu_topic

--- a/models/rotors_description/urdf/fixedwing_base.xacro
+++ b/models/rotors_description/urdf/fixedwing_base.xacro
@@ -1,0 +1,184 @@
+<?xml version="1.0"?>
+<!--
+  Copyright 2015 Fadri Furrer, ASL, ETH Zurich, Switzerland
+  Copyright 2015 Michael Burri, ASL, ETH Zurich, Switzerland
+  Copyright 2015 Mina Kamel, ASL, ETH Zurich, Switzerland
+  Copyright 2015 Janosch Nikolic, ASL, ETH Zurich, Switzerland
+  Copyright 2015 Markus Achtelik, ASL, ETH Zurich, Switzerland
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<robot xmlns:xacro="http://ros.org/wiki/xacro">
+  <!-- Main multirotor link -->
+  <xacro:macro name="fixedwing_base_macro" params="robot_namespace *origin">
+    <xacro:insert_block name="origin" />
+    <link name="base_link"></link>
+    <joint name="base_joint" type="fixed">
+      <parent link="base_link" />
+      <child link="base_link_inertial" />      
+    </joint>
+    <link name="base_link_inertial">
+      <inertial>
+        <mass value="1.5" />
+        <inertia ixx="0.197563" ixy="0.0" iyy="0.1458929" ixz="0.0" iyz="0.0" izz="0.1477" />
+      </inertial>
+      <visual>
+        <origin xyz="0.07 0 -0.08" rpy="0 0 0" />
+        <geometry>
+            <mesh scale="0.1 0.1 0.1" filename="model://plane/meshes/body.dae" />
+        </geometry>
+      </visual>
+      <collision name='base_link_collision'>
+        <origin xyz="0.0 0 -0.07" rpy="0 0 0" />
+        <geometry>
+            <box size="0.47 0.47 0.11"/>
+        </geometry>
+      </collision>
+    </link>
+    <gazebo reference="base_link">
+        <material>Gazebo/DarkGrey</material>
+        <!-- <maxVel>10</maxVel>
+        <minDepth>0.01</minDepth> -->
+        <selfCollide>0</selfCollide>
+    </gazebo>
+  </xacro:macro>
+
+  <!-- Rotor joint and link -->
+  <xacro:macro name="horizontal_rotor"
+    params="robot_namespace suffix direction motor_constant moment_constant parent mass_rotor radius_rotor time_constant_up time_constant_down max_rot_velocity motor_number rotor_drag_coefficient rolling_moment_coefficient color mesh mesh_scale *origin *inertia">
+    <joint name="rotor_${motor_number}_joint" type="continuous">
+      <xacro:insert_block name="origin" />
+      <axis xyz="0 0 1" />
+      <!-- TODO(ff): not currently set because it's not yet supported -->
+      <!-- <limit effort="2000" velocity="${max_rot_velocity}" /> -->
+      <parent link="${parent}" />
+      <child link="rotor_${motor_number}" />
+
+    </joint>
+    <!-- TODO(ff): not currently set because it's not yet supported -->
+    <!-- <gazebo reference="rotor_${motor_number}_joint"> <axis> <xyz>0 0 1</xyz>
+      <limit> <velocity> ${max_rot_velocity} </velocity> </limit> </axis> </gazebo> -->
+    <link name="rotor_${motor_number}">
+      <inertial>
+        <mass value="${mass_rotor}" /> <!-- [kg] -->
+        <xacro:insert_block name="inertia" />
+      </inertial>
+      <visual>
+        <origin xyz="0.0 0 -0.09" rpy="0 0.0 0" />
+        <geometry>
+          <mesh filename="model://plane/meshes/iris_prop_ccw.dae"
+            scale="${mesh_scale}" />
+        </geometry>
+      </visual>
+      <collision>
+        <geometry>
+          <cylinder length="0.005" radius="${radius_rotor}" /> <!-- [m] -->
+        </geometry>
+      </collision>
+    </link>
+    <gazebo>
+      <plugin name="${suffix}_motor_model" filename="libgazebo_motor_model.so">
+        <robotNamespace>${robot_namespace}</robotNamespace>
+        <jointName>rotor_${motor_number}_joint</jointName>
+        <linkName>rotor_${motor_number}</linkName>
+        <turningDirection>${direction}</turningDirection>
+        <timeConstantUp>${time_constant_up}</timeConstantUp>
+        <timeConstantDown>${time_constant_down}</timeConstantDown>
+        <maxRotVelocity>${max_rot_velocity}</maxRotVelocity>
+        <motorConstant>${motor_constant}</motorConstant>
+        <momentConstant>${moment_constant}</momentConstant>
+        <commandSubTopic>/gazebo/command/motor_speed</commandSubTopic>
+        <motorNumber>${motor_number}</motorNumber>
+        <rotorDragCoefficient>${rotor_drag_coefficient}</rotorDragCoefficient>
+        <rollingMomentCoefficient>${rolling_moment_coefficient}</rollingMomentCoefficient>
+        <motorSpeedPubTopic>/motor_speed/${motor_number}</motorSpeedPubTopic>
+        <rotorVelocitySlowdownSim>${rotor_velocity_slowdown_sim}</rotorVelocitySlowdownSim>
+        <!--
+        <gazebo_joint_control_pid>
+          <p>0.1</p>
+          <i>0</i>
+          <d>0</d>
+          <iMax>0</iMax>
+          <iMin>0</iMin>
+          <cmdMax>3</cmdMax>
+          <cmdMin>-3</cmdMin>
+        </gazebo_joint_control_pid>
+      -->
+      </plugin>
+    </gazebo>
+    <gazebo reference="rotor_${motor_number}">
+      <material>Gazebo/${color}</material>
+        <selfCollide>0</selfCollide>
+    </gazebo>
+  </xacro:macro>
+
+  <!-- Rotor joint and link -->
+  <xacro:macro name="control_surface"
+    params="robot_namespace link_name parent color mesh_file mesh_scale area joint_limit control_joint_rad_to_cl a0 cpx cpy cpz upx upy upz *origin *joint_origin *axis *mesh_origin">
+    <joint name="${link_name}_joint" type="revolute">
+      <xacro:insert_block name="joint_origin" />
+      <parent link="${parent}" />
+      <child link="${link_name}" />
+      <!-- <axis xyz="0 0 1" /> -->
+      <xacro:insert_block name="axis" />
+      <limit effort="1000" velocity="1000.0" lower="-${joint_limit}" upper="${joint_limit}" />
+      <!-- <dynamics damping="1.0"/> -->
+    </joint>
+    <link name="${link_name}">
+      <inertial>
+        <mass value="0.00001" /> <!-- [kg] -->
+        <inertia
+        ixx="0.000001"
+        iyy="0.000001"
+        izz="0.000001"
+        ixy="0.0" ixz="0.0"  iyz="0.0" /> <!-- [kg.m^2] [kg.m^2] [kg.m^2] [kg.m^2] [kg.m^2] [kg.m^2] -->
+        <xacro:insert_block name="origin" />
+      </inertial>
+      <visual>
+        <xacro:insert_block name="mesh_origin" />
+        <geometry>
+          <mesh filename="${mesh_file}" scale="${mesh_scale}" />
+        </geometry>
+      </visual>
+    </link>
+    <gazebo>
+         <plugin name="${link_name}_plugin" filename="libLiftDragPlugin.so">
+            <a0>${a0}</a0>
+            <cla>4.752798721</cla>
+            <cda>0.6417112299</cda>
+            <cma>-1.8</cma>
+            <alpha_stall>0.3391428111</alpha_stall>
+            <cla_stall>-3.85</cla_stall>
+            <cda_stall>-0.9233984055</cda_stall>
+            <cma_stall>0</cma_stall>
+            <cp>${cpx} ${cpy} ${cpz}</cp>
+            <area>${area}</area>
+            <air_density>1.2041</air_density>
+            <forward>1 0 0</forward>
+            <upward>${upx} ${upy} ${upz}</upward>
+            <link_name>${parent}</link_name>
+            <control_joint_name>
+               ${link_name}_joint
+            </control_joint_name>
+            <control_joint_rad_to_cl>${control_joint_rad_to_cl}</control_joint_rad_to_cl>
+         </plugin>
+    </gazebo>
+    <gazebo reference="${link_name}">
+      <material>Gazebo/${color}</material>
+    </gazebo>
+    <gazebo reference="${link_name}_joint">
+        <implicitSpringDamper>True</implicitSpringDamper>
+    </gazebo>
+  </xacro:macro>
+</robot>

--- a/models/rotors_description/urdf/plane.xacro
+++ b/models/rotors_description/urdf/plane.xacro
@@ -1,0 +1,206 @@
+<?xml version="1.0"?>
+
+<robot name="plane" xmlns:xacro="http://ros.org/wiki/xacro">
+  <!-- Properties -->
+  <xacro:property name="namespace" value="plane" />
+  <xacro:property name="rotor_velocity_slowdown_sim" value="10" />
+  <xacro:property name="mass" value="1.5" /> <!-- [kg] -->
+  <xacro:property name="body_width" value="0.47" /> <!-- [m] -->
+  <xacro:property name="body_height" value="0.11" /> <!-- [m] -->
+  <xacro:property name="mass_rotor" value="0.005" /> <!-- [kg] -->
+  <xacro:property name="arm_length_front_x" value="0.13" /> <!-- [m] -->
+  <xacro:property name="arm_length_back_x" value="0.13" /> <!-- [m] -->
+  <xacro:property name="arm_length_front_y" value="0.22" /> <!-- [m] -->
+  <xacro:property name="arm_length_back_y" value="0.2" /> <!-- [m] -->
+  <xacro:property name="rotor_offset_top" value="0.023" /> <!-- [m] -->
+  <xacro:property name="radius_rotor" value="0.128" /> <!-- [m] -->
+  <xacro:property name="motor_constant" value="8.54858e-06" /> <!-- [kg.m/s^2] -->
+  <xacro:property name="moment_constant" value="0.01" /> <!-- [m] -->
+  <xacro:property name="time_constant_up" value="0.0125" /> <!-- [s] -->
+  <xacro:property name="time_constant_down" value="0.025" /> <!-- [s] -->
+  <xacro:property name="max_rot_velocity" value="3500" /> <!-- [rad/s] -->
+  <xacro:property name="rotor_drag_coefficient" value="8.06428e-05" />
+  <xacro:property name="rolling_moment_coefficient" value="0.000001" />
+  <xacro:property name="color" value="$(arg visual_material)" />
+
+  <!-- Property Blocks -->
+  <xacro:property name="body_inertia">
+    <inertia 
+    ixx="${1/12 * mass * (body_height * body_height + body_width * body_width)}"
+    iyy="${1/12 * mass * (body_height * body_height + body_width * body_width)}"
+    izz="${1/12 * mass * (body_width * body_width + body_width * body_width)}"    
+    ixy="0.0" ixz="0.0" iyz="0.0" /> <!-- [kg.m^2] [kg.m^2] [kg.m^2] [kg.m^2] [kg.m^2] [kg.m^2] -->
+  </xacro:property>
+
+  <!-- inertia of a single rotor, assuming it is a cuboid. Height=3mm, width=15mm -->
+  <xacro:property name="rotor_inertia">
+    <inertia
+    ixx="9.75e-07"
+    iyy="0.000166704"
+    izz="0.000167604"
+    ixy="0.0" ixz="0.0"  iyz="0.0" /> <!-- [kg.m^2] [kg.m^2] [kg.m^2] [kg.m^2] [kg.m^2] [kg.m^2] -->
+  </xacro:property>
+
+  <xacro:property name="left_aileron_mesh_origin">
+    <origin xyz="0.07 -0.3 -0.08"/>
+  </xacro:property>
+
+  <xacro:property name="left_aileron_joint_origin">
+    <origin xyz="0.0 0.3 0.0"/>
+  </xacro:property>
+
+  <xacro:property name="right_aileron_mesh_origin">
+    <origin xyz="0.07 0.3 -0.08"/>
+  </xacro:property>
+
+  <xacro:property name="right_aileron_joint_origin">
+    <origin xyz="0.0 -0.3 0.0"/>
+  </xacro:property>
+
+  <xacro:property name="rudder_mesh_origin">
+    <origin xyz="0.57 0.0 -0.13"/>
+  </xacro:property>
+
+  <xacro:property name="rudder_joint_origin">
+    <origin xyz="-0.5 0.0 0.05"/>
+  </xacro:property>
+
+  <xacro:property name="elevator_mesh_origin">
+    <origin xyz="0.57 0.0 -0.08"/>
+  </xacro:property>
+
+  <xacro:property name="elevator_joint_origin">
+    <origin xyz="-0.5 0.0 0.0"/>
+  </xacro:property>
+
+  <!-- Included URDF Files -->
+  <xacro:include filename="$(arg rotors_description_dir)/urdf/fixedwing_base.xacro" />
+  <origin xyz="0 0 0.246" rpy="0 0 0" />
+
+  <!-- Instantiate multirotor_base_macro once -->
+  <xacro:fixedwing_base_macro
+    robot_namespace="${namespace}">
+    <origin xyz="0 0 0.0" rpy="0 0 0" />      
+  </xacro:fixedwing_base_macro>
+
+  <!-- Instantiate rotors -->
+  <xacro:horizontal_rotor
+    robot_namespace="${namespace}"
+    suffix="front_right"
+    direction="cw"
+    motor_constant="${motor_constant}"
+    moment_constant="${moment_constant}"
+    parent="base_link"
+    mass_rotor="${mass_rotor}"
+    radius_rotor="0.1"
+    time_constant_up="${time_constant_up}"
+    time_constant_down="${time_constant_down}"
+    max_rot_velocity="${max_rot_velocity}"
+    motor_number="4"
+    rotor_drag_coefficient="${rotor_drag_coefficient}"
+    rolling_moment_coefficient="${rolling_moment_coefficient}"
+    mesh="iris_prop"
+    mesh_scale="1 1 1"
+    color="Blue">
+    <origin xyz="0.3 0 0.0" rpy="0 1.57 0" />
+    <xacro:insert_block name="rotor_inertia" />
+  </xacro:horizontal_rotor>
+
+  <!-- Left Aileron -->
+  <xacro:control_surface
+    robot_namespace="${namespace}"
+    link_name="left_elevon"
+    parent="base_link"
+    mesh_file="model://plane/meshes/left_aileron.dae"
+    mesh_scale="0.1 0.1 0.1"
+    color="Blue"
+    area="0.12"
+    control_joint_rad_to_cl="-0.5"
+    a0="0.05984281113"
+    cpx="-0.05"
+    cpy="0.3"
+    cpz="0.05"
+    upx="0"
+    upy="0"
+    upz="1"
+    joint_limit="0.53">
+    <origin xyz="0.0 0.0 0.0" rpy="0 0 0" />
+    <axis xyz="0 1 0" />
+    <xacro:insert_block name="left_aileron_joint_origin" />
+    <xacro:insert_block name="left_aileron_mesh_origin" />
+  </xacro:control_surface> 
+
+  <!-- Right Aileron -->
+  <xacro:control_surface
+    robot_namespace="${namespace}"
+    link_name="right_elevon"
+    parent="base_link"
+    mesh_file="model://plane/meshes/right_aileron.dae"
+    mesh_scale="0.1 0.1 0.1"
+    color="Blue"
+    area="0.12"
+    control_joint_rad_to_cl="-0.5"
+    a0="0.05984281113"
+    cpx="-0.05"
+    cpy="-0.3"
+    cpz="0.05"
+    upx="0"
+    upy="0"
+    upz="1"
+    joint_limit="0.53">
+    <origin xyz="0.0 0.0 0.0" rpy="0 0 0" />
+    <axis xyz="0 1 0" />
+    <xacro:insert_block name="right_aileron_joint_origin" />
+    <xacro:insert_block name="right_aileron_mesh_origin" />
+  </xacro:control_surface> 
+
+  <!-- Elevator -->
+  <xacro:control_surface
+    robot_namespace="${namespace}"
+    link_name="elevator"
+    mesh_file="model://plane/meshes/elevators.dae"
+    parent="base_link"
+    mesh_scale="0.1 0.1 0.1"
+    color="Blue"
+    area="0.01"
+    control_joint_rad_to_cl="-4.0"
+    a0="-0.2"
+    cpx="-0.5"
+    cpy="0"
+    cpz="0.0"
+    upx="0"
+    upy="0"
+    upz="1"
+    joint_limit="0.53">
+    <origin xyz="0.0 0.0 0.0" rpy="0 0 0" />
+    <axis xyz="0 1 0" />
+      <xacro:insert_block name="elevator_joint_origin" />
+    <xacro:insert_block name="elevator_mesh_origin" />
+  </xacro:control_surface> 
+
+
+  <!-- Rudder -->
+  <xacro:control_surface
+    robot_namespace="${namespace}"
+    link_name="rudder"
+    parent="base_link"
+    mesh_file="model://plane/meshes/rudder.dae"
+    mesh_scale="0.1 0.1 0.1"
+    color="Blue"
+    area="0.02"
+    control_joint_rad_to_cl="-0.5"
+    a0="0.0"
+    cpx="-0.5"
+    cpy="0"
+    cpz="0.05"
+    upx="0"
+    upy="1"
+    upz="0"
+    joint_limit="0.53">
+    <origin xyz="0.0 0.0 0.0" rpy="0 0 0" />
+    <axis xyz="0 0 1" />
+    <xacro:insert_block name="rudder_joint_origin" />
+    <xacro:insert_block name="rudder_mesh_origin" />
+  </xacro:control_surface> 
+
+</robot>

--- a/models/rotors_description/urdf/plane_base.xacro
+++ b/models/rotors_description/urdf/plane_base.xacro
@@ -1,0 +1,191 @@
+<?xml version="1.0"?>
+
+<robot name="plane" xmlns:xacro="http://ros.org/wiki/xacro">
+  <!-- Properties that can be assigned at build time as arguments.
+  Is there a reason not to make all properties arguments?
+  -->
+  <xacro:arg name='name' default='plane' />
+  <xacro:arg name='mavlink_addr' default='INADDR_ANY' />
+  <xacro:arg name='mavlink_udp_port' default='14560' />
+  <xacro:arg name='mavlink_tcp_port' default='4560' />
+  <xacro:arg name='serial_enabled' default='false' />
+  <xacro:arg name='serial_device' default='/dev/ttyACM0' />
+  <xacro:arg name='baudrate' default='921600' />
+  <xacro:arg name='qgc_addr' default='INADDR_ANY' />
+  <xacro:arg name='qgc_udp_port' default='14550' />
+  <xacro:arg name='sdk_addr' default='INADDR_ANY' />
+  <xacro:arg name='sdk_udp_port' default='14540' />
+  <xacro:arg name='hil_mode' default='false' />
+  <xacro:arg name='hil_state_level' default='false' />
+  <xacro:arg name='send_vision_estimation' default='false' />
+  <xacro:arg name='send_odometry' default='false' />
+  <xacro:arg name='enable_lockstep' default='true' />
+  <xacro:arg name='use_tcp' default='true' />
+  <xacro:arg name='vehicle_is_tailsitter' default='false' />
+  <xacro:arg name='visual_material' default='DarkGrey' />
+  <xacro:arg name='enable_mavlink_interface' default='true' />
+  <xacro:arg name='enable_wind' default='false' />
+  <!-- The following causes segfault with multiple vehicles if defaults to true!!! -->
+  <xacro:arg name='enable_ground_truth' default='false' />
+  <xacro:arg name='enable_logging' default='false' />
+  <xacro:arg name='log_file' default='iris' />
+
+  <!-- macros for gazebo plugins, sensors -->
+  <xacro:include filename="$(arg rotors_description_dir)/urdf/component_snippets.xacro" />
+
+  <!-- Instantiate iris "mechanics" -->
+  <xacro:include filename="$(arg rotors_description_dir)/urdf/plane.xacro" />
+
+  <xacro:if value="$(arg enable_wind)">
+    <xacro:wind_plugin_macro
+        namespace="${namespace}"
+        wind_direction="0 0 1"
+        wind_force_mean="0.7"
+        xyz_offset="1 0 0"
+        wind_gust_direction="0 0 0"
+        wind_gust_duration="0"
+        wind_gust_start="0"
+        wind_gust_force_mean="0"
+        />
+  </xacro:if>
+
+
+  <!-- Instantiate gps plugin. -->
+  <xacro:gps_plugin_macro
+    namespace="${namespace}"
+    gps_noise="true"
+    >
+  </xacro:gps_plugin_macro>
+
+  <!-- Instantiate magnetometer plugin. -->
+  <xacro:magnetometer_plugin_macro
+    namespace="${namespace}"
+    pub_rate="20"
+    noise_density="0.0004"
+    random_walk="0.0000064"
+    bias_correlation_time="600"
+    mag_topic="/mag"
+    >
+  </xacro:magnetometer_plugin_macro>
+
+  <!-- Instantiate barometer plugin. -->
+  <xacro:barometer_plugin_macro
+    namespace="${namespace}"
+    pub_rate="10"
+    baro_topic="/baro"
+    >
+  </xacro:barometer_plugin_macro>
+
+  <xacro:if value="$(arg enable_mavlink_interface)">
+  <!-- Instantiate mavlink telemetry interface. -->
+  <xacro:mavlink_interface_macro_fw
+    namespace="${namespace}"
+    imu_sub_topic="/imu"
+    gps_sub_topic="/gps"
+    mag_sub_topic="/mag"
+    baro_sub_topic="/baro"
+    mavlink_addr="$(arg mavlink_addr)"
+    mavlink_udp_port="$(arg mavlink_udp_port)"
+    mavlink_tcp_port="$(arg mavlink_tcp_port)"
+    serial_enabled="$(arg serial_enabled)"
+    serial_device="$(arg serial_device)"
+    baudrate="$(arg baudrate)"
+    qgc_addr="$(arg qgc_addr)"
+    qgc_udp_port="$(arg qgc_udp_port)"
+    sdk_addr="$(arg sdk_addr)"
+    sdk_udp_port="$(arg sdk_udp_port)"
+    hil_mode="$(arg hil_mode)"
+    hil_state_level="$(arg hil_state_level)"
+    vehicle_is_tailsitter="$(arg vehicle_is_tailsitter)"
+    send_vision_estimation="$(arg send_vision_estimation)"
+    send_odometry="$(arg send_odometry)"
+    enable_lockstep="$(arg enable_lockstep)"
+    use_tcp="$(arg use_tcp)"
+    >
+  </xacro:mavlink_interface_macro_fw>
+  </xacro:if>
+
+  <!-- Mount an ADIS16448 IMU. -->
+  <xacro:imu_plugin_macro
+    namespace="${namespace}"
+    imu_suffix=""
+    parent_link="base_link"
+    imu_topic="/imu"
+    mass_imu_sensor="0.015"
+    gyroscope_noise_density="0.0003394"
+    gyroscopoe_random_walk="0.000038785"
+    gyroscope_bias_correlation_time="1000.0"
+    gyroscope_turn_on_bias_sigma="0.0087"
+    accelerometer_noise_density="0.004"
+    accelerometer_random_walk="0.006"
+    accelerometer_bias_correlation_time="300.0"
+    accelerometer_turn_on_bias_sigma="0.1960"
+  >
+    <inertia ixx="0.00001" ixy="0.0" ixz="0.0" iyy="0.00001" iyz="0.0" izz="0.00001" />
+    <origin xyz="0 0 0" rpy="0 0 0" />
+  </xacro:imu_plugin_macro>
+
+  <xacro:if value="$(arg enable_ground_truth)">
+    <!-- Mount an IMU providing ground truth. -->
+    <xacro:imu_plugin_macro
+      namespace="${namespace}"
+      imu_suffix="gt"
+      parent_link="base_link"
+      imu_topic="ground_truth/imu"
+      mass_imu_sensor="0.00001"
+      gyroscope_noise_density="0.0"
+      gyroscopoe_random_walk="0.0"
+      gyroscope_bias_correlation_time="1000.0"
+      gyroscope_turn_on_bias_sigma="0.0"
+      accelerometer_noise_density="0.0"
+      accelerometer_random_walk="0.0"
+      accelerometer_bias_correlation_time="300.0"
+      accelerometer_turn_on_bias_sigma="0.0"
+    >
+      <inertia ixx="0.00001" ixy="0.0" ixz="0.0" iyy="0.00001" iyz="0.0" izz="0.00001" />
+      <origin xyz="0 0 0" rpy="0 0 0" />
+    </xacro:imu_plugin_macro>
+
+    <!-- Mount a generic odometry sensor providing ground truth. -->
+    <xacro:odometry_plugin_macro
+      namespace="${namespace}/ground_truth"
+      odometry_sensor_suffix="gt"
+      parent_link="base_link"
+      pose_topic="pose"
+      pose_with_covariance_topic="pose_with_covariance"
+      position_topic="position"
+      transform_topic="transform"
+      odometry_topic="odometry"
+      parent_frame_id="world"
+      mass_odometry_sensor="0.00001"
+      measurement_divisor="1"
+      measurement_delay="0"
+      unknown_delay="0.0"
+      noise_normal_position="0 0 0"
+      noise_normal_quaternion="0 0 0"
+      noise_normal_linear_velocity="0 0 0"
+      noise_normal_angular_velocity="0 0 0"
+      noise_uniform_position="0 0 0"
+      noise_uniform_quaternion="0 0 0"
+      noise_uniform_linear_velocity="0 0 0"
+      noise_uniform_angular_velocity="0 0 0"
+      enable_odometry_map="false"
+      odometry_map=""
+      image_scale=""
+    >
+      <inertia ixx="0.00001" ixy="0.0" ixz="0.0" iyy="0.00001" iyz="0.0" izz="0.00001" /> <!-- [kg.m^2] [kg.m^2] [kg.m^2] [kg.m^2] [kg.m^2] [kg.m^2] -->
+      <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
+    </xacro:odometry_plugin_macro>
+  </xacro:if>
+
+  <xacro:if value="$(arg enable_logging)">
+    <!-- Instantiate a logger -->
+    <xacro:bag_plugin_macro
+      namespace="${namespace}"
+      bag_file="$(arg log_file)"
+      rotor_velocity_slowdown_sim="${rotor_velocity_slowdown_sim}"
+    >
+    </xacro:bag_plugin_macro>
+  </xacro:if>
+
+</robot>


### PR DESCRIPTION
**Describe problem solved by this pull request**
Since the plane model is defined as a sdf format, it was not possible to launch multivehicle simulation, as it relies on xacro macros to generate sdf files.

**Describe your solution**
This PR ports the `plane.sdf` into a xacro format so that it can generate sdf files for multivehicle simulations.

**Test data / coverage**
Video: 
[![Video](https://img.youtube.com/vi/aEzFKPMEfjc/0.jpg)](https://youtu.be/aEzFKPMEfjc "Hovering done")

**Describe possible alternatives**
We can get rid of the sdf file and move towards xacro files for vehicles that support multivehicle simulation, but I am not sure if this is the right direction since doing checks on xacros are quite hard and some configurations in xacro files lead to surprising results in the simulation. 

**Additional context**
- Unlike iris, the sdf file for the plane was not removed yet.
- This already includes rudder control as in https://github.com/PX4/sitl_gazebo/pull/384