### PR TITLE
Fix tiltrotor oscillations

### DIFF
--- a/models/tiltrotor/tiltrotor.sdf
+++ b/models/tiltrotor/tiltrotor.sdf
@@ -1086,7 +1086,7 @@
           <joint_control_type>position</joint_control_type>
           <joint_name>motor_0_joint</joint_name>
            <joint_control_pid>
-            <p>100</p>
+            <p>80</p>
             <i>0</i>
             <d>0</d>
             <iMax>0.0</iMax>
@@ -1104,7 +1104,7 @@
           <joint_control_type>position</joint_control_type>
           <joint_name>motor_1_joint</joint_name>
            <joint_control_pid>
-            <p>100</p>
+            <p>80</p>
             <i>0</i>
             <d>0</d>
             <iMax>0.0</iMax>
@@ -1122,7 +1122,7 @@
           <joint_control_type>position</joint_control_type>
           <joint_name>motor_2_joint</joint_name>
            <joint_control_pid>
-            <p>100</p>
+            <p>80</p>
             <i>0</i>
             <d>0</d>
             <iMax>0.0</iMax>
@@ -1140,7 +1140,7 @@
           <joint_control_type>position</joint_control_type>
           <joint_name>motor_3_joint</joint_name>
            <joint_control_pid>
-            <p>100</p>
+            <p>80</p>
             <i>0</i>
             <d>0</d>
             <iMax>0.0</iMax>


### PR DESCRIPTION
Tilt rotors were oscillating rapidly when stationary. This was due to the high gains of the joint control pid loop of the tilt joints. This PR lowers the gains slightly so the oscillations are not visible anymore

Before PR:
![tiltrotor](https://user-images.githubusercontent.com/5248102/71743603-3d1b5f00-2e65-11ea-95f7-c7e750bcc163.gif)

After PR:
![tiltrotor_pr](https://user-images.githubusercontent.com/5248102/71744130-a51e7500-2e66-11ea-8950-8bf30028b47b.gif)
(this is not a image, but a moving gif)
After the joint control gain has been lowered, the vehicle is still able to fly a successful mission: [log](https://review.px4.io/plot_app?log=396cd69d-272f-4416-b127-c50ea4c35439)