### PR TITLE
Update gazebo_gst_camera_plugin for customable UDP Host

### DIFF
--- a/include/gazebo_gst_camera_plugin.h
+++ b/include/gazebo_gst_camera_plugin.h
@@ -65,7 +65,7 @@ class GAZEBO_VISIBLE GstCameraPlugin : public SensorPlugin
   float rate;
   protected: std::string format;
 
-  protected: std::string udpDstIP;
+  protected: std::string udpHost;
   protected: int udpPort;
 
   protected: sensors::CameraSensorPtr parentSensor;

--- a/include/gazebo_gst_camera_plugin.h
+++ b/include/gazebo_gst_camera_plugin.h
@@ -35,7 +35,7 @@ namespace gazebo
 /**
  * @class GstCameraPlugin
  * A Gazebo plugin that can be attached to a camera and then streams the video data using gstreamer.
- * It streams to a configurable UDP port, default is 5600.
+ * It streams to a configurable UDP IP and UDP Port, defaults are respectively 127.0.0.1 and 5600.
  *
  * Connect to the stream via command line with:
  * gst-launch-1.0  -v udpsrc port=5600 caps='application/x-rtp, media=(string)video, clock-rate=(int)90000, encoding-name=(string)H264' \
@@ -65,6 +65,7 @@ class GAZEBO_VISIBLE GstCameraPlugin : public SensorPlugin
   float rate;
   protected: std::string format;
 
+  protected: std::string udpDstIP;
   protected: int udpPort;
 
   protected: sensors::CameraSensorPtr parentSensor;

--- a/models/typhoon_h480/typhoon_h480.sdf
+++ b/models/typhoon_h480/typhoon_h480.sdf
@@ -420,7 +420,7 @@
              camera image size) -->
         <plugin name="GstCameraPlugin" filename="libgazebo_gst_camera_plugin.so">
             <robotNamespace></robotNamespace>
-            <udpDstIP>5600</udpDstIP>
+            <udpDstIP>127.0.0.1</udpDstIP>
             <udpPort>5600</udpPort>
         </plugin>
         <plugin name="GeotaggedImagesPlugin" filename="libgazebo_geotagged_images_plugin.so">

--- a/models/typhoon_h480/typhoon_h480.sdf
+++ b/models/typhoon_h480/typhoon_h480.sdf
@@ -420,6 +420,7 @@
              camera image size) -->
         <plugin name="GstCameraPlugin" filename="libgazebo_gst_camera_plugin.so">
             <robotNamespace></robotNamespace>
+            <udpDstIP>5600</udpDstIP>
             <udpPort>5600</udpPort>
         </plugin>
         <plugin name="GeotaggedImagesPlugin" filename="libgazebo_geotagged_images_plugin.so">

--- a/models/typhoon_h480/typhoon_h480.sdf
+++ b/models/typhoon_h480/typhoon_h480.sdf
@@ -420,7 +420,7 @@
              camera image size) -->
         <plugin name="GstCameraPlugin" filename="libgazebo_gst_camera_plugin.so">
             <robotNamespace></robotNamespace>
-            <udpDstIP>127.0.0.1</udpDstIP>
+            <udpHost>127.0.0.1</udpHost>
             <udpPort>5600</udpPort>
         </plugin>
         <plugin name="GeotaggedImagesPlugin" filename="libgazebo_geotagged_images_plugin.so">

--- a/src/gazebo_gst_camera_plugin.cpp
+++ b/src/gazebo_gst_camera_plugin.cpp
@@ -132,7 +132,7 @@ void GstCameraPlugin::startGstThread() {
   g_object_set(G_OBJECT(payload), "config-interval", 1, NULL);
 
   // Config udpsink
-  g_object_set(G_OBJECT(sink), "host", this->udpDstIP.c_str(), NULL);
+  g_object_set(G_OBJECT(sink), "host", this->udpHost.c_str(), NULL);
   g_object_set(G_OBJECT(sink), "port", this->udpPort, NULL);
   //g_object_set(G_OBJECT(sink), "sync", false, NULL);
   //g_object_set(G_OBJECT(sink), "async", false, NULL);
@@ -251,9 +251,9 @@ void GstCameraPlugin::Load(sensors::SensorPtr sensor, sdf::ElementPtr sdf)
   else
     gzwarn << "[gazebo_gst_camera_plugin] Please specify a robotNamespace.\n";
 
-  this->udpDstIP = "127.0.0.1";
-  if (sdf->HasElement("udpDstIP")) {
-	this->udpDstIP = sdf->GetElement("udpDstIP")->Get<string>();
+  this->udpHost = "127.0.0.1";
+  if (sdf->HasElement("udpHost")) {
+	this->udpHost = sdf->GetElement("udpHost")->Get<string>();
   }
 	
   this->udpPort = 5600;

--- a/src/gazebo_gst_camera_plugin.cpp
+++ b/src/gazebo_gst_camera_plugin.cpp
@@ -132,7 +132,7 @@ void GstCameraPlugin::startGstThread() {
   g_object_set(G_OBJECT(payload), "config-interval", 1, NULL);
 
   // Config udpsink
-  g_object_set(G_OBJECT(sink), "host", "127.0.0.1", NULL);
+  g_object_set(G_OBJECT(sink), "host", this->udpDstIP.c_str(), NULL);
   g_object_set(G_OBJECT(sink), "port", this->udpPort, NULL);
   //g_object_set(G_OBJECT(sink), "sync", false, NULL);
   //g_object_set(G_OBJECT(sink), "async", false, NULL);
@@ -251,6 +251,11 @@ void GstCameraPlugin::Load(sensors::SensorPtr sensor, sdf::ElementPtr sdf)
   else
     gzwarn << "[gazebo_gst_camera_plugin] Please specify a robotNamespace.\n";
 
+  this->udpDstIP = "127.0.0.1";
+  if (sdf->HasElement("udpDstIP")) {
+	this->udpDstIP = sdf->GetElement("udpDstIP")->Get<string>();
+  }
+	
   this->udpPort = 5600;
   if (sdf->HasElement("udpPort")) {
 	this->udpPort = sdf->GetElement("udpPort")->Get<int>();


### PR DESCRIPTION
Hello, 
I'm working on OpenCV with gazebo. And usually It's needed to stream gstreamer video to another device IP (e.g. raspberry pi). So, it could be wonderful to add this PR to avoid change IP from here: https://github.com/PX4/sitl_gazebo/blob/b35b43934044e4f4ef52a0ae1a3316f07e5671b5/src/gazebo_gst_camera_plugin.cpp#L135

I added following commits like UDP port and also I added custom IP to Typhoon_h480 SDF file to check if it's running on typhoon model.