### PR TITLE
Decrease drift on simulated vision system

### DIFF
--- a/models/iris_vision/iris_vision.sdf
+++ b/models/iris_vision/iris_vision.sdf
@@ -3,7 +3,7 @@
     <plugin name="vision_plugin" filename="libgazebo_vision_plugin.so">
         <robotNamespace></robotNamespace>
         <pubRate>30</pubRate>
-        <randomWalk>1.0</randomWalk>
+        <randomWalk>0.1</randomWalk>
         <noiseDensity>5e-04</noiseDensity>
         <corellationTime>60.0</corellationTime>
     </plugin>

--- a/src/gazebo_mavlink_interface.cpp
+++ b/src/gazebo_mavlink_interface.cpp
@@ -998,7 +998,7 @@ void GazeboMavlinkInterface::VisionCallback(OdomPtr& odom_message) {
 
     odom.time_usec = odom_message->time_usec();
 
-    odom.frame_id = MAV_FRAME_VISION_NED;
+    odom.frame_id = MAV_FRAME_LOCAL_FRD;
     odom.child_frame_id = MAV_FRAME_BODY_FRD;
 
     odom.x = position.X();

--- a/src/gazebo_vision_plugin.cpp
+++ b/src/gazebo_vision_plugin.cpp
@@ -204,9 +204,9 @@ void VisionPlugin::OnUpdate(const common::UpdateInfo&)
     odom_msg.set_allocated_orientation(orientation);
 
     gazebo::msgs::Vector3d* linear_velocity = new gazebo::msgs::Vector3d();
-    linear_velocity->set_x(velocity_model_world.X() + noise_linvel.X() + _bias.X());
-    linear_velocity->set_y(velocity_model_world.Y() + noise_linvel.Y() + _bias.Y());
-    linear_velocity->set_z(velocity_model_world.Z() + noise_linvel.Z() + _bias.Z());
+    linear_velocity->set_x(velocity_model_world.X() + noise_linvel.X());
+    linear_velocity->set_y(velocity_model_world.Y() + noise_linvel.Y());
+    linear_velocity->set_z(velocity_model_world.Z() + noise_linvel.Z());
     odom_msg.set_allocated_linear_velocity(linear_velocity);
 
     gazebo::msgs::Vector3d* angular_velocity = new gazebo::msgs::Vector3d();


### PR DESCRIPTION
The modeled drift of the vision system is driven by a random walk. The previous random walk parameter feels to be too high as it caused the drone to drift multiple meters without any user input.
Decreasing the parameter to 0.1 made it stay roughly in place, which is matches my observation from test flights. One could think of scaling the random walk based on velocity as most of the vision drift is accumulated during motion.

Previously the bias (=drift) was added to the velocity as well. This seems not correct as a VIO system should be able to provide drift free velocity.