### PR TITLE
gazebo_lidar_plugin: Rename class to LidarPlugin

### DIFF
--- a/include/gazebo_lidar_plugin.h
+++ b/include/gazebo_lidar_plugin.h
@@ -15,12 +15,12 @@
  *
 */
 /*
- * Desc: Ray Plugin
+ * Desc: Lidar Plugin
  * Author: Nate Koenig mod by John Hsu
  */
 
-#ifndef _GAZEBO_RAY_PLUGIN_HH_
-#define _GAZEBO_RAY_PLUGIN_HH_
+#ifndef _GAZEBO_LIDAR_PLUGIN_HH_
+#define _GAZEBO_LIDAR_PLUGIN_HH_
 
 #include <gazebo/gazebo.hh>
 #include <gazebo/common/common.hh>
@@ -46,13 +46,13 @@ namespace gazebo
   static constexpr double kDefaultFOV = 0.0523598776;   // standard 3 degrees
 
   /// \brief A Ray Sensor Plugin
-  class GAZEBO_VISIBLE RayPlugin : public SensorPlugin
+  class GAZEBO_VISIBLE LidarPlugin : public SensorPlugin
   {
     /// \brief Constructor
-    public: RayPlugin();
+    public: LidarPlugin();
 
     /// \brief Destructor
-    public: virtual ~RayPlugin();
+    public: virtual ~LidarPlugin();
 
     /// \brief Update callback
     public: virtual void OnNewLaserScans();
@@ -76,7 +76,7 @@ namespace gazebo
 
       gazebo::msgs::Quaternion orientation_;
 
-    /// \brief The connection tied to RayPlugin::OnNewLaserScans()
+    /// \brief The connection tied to LidarPlugin::OnNewLaserScans()
     private:
       event::ConnectionPtr newLaserScansConnection_;
       sensor_msgs::msgs::Range lidar_message_;

--- a/src/gazebo_lidar_plugin.cpp
+++ b/src/gazebo_lidar_plugin.cpp
@@ -33,15 +33,15 @@ using namespace gazebo;
 using namespace std;
 
 // Register this plugin with the simulator
-GZ_REGISTER_SENSOR_PLUGIN(RayPlugin)
+GZ_REGISTER_SENSOR_PLUGIN(LidarPlugin)
 
 /////////////////////////////////////////////////
-RayPlugin::RayPlugin()
+LidarPlugin::LidarPlugin()
 {
 }
 
 /////////////////////////////////////////////////
-RayPlugin::~RayPlugin()
+LidarPlugin::~LidarPlugin()
 {
   newLaserScansConnection_->~Connection();
   newLaserScansConnection_.reset();
@@ -50,18 +50,18 @@ RayPlugin::~RayPlugin()
 }
 
 /////////////////////////////////////////////////
-void RayPlugin::Load(sensors::SensorPtr _parent, sdf::ElementPtr _sdf)
+void LidarPlugin::Load(sensors::SensorPtr _parent, sdf::ElementPtr _sdf)
 {
   // Get then name of the parent sensor
   parentSensor_ = std::dynamic_pointer_cast<sensors::RaySensor>(_parent);
 
   if (!parentSensor_)
-    gzthrow("RayPlugin requires a Ray Sensor as its parent");
+    gzthrow("LidarPlugin requires a Ray Sensor as its parent");
 
   world_ = physics::get_world(parentSensor_->WorldName());
 
   newLaserScansConnection_ = parentSensor_->LaserShape()->ConnectNewLaserScans(
-      boost::bind(&RayPlugin::OnNewLaserScans, this));
+      boost::bind(&LidarPlugin::OnNewLaserScans, this));
 
   if (_sdf->HasElement("robotNamespace"))
     namespace_ = _sdf->GetElement("robotNamespace")->Get<std::string>();
@@ -129,7 +129,7 @@ void RayPlugin::Load(sensors::SensorPtr _parent, sdf::ElementPtr _sdf)
 }
 
 /////////////////////////////////////////////////
-void RayPlugin::OnNewLaserScans()
+void LidarPlugin::OnNewLaserScans()
 {
   // Get the current simulation time.
 #if GAZEBO_MAJOR_VERSION >= 9


### PR DESCRIPTION
The old name 'RayPlugin' collides with Gazebo's own RayPlugin, causing errors (failure to load plugin, or segfaults) when plugins are being loaded. This issue seems to happens if you try to load PX4 sitl_gazebo's `gazebo_lidar_plugin` alongside any other Gazebo plugin using RayPlugin. I'm guessing this plugin was based on an implementation of RayPlugin from Gazebo, and the implementer forgot to change the class name.

