### PR TITLE
Catapult plugin for simulating catapult / handlaunching fixed wing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -326,6 +326,7 @@ add_library(gazebo_multirotor_base_plugin SHARED src/gazebo_multirotor_base_plug
 add_library(gazebo_wind_plugin SHARED src/gazebo_wind_plugin.cpp)
 add_library(gazebo_magnetometer_plugin SHARED src/gazebo_magnetometer_plugin.cpp src/geo_mag_declination.cpp)
 add_library(gazebo_barometer_plugin SHARED src/gazebo_barometer_plugin.cpp)
+add_library(gazebo_catapult_plugin SHARED src/gazebo_catapult_plugin.cpp)
 
 set(plugins
   gazebo_geotagged_images_plugin
@@ -345,6 +346,7 @@ set(plugins
   gazebo_wind_plugin
   gazebo_magnetometer_plugin
   gazebo_barometer_plugin
+  gazebo_catapult_plugin
   )
 
 foreach(plugin ${plugins})

--- a/include/gazebo_catapult_plugin.h
+++ b/include/gazebo_catapult_plugin.h
@@ -1,0 +1,110 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+/**
+ * @brief Catapult Plugin
+ *
+ * This plugin simulates a catapult / handlaunch for fixed wing vehicles
+ *
+ * @author Jaeyoung Lim <jaeyoung@auterion.com>
+ */
+
+#ifndef _GAZEBO_CATAPULT_PLUGIN_HH_
+#define _GAZEBO_CATAPULT_PLUGIN_HH_
+
+#include <math.h>
+#include <common.h>
+#include <sdf/sdf.hh>
+
+#include <gazebo/common/common.hh>
+#include <gazebo/common/Plugin.hh>
+#include <gazebo/gazebo.hh>
+#include <gazebo/util/system.hh>
+#include <gazebo/transport/transport.hh>
+#include <gazebo/msgs/msgs.hh>
+#include <gazebo/physics/physics.hh>
+#include <ignition/math.hh>
+#include "CommandMotorSpeed.pb.h"
+
+
+#include <Odometry.pb.h>
+
+namespace gazebo
+{
+
+typedef const boost::shared_ptr<const mav_msgs::msgs::CommandMotorSpeed> CommandMotorSpeedPtr;
+
+enum LaunchStatus {
+    VEHICLE_STANDBY,
+    VEHICLE_INLAUNCH,
+    VEHICLE_LAUNCHED
+};
+
+class GAZEBO_VISIBLE CatapultPlugin : public ModelPlugin
+{
+public:
+  CatapultPlugin();
+  virtual ~CatapultPlugin();
+
+protected:
+  virtual void Load(physics::ModelPtr model, sdf::ElementPtr sdf);
+  virtual void OnUpdate(const common::UpdateInfo&);
+
+private:
+  void TriggerCallback(const boost::shared_ptr<const msgs::Int> &_msg);
+  void VelocityCallback(CommandMotorSpeedPtr &rot_velocities);
+
+  std::string namespace_;
+  physics::ModelPtr model_;
+  physics::WorldPtr world_;
+  physics::LinkPtr link_;
+
+  event::ConnectionPtr _updateConnection;
+
+  LaunchStatus launch_status_;
+  common::Time trigger_time_;
+  
+  double max_rot_velocity_ = 3500;
+  double ref_motor_rot_vel_;
+  double arm_rot_vel_ = 100;
+  double launch_duration_ = 0.01;
+  double force_magnitude_ = 1.0;
+  int motor_number_;
+
+  std::string trigger_sub_topic_ = "/gazebo/command/motor_speed";
+
+  transport::NodePtr node_handle_;
+  transport::SubscriberPtr trigger_sub_;
+
+};     // class GAZEBO_VISIBLE CatapultPlugin
+}      // namespace gazebo
+#endif // _GAZEBO_CATAPULT_PLUGIN_HH_

--- a/models/plane_catapult/model.config
+++ b/models/plane_catapult/model.config
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<model>
+  <name>plane_catapult</name>
+  <version>1.0</version>
+  <sdf version='1.5'>plane_catapult.sdf</sdf>
+  <description>
+    This is a model of a standard plane with a camera
+  </description>  
+</model>

--- a/models/plane_catapult/plane_catapult.sdf
+++ b/models/plane_catapult/plane_catapult.sdf
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<sdf version='1.5'>
+  <model name='plane_catapult'>
+    <include>
+      <uri>model://plane</uri>
+    </include>
+    <!--fixedwing catapult-->
+    <plugin name='catapult_plugin' filename='libgazebo_catapult_plugin.so'>
+      <robotNamespace/>
+      <link_name>plane::base_link</link_name>
+      <commandSubTopic>/gazebo/command/motor_speed</commandSubTopic>
+      <motorNumber>4</motorNumber>
+      <force>50.0</force>
+      <duration>0.5</duration>
+    </plugin>
+  </model>
+</sdf>

--- a/src/gazebo_catapult_plugin.cpp
+++ b/src/gazebo_catapult_plugin.cpp
@@ -1,0 +1,138 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+/**
+ * @brief Catapult Plugin
+ *
+ * This plugin simulates a catapult / handlaunch for fixed wing vehicles
+ *
+ * @author Jaeyoung Lim <jaeyoung@auterion.com>
+ */
+
+#include "gazebo_catapult_plugin.h"
+
+namespace gazebo {
+GZ_REGISTER_MODEL_PLUGIN(CatapultPlugin)
+
+CatapultPlugin::CatapultPlugin() : ModelPlugin()
+{
+}
+
+CatapultPlugin::~CatapultPlugin()
+{
+  _updateConnection->~Connection();
+}
+
+void CatapultPlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf)
+{
+  model_ = _model;
+  world_ = model_->GetWorld();
+
+  namespace_.clear();
+  if (_sdf->HasElement("robotNamespace")) {
+    namespace_ = _sdf->GetElement("robotNamespace")->Get<std::string>();
+  } else {
+    gzerr << "[gazebo_catapult_plugin] Please specify a robotNamespace.\n";
+  }
+
+  if (_sdf->HasElement("link_name")) {
+    sdf::ElementPtr elem = _sdf->GetElement("link_name");
+    std::string linkName = elem->Get<std::string>();
+    this->link_ = this->model_->GetLink(linkName);
+
+    if (!this->link_) {
+      gzerr << "Link with name[" << linkName << "] not found. "
+        << "The Catapult plugin will not be able to launch the vehicle\n";
+    }
+  } else {
+    gzerr << "[gazebo_catapult_plugin] link_name needs to be provided";
+  }
+
+  if (_sdf->HasElement("motorNumber"))
+    motor_number_ = _sdf->GetElement("motorNumber")->Get<int>();
+  else
+    gzerr << "[gazebo_catapult_plugin] Please specify a motorNumber.\n";
+
+  getSdfParam<std::string>(_sdf, "commandSubTopic", trigger_sub_topic_, trigger_sub_topic_);
+  getSdfParam<double>(_sdf, "force", force_magnitude_, force_magnitude_);
+  getSdfParam<std::string>(_sdf, "direction", trigger_sub_topic_, trigger_sub_topic_);
+  getSdfParam<double>(_sdf, "duration", launch_duration_, launch_duration_);
+
+  // Listen to the update event. This event is broadcast every simulation iteration.
+  _updateConnection = event::Events::ConnectWorldUpdateBegin(boost::bind(&CatapultPlugin::OnUpdate, this, _1));
+
+  node_handle_ = transport::NodePtr(new transport::Node());
+  node_handle_->Init(namespace_);
+
+  trigger_sub_ = node_handle_->Subscribe("~/" + model_->GetName() + trigger_sub_topic_, &CatapultPlugin::VelocityCallback, this);
+}
+
+void CatapultPlugin::OnUpdate(const common::UpdateInfo&){
+
+    bool vehicle_launched_ = false;
+    //Launch vehicle if the vehilce is armed
+    if(ref_motor_rot_vel_ > arm_rot_vel_ && launch_status_ != VEHICLE_LAUNCHED ) {
+      if(launch_status_ == VEHICLE_STANDBY) {
+      #if GAZEBO_MAJOR_VERSION >= 9
+        trigger_time_ = world_->SimTime();
+      #else
+        trigger_time_ = world_->GetSimTime();
+      #endif
+        launch_status_ = VEHICLE_INLAUNCH;
+        std::cout << "[gazebo_catapult_plugin] Catapult armed " << std::endl;
+      
+      } else { // launch_status = VEHICLE_INLAUNCH
+        //Define launch direction
+        ignition::math::Vector3d direction(1.0, 0.0, 2.0);
+        direction.Normalize();
+
+        //Apply force to the vehicle
+        ignition::math::Vector3d force = force_magnitude_ * direction;
+        this->link_->AddForce(force);     
+        #if GAZEBO_MAJOR_VERSION >= 9
+          common::Time curr_time = world_->SimTime();
+        #else
+          common::Time curr_time = world_->GetSimTime();
+        #endif
+        if (curr_time - trigger_time_  > launch_duration_) launch_status_ = VEHICLE_LAUNCHED;
+      }
+    }
+}
+
+void CatapultPlugin::VelocityCallback(CommandMotorSpeedPtr &rot_velocities) {
+  if(rot_velocities->motor_speed_size() < motor_number_) {
+    std::cout  << "You tried to access index " << motor_number_
+      << " of the MotorSpeed message array which is of size " << rot_velocities->motor_speed_size() << "." << std::endl;
+  } else ref_motor_rot_vel_ = std::min(static_cast<double>(rot_velocities->motor_speed(motor_number_)), static_cast<double>(max_rot_velocity_));
+}
+
+} // namespace gazebo

--- a/worlds/plane_catapult.world
+++ b/worlds/plane_catapult.world
@@ -1,0 +1,50 @@
+<?xml version="1.0" ?>
+<sdf version="1.5">
+  <world name="default">
+    <!-- A global light source -->
+    <include>
+      <uri>model://sun</uri>
+    </include>
+    <!-- A ground plane -->
+    <include>
+      <uri>model://ground_plane</uri>
+    </include>
+    <include>
+      <uri>model://plane_catapult</uri>
+    </include>
+    <physics name='default_physics' default='0' type='ode'>
+      <gravity>0 0 -9.8066</gravity>
+      <ode>
+        <solver>
+          <type>quick</type>
+          <iters>10</iters>
+          <sor>1.3</sor>
+          <use_dynamic_moi_rescaling>0</use_dynamic_moi_rescaling>
+        </solver>
+        <constraints>
+          <cfm>0</cfm>
+          <erp>0.2</erp>
+          <contact_max_correcting_vel>100</contact_max_correcting_vel>
+          <contact_surface_layer>0.001</contact_surface_layer>
+        </constraints>
+      </ode>
+      <max_step_size>0.004</max_step_size>
+      <real_time_factor>1</real_time_factor>
+      <real_time_update_rate>250</real_time_update_rate>
+      <magnetic_field>6.0e-6 2.3e-5 -4.2e-5</magnetic_field>
+    </physics>
+    <!--
+    <gui fullscreen='0'>
+      <camera name='user_camera'>
+        <pose>5.4634 -5.46339 2.17586 0 0.275643 2.35619</pose>
+        <view_controller>orbit</view_controller>
+        <projection_type>perspective</projection_type>
+        <track_visual>
+          <name>plane</name>
+          <use_model_frame>1</use_model_frame>
+        </track_visual>
+      </camera>
+    </gui>
+  -->
+  </world>
+</sdf>


### PR DESCRIPTION
**Describe problem solved by this pull request**
This PR implements a catapult plugin, which simulates fixed wing being launched by a catapult or being hand launched. This is required to test the takeoff mode of the fixed wing, which has been largely untested in simulation until now. 

**Describe your solution**
The plugin applies a fixed amount of force for a specified duration to simulate the launch. 

**Describe possible alternatives**
This could have been implemented on a much aesthetically pleasing way, with a separate catapult mesh, but I think it is good enough for now to cover the tests that is needed for the firmware. It was very hard to find a good mesh of a catapult without licensing problems. 

**Test data / coverage**
![launcher](https://user-images.githubusercontent.com/5248102/72202253-6d628f00-345d-11ea-9df0-4eaa0bba8b07.gif)


**Additional context**
This was brought up from a discussion with @dagar  