### PR TITLE
Update gazebo_video_stream_widget.h

### DIFF
--- a/include/gazebo_video_stream_widget.h
+++ b/include/gazebo_video_stream_widget.h
@@ -19,10 +19,10 @@
 
 #include <gazebo/common/Plugin.hh>
 #include <gazebo/gui/GuiPlugin.hh>
-#if GAZEBO_MAJOR_VERSION >= 9
+#ifndef Q_MOC_RUN  // See: https://bugreports.qt-project.org/browse/QTBUG-22829
+#   if GAZEBO_MAJOR_VERSION >= 9
 #include <gazebo/transport/transport.hh>
-#else
-#   ifndef Q_MOC_RUN  // See: https://bugreports.qt-project.org/browse/QTBUG-22829
+#   else
 #include <gazebo/transport/transport.hh>
 #include <gazebo/gui/gui.hh>
 #   endif


### PR DESCRIPTION
The MOC bug applies to any version of gazebo, not just < 9. You want to avoid including <gazebo/transport/transport.hh> during a MOC run.