### PR TITLE
Add support for VTOL multivehicle simulation in SITL gazebo

### DIFF
--- a/models/rotors_description/urdf/component_snippets.xacro
+++ b/models/rotors_description/urdf/component_snippets.xacro
@@ -366,6 +366,120 @@
     </gazebo>
   </xacro:macro>
 
+  <!-- Macro to add the mavlink interface for a fixed-wing model. -->
+  <xacro:macro name="mavlink_interface_macro_vtol" params="namespace imu_sub_topic gps_sub_topic mag_sub_topic baro_sub_topic mavlink_addr mavlink_udp_port mavlink_tcp_port serial_enabled serial_device baudrate qgc_addr qgc_udp_port sdk_addr sdk_udp_port hil_mode hil_state_level vehicle_is_tailsitter send_vision_estimation send_odometry enable_lockstep use_tcp">
+    <gazebo>
+      <plugin name='mavlink_interface' filename='libgazebo_mavlink_interface.so'>
+        <robotNamespace>${namespace}</robotNamespace>
+        <imuSubTopic>${imu_sub_topic}</imuSubTopic>
+        <gpsSubTopic>${gps_sub_topic}</gpsSubTopic>
+        <magSubTopic>${mag_sub_topic}</magSubTopic>
+        <baroSubTopic>${baro_sub_topic}</baroSubTopic>
+        <mavlink_addr>$(arg mavlink_addr)</mavlink_addr>
+        <mavlink_udp_port>$(arg mavlink_udp_port)</mavlink_udp_port>
+        <mavlink_tcp_port>$(arg mavlink_tcp_port)</mavlink_tcp_port>
+        <serialEnabled>$(arg serial_enabled)</serialEnabled>
+        <serialDevice>$(arg serial_device)</serialDevice>
+        <baudRate>$(arg baudrate)</baudRate>
+        <qgc_addr>$(arg qgc_addr)</qgc_addr>
+        <qgc_udp_port>$(arg qgc_udp_port)</qgc_udp_port>
+        <sdk_addr>$(arg sdk_addr)</sdk_addr>
+        <sdk_udp_port>$(arg sdk_udp_port)</sdk_udp_port>
+        <hil_mode>$(arg hil_mode)</hil_mode>
+        <hil_state_level>$(arg hil_state_level)</hil_state_level>
+        <vehicle_is_tailsitter>$(arg vehicle_is_tailsitter)</vehicle_is_tailsitter>
+        <send_vision_estimation>$(arg send_vision_estimation)</send_vision_estimation>
+        <send_odometry>$(arg send_odometry)</send_odometry>
+        <enable_lockstep>$(arg enable_lockstep)</enable_lockstep>
+        <use_tcp>$(arg use_tcp)</use_tcp>
+        <motorSpeedCommandPubTopic>/gazebo/command/motor_speed</motorSpeedCommandPubTopic>
+        <control_channels>
+          <channel name="rotor0">
+            <input_index>0</input_index>
+            <input_offset>0</input_offset>
+            <input_scaling>1500</input_scaling>
+            <zero_position_disarmed>0</zero_position_disarmed>
+            <zero_position_armed>0</zero_position_armed>
+            <joint_control_type>velocity</joint_control_type>
+            <joint_name>rotor_0_joint</joint_name>
+          </channel>
+          <channel name="rotor1">
+            <input_index>1</input_index>
+            <input_offset>0</input_offset>
+            <input_scaling>1500</input_scaling>
+            <zero_position_disarmed>0</zero_position_disarmed>
+            <zero_position_armed>0</zero_position_armed>
+            <joint_control_type>velocity</joint_control_type>
+            <joint_name>rotor_1_joint</joint_name>
+          </channel>
+          <channel name="rotor2">
+            <input_index>2</input_index>
+            <input_offset>0</input_offset>
+            <input_scaling>1500</input_scaling>
+            <zero_position_disarmed>0</zero_position_disarmed>
+            <zero_position_armed>0</zero_position_armed>
+            <joint_control_type>velocity</joint_control_type>
+            <joint_name>rotor_2_joint</joint_name>
+          </channel>
+          <channel name="rotor3">
+            <input_index>3</input_index>
+            <input_offset>0</input_offset>
+            <input_scaling>1500</input_scaling>
+            <zero_position_disarmed>0</zero_position_disarmed>
+            <zero_position_armed>0</zero_position_armed>
+            <joint_control_type>velocity</joint_control_type>
+            <joint_name>rotor_3_joint</joint_name>
+          </channel>
+          <channel name="rotor4">
+            <input_index>4</input_index>
+            <input_offset>0</input_offset>
+            <input_scaling>5500</input_scaling>
+            <zero_position_disarmed>0</zero_position_disarmed>
+            <zero_position_armed>0</zero_position_armed>
+            <joint_control_type>velocity</joint_control_type>
+            <joint_name>rotor_puller_joint</joint_name>
+          </channel>
+          <channel name="left_elevon">
+            <input_index>5</input_index>
+            <input_offset>0</input_offset>
+            <input_scaling>1</input_scaling>
+            <zero_position_disarmed>0</zero_position_disarmed>
+            <zero_position_armed>0</zero_position_armed>
+            <joint_control_type>position_kinematic</joint_control_type>
+            <joint_name>left_elevon_joint</joint_name>
+          </channel>
+          <channel name="right_elevon">
+            <input_index>6</input_index>
+            <input_offset>0</input_offset>
+            <input_scaling>1</input_scaling>
+            <zero_position_disarmed>0</zero_position_disarmed>
+            <zero_position_armed>0</zero_position_armed>
+            <joint_control_type>position_kinematic</joint_control_type>
+            <joint_name>right_elevon_joint</joint_name>
+          </channel>
+          <channel name="elevator">
+            <input_index>7</input_index>
+            <input_offset>0</input_offset>
+            <input_scaling>1</input_scaling>
+            <zero_position_disarmed>0</zero_position_disarmed>
+            <zero_position_armed>0</zero_position_armed>
+            <joint_control_type>position_kinematic</joint_control_type>
+            <joint_name>elevator_joint</joint_name>
+          </channel>
+        </control_channels>
+        <left_elevon_joint>
+          left_elevon_joint
+        </left_elevon_joint>
+        <right_elevon_joint>
+          right_elevon_joint
+        </right_elevon_joint>
+        <elevator_joint>
+          elevator_joint
+        </elevator_joint>
+      </plugin>
+    </gazebo>
+  </xacro:macro>
+
   <!-- Macro to add an IMU. -->
   <xacro:macro name="imu_plugin_macro"
     params="namespace imu_suffix parent_link imu_topic

--- a/models/rotors_description/urdf/fixedwing_base.xacro
+++ b/models/rotors_description/urdf/fixedwing_base.xacro
@@ -181,4 +181,57 @@
         <implicitSpringDamper>True</implicitSpringDamper>
     </gazebo>
   </xacro:macro>
+
+  <xacro:macro name="hidden_control_surface"
+    params="robot_namespace link_name parent color area joint_limit control_joint_rad_to_cl a0 cpx cpy cpz upx upy upz *origin *joint_origin *axis">
+    <joint name="${link_name}_joint" type="revolute">
+      <parent link="${parent}" />
+      <child link="${link_name}" />
+      <xacro:insert_block name="joint_origin" />
+      <!-- <axis xyz="0 0 1" /> -->
+      <xacro:insert_block name="axis" />
+      <limit effort="1000" velocity="1000.0" lower="-${joint_limit}" upper="${joint_limit}" />
+      <!-- <dynamics damping="1.0"/> -->
+    </joint>
+    <link name="${link_name}">
+      <inertial>
+        <mass value="0.00001" /> <!-- [kg] -->
+        <inertia
+        ixx="0.000001"
+        iyy="0.000001"
+        izz="0.000001"
+        ixy="0.0" ixz="0.0"  iyz="0.0" /> <!-- [kg.m^2] [kg.m^2] [kg.m^2] [kg.m^2] [kg.m^2] [kg.m^2] -->
+        <xacro:insert_block name="origin" />
+      </inertial>
+    </link>
+    <gazebo>
+         <plugin name="${link_name}_plugin" filename="libLiftDragPlugin.so">
+            <a0>${a0}</a0>
+            <cla>4.752798721</cla>
+            <cda>0.6417112299</cda>
+            <cma>-1.8</cma>
+            <alpha_stall>0.3391428111</alpha_stall>
+            <cla_stall>-3.85</cla_stall>
+            <cda_stall>-0.9233984055</cda_stall>
+            <cma_stall>0</cma_stall>
+            <cp>${cpx} ${cpy} ${cpz}</cp>
+            <area>${area}</area>
+            <air_density>1.2041</air_density>
+            <forward>1 0 0</forward>
+            <upward>${upx} ${upy} ${upz}</upward>
+            <link_name>${parent}</link_name>
+            <control_joint_name>
+               ${link_name}_joint
+            </control_joint_name>
+            <control_joint_rad_to_cl>${control_joint_rad_to_cl}</control_joint_rad_to_cl>
+         </plugin>
+    </gazebo>
+    <gazebo reference="${link_name}">
+      <material>Gazebo/${color}</material>
+    </gazebo>
+    <gazebo reference="${link_name}_joint">
+        <implicitSpringDamper>True</implicitSpringDamper>
+    </gazebo>
+  </xacro:macro>
+
 </robot>

--- a/models/rotors_description/urdf/standard_vtol.xacro
+++ b/models/rotors_description/urdf/standard_vtol.xacro
@@ -1,0 +1,273 @@
+<?xml version="1.0"?>
+
+<robot name="standard_vtol" xmlns:xacro="http://ros.org/wiki/xacro">
+  <!-- Properties -->
+  <xacro:property name="namespace" value="standard_vtol" />
+  <xacro:property name="rotor_velocity_slowdown_sim" value="20" />
+  <xacro:property name="mesh_file" value="iris.stl" />
+  <xacro:property name="mesh_scale" value="1 1 1"/>
+  <xacro:property name="mesh_scale_prop" value="1 1 1"/>
+  <xacro:property name="mass" value="1.5" /> <!-- [kg] -->
+  <xacro:property name="body_width" value="0.47" /> <!-- [m] -->
+  <xacro:property name="body_height" value="0.11" /> <!-- [m] -->
+  <xacro:property name="mass_rotor" value="0.005" /> <!-- [kg] -->
+  <xacro:property name="arm_length_front_x" value="0.35" /> <!-- [m] -->
+  <xacro:property name="arm_length_back_x" value="0.35" /> <!-- [m] -->
+  <xacro:property name="arm_length_front_y" value="0.35" /> <!-- [m] -->
+  <xacro:property name="arm_length_back_y" value="0.35" /> <!-- [m] -->
+  <xacro:property name="rotor_offset_top" value="0.07" /> <!-- [m] -->
+  <xacro:property name="radius_rotor" value="0.128" /> <!-- [m] -->
+  <xacro:property name="motor_constant" value="8.54858e-06" /> <!-- [kg.m/s^2] -->
+  <xacro:property name="moment_constant" value="0.06" /> <!-- [m] -->
+  <xacro:property name="time_constant_up" value="0.0125" /> <!-- [s] -->
+  <xacro:property name="time_constant_down" value="0.025" /> <!-- [s] -->
+  <xacro:property name="max_rot_velocity" value="1500" /> <!-- [rad/s] -->
+  <xacro:property name="sin30" value="0.5" />
+  <xacro:property name="cos30" value="0.866025403784" />
+  <xacro:property name="sqrt2" value="1.4142135623730951" />
+  <xacro:property name="rotor_drag_coefficient" value="8.06428e-04" />
+  <xacro:property name="rolling_moment_coefficient" value="0.000001" />
+  <xacro:property name="color" value="$(arg visual_material)" />
+
+  <!-- Property Blocks -->
+  <xacro:property name="body_inertia">
+    <inertia
+    ixx="${1/12 * mass * (body_height * body_height + body_width * body_width)}"
+    iyy="${1/12 * mass * (body_height * body_height + body_width * body_width)}"
+    izz="${1/12 * mass * (body_width * body_width + body_width * body_width)}"
+    ixy="0.0" ixz="0.0" iyz="0.0" /> <!-- [kg.m^2] [kg.m^2] [kg.m^2] [kg.m^2] [kg.m^2] [kg.m^2] -->
+  </xacro:property>
+
+  <!-- inertia of a single rotor, assuming it is a cuboid. Height=3mm, width=15mm -->
+  <xacro:property name="rotor_inertia">
+    <inertia
+    ixx="${1/12 * mass_rotor * (0.015 * 0.015 + 0.003 * 0.003) * rotor_velocity_slowdown_sim}"
+    iyy="${1/12 * mass_rotor * (4 * radius_rotor * radius_rotor + 0.003 * 0.003) * rotor_velocity_slowdown_sim}"
+    izz="${1/12 * mass_rotor * (4 * radius_rotor * radius_rotor + 0.015 * 0.015) * rotor_velocity_slowdown_sim}"
+    ixy="0.0" ixz="0.0"  iyz="0.0" /> <!-- [kg.m^2] [kg.m^2] [kg.m^2] [kg.m^2] [kg.m^2] [kg.m^2] -->
+  </xacro:property>
+
+  <!-- Included URDF Files -->
+  <xacro:include filename="$(arg rotors_description_dir)/urdf/multirotor_base.xacro" />
+  <xacro:include filename="$(arg rotors_description_dir)/urdf/fixedwing_base.xacro" />
+  <xacro:include filename="$(arg rotors_description_dir)/urdf/vtol_base.xacro" />
+
+  <!-- Instantiate multirotor_base_macro once -->
+  <xacro:vtol_base_macro
+    robot_namespace="${namespace}">
+    <origin xyz="0 0 0.246" rpy="0 0 0" />
+  </xacro:vtol_base_macro>
+
+  <!-- Instantiate rotors -->
+  <xacro:vertical_rotor
+    robot_namespace="${namespace}"
+    suffix="front_right"
+    direction="ccw"
+    motor_constant="${motor_constant}"
+    moment_constant="${moment_constant}"
+    parent="base_link"
+    mass_rotor="${mass_rotor}"
+    radius_rotor="${radius_rotor}"
+    time_constant_up="${time_constant_up}"
+    time_constant_down="${time_constant_down}"
+    max_rot_velocity="${max_rot_velocity}"
+    motor_number="0"
+    rotor_drag_coefficient="${rotor_drag_coefficient}"
+    rolling_moment_coefficient="${rolling_moment_coefficient}"
+    mesh="iris_prop"
+    mesh_scale="${mesh_scale_prop}"
+    color="Blue">
+    <origin xyz="${arm_length_front_x} -${arm_length_front_y} ${rotor_offset_top}" rpy="0 0 0" />
+    <xacro:insert_block name="rotor_inertia" />
+  </xacro:vertical_rotor>
+
+  <xacro:vertical_rotor
+    robot_namespace="${namespace}"
+    suffix="back_left"
+    direction="ccw"
+    motor_constant="${motor_constant}"
+    moment_constant="${moment_constant}"
+    parent="base_link"
+    mass_rotor="${mass_rotor}"
+    radius_rotor="${radius_rotor}"
+    time_constant_up="${time_constant_up}"
+    time_constant_down="${time_constant_down}"
+    max_rot_velocity="${max_rot_velocity}"
+    motor_number="1"
+    rotor_drag_coefficient="${rotor_drag_coefficient}"
+    rolling_moment_coefficient="${rolling_moment_coefficient}"
+    mesh="iris_prop"
+    mesh_scale="${mesh_scale_prop}"
+    color="DarkGrey">
+    <origin xyz="-${arm_length_back_x} ${arm_length_back_y} ${rotor_offset_top}" rpy="0 0 0" />
+    <xacro:insert_block name="rotor_inertia" />
+  </xacro:vertical_rotor>
+
+  <xacro:vertical_rotor robot_namespace="${namespace}"
+    suffix="front_left"
+    direction="cw"
+    motor_constant="${motor_constant}"
+    moment_constant="${moment_constant}"
+    parent="base_link"
+    mass_rotor="${mass_rotor}"
+    radius_rotor="${radius_rotor}"
+    time_constant_up="${time_constant_up}"
+    time_constant_down="${time_constant_down}"
+    max_rot_velocity="${max_rot_velocity}"
+    motor_number="2"
+    rotor_drag_coefficient="${rotor_drag_coefficient}"
+    rolling_moment_coefficient="${rolling_moment_coefficient}"
+    mesh="iris_prop"
+    mesh_scale="${mesh_scale_prop}"
+    color="Blue">
+    <origin xyz="${arm_length_front_x} ${arm_length_front_y} ${rotor_offset_top}" rpy="0 0 0" />
+    <xacro:insert_block name="rotor_inertia" />
+  </xacro:vertical_rotor>
+
+  <xacro:vertical_rotor robot_namespace="${namespace}"
+    suffix="back_right"
+    direction="cw"
+    motor_constant="${motor_constant}"
+    moment_constant="${moment_constant}"
+    parent="base_link"
+    mass_rotor="${mass_rotor}"
+    radius_rotor="${radius_rotor}"
+    time_constant_up="${time_constant_up}"
+    time_constant_down="${time_constant_down}"
+    max_rot_velocity="${max_rot_velocity}"
+    motor_number="3"
+    rotor_drag_coefficient="${rotor_drag_coefficient}"
+    rolling_moment_coefficient="${rolling_moment_coefficient}"
+    mesh="iris_prop"
+    mesh_scale="${mesh_scale_prop}"
+    color="DarkGrey">
+    <origin xyz="-${arm_length_back_x} -${arm_length_back_y} ${rotor_offset_top}" rpy="0 0 0" />
+    <xacro:insert_block name="rotor_inertia" />
+  </xacro:vertical_rotor>
+
+  <xacro:vertical_rotor
+    robot_namespace="${namespace}"
+    suffix="rotor_puller"
+    direction="cw"
+    motor_constant="${motor_constant}"
+    moment_constant="0.01"
+    parent="base_link"
+    mass_rotor="${mass_rotor}"
+    radius_rotor="0.06"
+    time_constant_up="${time_constant_up}"
+    time_constant_down="${time_constant_down}"
+    max_rot_velocity="3500"
+    motor_number="4"
+    rotor_drag_coefficient="8.06428e-05"
+    rolling_moment_coefficient="${rolling_moment_coefficient}"
+    mesh="iris_prop"
+    mesh_scale="1 1 1"
+    color="Blue">
+    <origin xyz="-0.27 0 0.02" rpy="0 1.57 0" />
+    <xacro:insert_block name="rotor_inertia" />
+  </xacro:vertical_rotor>
+
+
+  <xacro:property name="left_elevon_mesh_origin">
+    <origin xyz="-0.105 0.004 -0.034" rpy="1.5707963268 0 3.1415926536"/>
+  </xacro:property>
+  <xacro:property name="left_elevon_joint_origin">
+    <origin xyz="-0 0 0" rpy="0 0 0"/>
+  </xacro:property>
+  <xacro:property name="right_elevon_mesh_origin">
+    <origin xyz="0.281 -1.032 -0.034" rpy="1.5707963268 0 3.1415926536"/>
+  </xacro:property>
+  <xacro:property name="right_elevon_joint_origin">
+    <origin xyz="0.0 0 0.0" rpy="0 0 0"/>
+  </xacro:property>
+  <xacro:property name="elevator_joint_origin">
+    <origin xyz="-0.5 0 0.0" rpy="0 0 0"/>
+  </xacro:property>
+
+  <xacro:control_surface
+    robot_namespace="${namespace}"
+    link_name="left_elevon"
+    parent="base_link"
+    mesh_file="model://standard_vtol/meshes/x8_elevon_left.dae"
+    mesh_scale="0.001 0.001 0.001"
+    color="Blue"
+    area="0.5"
+    control_joint_rad_to_cl="-1.0"
+    a0="0.05984281113"
+    cpx="-0.05"
+    cpy="0.3"
+    cpz="0.05"
+    upx="0"
+    upy="0"
+    upz="1"
+    joint_limit="0.53">
+    <origin xyz="0.0 0.3 0.0" rpy="0 0 0" />
+    <axis xyz="0 1 0" />
+    <xacro:insert_block name="left_elevon_joint_origin" />
+    <xacro:insert_block name="left_elevon_mesh_origin" />
+  </xacro:control_surface>
+
+  <xacro:control_surface
+    robot_namespace="${namespace}"
+    link_name="right_elevon"
+    parent="base_link"
+    mesh_file="model://standard_vtol/meshes/x8_elevon_right.dae"
+    mesh_scale="0.001 0.001 0.001"
+    color="Blue"
+    area="0.5"
+    control_joint_rad_to_cl="-1.0"
+    a0="0.05984281113"
+    cpx="-0.05"
+    cpy="-0.3"
+    cpz="0.05"
+    upx="0"
+    upy="0"
+    upz="1"
+    joint_limit="0.53">
+    <origin xyz="0.0 -0.6 0.0" rpy="0 0 0" />
+    <axis xyz="0 1 0" />
+    <xacro:insert_block name="right_elevon_joint_origin" />
+    <xacro:insert_block name="right_elevon_mesh_origin" />
+  </xacro:control_surface>
+
+  <xacro:hidden_control_surface
+    robot_namespace="${namespace}"
+    link_name="elevator"
+    parent="base_link"
+    area="0.01"
+    color="Blue"
+    control_joint_rad_to_cl="-12.0"
+    a0="-0.2"
+    cpx="-0.5"
+    cpy="0"
+    cpz="0"
+    upx="0"
+    upy="0"
+    upz="1"
+    joint_limit="0.53">
+    <origin xyz="-0.5 0.0 0.0" rpy="0 0 0" />
+    <axis xyz="0 1 0" />
+    <xacro:insert_block name="elevator_joint_origin" />
+  </xacro:hidden_control_surface>
+
+  <xacro:hidden_control_surface
+    robot_namespace="${namespace}"
+    link_name="rudder"
+    parent="base_link"
+    area="0.02"
+    color="Blue"
+    control_joint_rad_to_cl="-12.0"
+    a0="-0.02"
+    cpx="-0.5"
+    cpy="0"
+    cpz="0.05"
+    upx="0"
+    upy="1"
+    upz="0"
+    joint_limit="0.01">
+    <origin xyz="-0.5 0.0 0.05" rpy="0 0 0" />
+    <axis xyz="0 1 0" />
+    <xacro:insert_block name="right_elevon_joint_origin" />
+  </xacro:hidden_control_surface>
+
+</robot>

--- a/models/rotors_description/urdf/standard_vtol_base.xacro
+++ b/models/rotors_description/urdf/standard_vtol_base.xacro
@@ -1,0 +1,191 @@
+<?xml version="1.0"?>
+
+<robot name="standard_vtol" xmlns:xacro="http://ros.org/wiki/xacro">
+  <!-- Properties that can be assigned at build time as arguments.
+  Is there a reason not to make all properties arguments?
+  -->
+  <xacro:arg name='name' default='standard_vtol' />
+  <xacro:arg name='mavlink_addr' default='INADDR_ANY' />
+  <xacro:arg name='mavlink_udp_port' default='14560' />
+  <xacro:arg name='mavlink_tcp_port' default='4560' />
+  <xacro:arg name='serial_enabled' default='false' />
+  <xacro:arg name='serial_device' default='/dev/ttyACM0' />
+  <xacro:arg name='baudrate' default='921600' />
+  <xacro:arg name='qgc_addr' default='INADDR_ANY' />
+  <xacro:arg name='qgc_udp_port' default='14550' />
+  <xacro:arg name='sdk_addr' default='INADDR_ANY' />
+  <xacro:arg name='sdk_udp_port' default='14540' />
+  <xacro:arg name='hil_mode' default='false' />
+  <xacro:arg name='hil_state_level' default='false' />
+  <xacro:arg name='send_vision_estimation' default='false' />
+  <xacro:arg name='send_odometry' default='false' />
+  <xacro:arg name='enable_lockstep' default='true' />
+  <xacro:arg name='use_tcp' default='true' />
+  <xacro:arg name='vehicle_is_tailsitter' default='false' />
+  <xacro:arg name='visual_material' default='DarkGrey' />
+  <xacro:arg name='enable_mavlink_interface' default='true' />
+  <xacro:arg name='enable_wind' default='false' />
+  <!-- The following causes segfault with multiple vehicles if defaults to true!!! -->
+  <xacro:arg name='enable_ground_truth' default='false' />
+  <xacro:arg name='enable_logging' default='false' />
+  <xacro:arg name='log_file' default='iris' />
+
+  <!-- macros for gazebo plugins, sensors -->
+  <xacro:include filename="$(arg rotors_description_dir)/urdf/component_snippets.xacro" />
+
+  <!-- Instantiate iris "mechanics" -->
+  <xacro:include filename="$(arg rotors_description_dir)/urdf/standard_vtol.xacro" />
+
+  <xacro:if value="$(arg enable_wind)">
+    <xacro:wind_plugin_macro
+        namespace="${namespace}"
+        wind_direction="0 0 1"
+        wind_force_mean="0.7"
+        xyz_offset="1 0 0"
+        wind_gust_direction="0 0 0"
+        wind_gust_duration="0"
+        wind_gust_start="0"
+        wind_gust_force_mean="0"
+        />
+  </xacro:if>
+
+
+  <!-- Instantiate gps plugin. -->
+  <xacro:gps_plugin_macro
+    namespace="${namespace}"
+    gps_noise="true"
+    >
+  </xacro:gps_plugin_macro>
+
+  <!-- Instantiate magnetometer plugin. -->
+  <xacro:magnetometer_plugin_macro
+    namespace="${namespace}"
+    pub_rate="20"
+    noise_density="0.0004"
+    random_walk="0.0000064"
+    bias_correlation_time="600"
+    mag_topic="/mag"
+    >
+  </xacro:magnetometer_plugin_macro>
+
+  <!-- Instantiate barometer plugin. -->
+  <xacro:barometer_plugin_macro
+    namespace="${namespace}"
+    pub_rate="10"
+    baro_topic="/baro"
+    >
+  </xacro:barometer_plugin_macro>
+
+  <xacro:if value="$(arg enable_mavlink_interface)">
+  <!-- Instantiate mavlink telemetry interface. -->
+  <xacro:mavlink_interface_macro_vtol
+    namespace="${namespace}"
+    imu_sub_topic="/imu"
+    gps_sub_topic="/gps"
+    mag_sub_topic="/mag"
+    baro_sub_topic="/baro"
+    mavlink_addr="$(arg mavlink_addr)"
+    mavlink_udp_port="$(arg mavlink_udp_port)"
+    mavlink_tcp_port="$(arg mavlink_tcp_port)"
+    serial_enabled="$(arg serial_enabled)"
+    serial_device="$(arg serial_device)"
+    baudrate="$(arg baudrate)"
+    qgc_addr="$(arg qgc_addr)"
+    qgc_udp_port="$(arg qgc_udp_port)"
+    sdk_addr="$(arg sdk_addr)"
+    sdk_udp_port="$(arg sdk_udp_port)"
+    hil_mode="$(arg hil_mode)"
+    hil_state_level="$(arg hil_state_level)"
+    vehicle_is_tailsitter="$(arg vehicle_is_tailsitter)"
+    send_vision_estimation="$(arg send_vision_estimation)"
+    send_odometry="$(arg send_odometry)"
+    enable_lockstep="$(arg enable_lockstep)"
+    use_tcp="$(arg use_tcp)"
+    >
+  </xacro:mavlink_interface_macro_vtol>
+  </xacro:if>
+
+  <!-- Mount an ADIS16448 IMU. -->
+  <xacro:imu_plugin_macro
+    namespace="${namespace}"
+    imu_suffix=""
+    parent_link="base_link"
+    imu_topic="/imu"
+    mass_imu_sensor="0.015"
+    gyroscope_noise_density="0.0003394"
+    gyroscopoe_random_walk="0.000038785"
+    gyroscope_bias_correlation_time="1000.0"
+    gyroscope_turn_on_bias_sigma="0.0087"
+    accelerometer_noise_density="0.004"
+    accelerometer_random_walk="0.006"
+    accelerometer_bias_correlation_time="300.0"
+    accelerometer_turn_on_bias_sigma="0.1960"
+  >
+    <inertia ixx="0.00001" ixy="0.0" ixz="0.0" iyy="0.00001" iyz="0.0" izz="0.00001" />
+    <origin xyz="0 0 0" rpy="0 0 0" />
+  </xacro:imu_plugin_macro>
+
+  <xacro:if value="$(arg enable_ground_truth)">
+    <!-- Mount an IMU providing ground truth. -->
+    <xacro:imu_plugin_macro
+      namespace="${namespace}"
+      imu_suffix="gt"
+      parent_link="base_link"
+      imu_topic="ground_truth/imu"
+      mass_imu_sensor="0.00001"
+      gyroscope_noise_density="0.0"
+      gyroscopoe_random_walk="0.0"
+      gyroscope_bias_correlation_time="1000.0"
+      gyroscope_turn_on_bias_sigma="0.0"
+      accelerometer_noise_density="0.0"
+      accelerometer_random_walk="0.0"
+      accelerometer_bias_correlation_time="300.0"
+      accelerometer_turn_on_bias_sigma="0.0"
+    >
+      <inertia ixx="0.00001" ixy="0.0" ixz="0.0" iyy="0.00001" iyz="0.0" izz="0.00001" />
+      <origin xyz="0 0 0" rpy="0 0 0" />
+    </xacro:imu_plugin_macro>
+
+    <!-- Mount a generic odometry sensor providing ground truth. -->
+    <xacro:odometry_plugin_macro
+      namespace="${namespace}/ground_truth"
+      odometry_sensor_suffix="gt"
+      parent_link="base_link"
+      pose_topic="pose"
+      pose_with_covariance_topic="pose_with_covariance"
+      position_topic="position"
+      transform_topic="transform"
+      odometry_topic="odometry"
+      parent_frame_id="world"
+      mass_odometry_sensor="0.00001"
+      measurement_divisor="1"
+      measurement_delay="0"
+      unknown_delay="0.0"
+      noise_normal_position="0 0 0"
+      noise_normal_quaternion="0 0 0"
+      noise_normal_linear_velocity="0 0 0"
+      noise_normal_angular_velocity="0 0 0"
+      noise_uniform_position="0 0 0"
+      noise_uniform_quaternion="0 0 0"
+      noise_uniform_linear_velocity="0 0 0"
+      noise_uniform_angular_velocity="0 0 0"
+      enable_odometry_map="false"
+      odometry_map=""
+      image_scale=""
+    >
+      <inertia ixx="0.00001" ixy="0.0" ixz="0.0" iyy="0.00001" iyz="0.0" izz="0.00001" /> <!-- [kg.m^2] [kg.m^2] [kg.m^2] [kg.m^2] [kg.m^2] [kg.m^2] -->
+      <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
+    </xacro:odometry_plugin_macro>
+  </xacro:if>
+
+  <xacro:if value="$(arg enable_logging)">
+    <!-- Instantiate a logger -->
+    <xacro:bag_plugin_macro
+      namespace="${namespace}"
+      bag_file="$(arg log_file)"
+      rotor_velocity_slowdown_sim="${rotor_velocity_slowdown_sim}"
+    >
+    </xacro:bag_plugin_macro>
+  </xacro:if>
+
+</robot>

--- a/models/rotors_description/urdf/vtol_base.xacro
+++ b/models/rotors_description/urdf/vtol_base.xacro
@@ -1,0 +1,56 @@
+<?xml version="1.0"?>
+<!--
+  Copyright 2015 Fadri Furrer, ASL, ETH Zurich, Switzerland
+  Copyright 2015 Michael Burri, ASL, ETH Zurich, Switzerland
+  Copyright 2015 Mina Kamel, ASL, ETH Zurich, Switzerland
+  Copyright 2015 Janosch Nikolic, ASL, ETH Zurich, Switzerland
+  Copyright 2015 Markus Achtelik, ASL, ETH Zurich, Switzerland
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<robot xmlns:xacro="http://ros.org/wiki/xacro">
+  <!-- Main multirotor link -->
+  <xacro:macro name="vtol_base_macro" params="robot_namespace *origin">
+    <xacro:insert_block name="origin" />
+    <link name="base_link"></link>
+    <joint name="base_joint" type="fixed">
+      <parent link="base_link" />
+      <child link="base_link_inertial" />
+    </joint>
+    <link name="base_link_inertial">
+      <inertial>
+        <mass value="1.5" />
+        <inertia ixx="0.477708333333" ixy="0.0" iyy="0.341666666667" ixz="0.0" iyz="0.0" izz="0.811041666667" />
+      </inertial>
+      <visual>
+        <origin xyz="0.53 -1.072 -0.1" rpy="1.5707963268 0 3.1415926536" />
+        <geometry>
+            <mesh scale="0.001 0.001 0.001" filename="model://standard_vtol/meshes/x8_wing.dae" />
+        </geometry>
+      </visual>
+      <collision name='base_link_collision'>
+        <origin xyz="0.0 0 -0.07" rpy="0 0 0" />
+        <geometry>
+            <box size="0.55 2.144 0.05"/>
+        </geometry>
+      </collision>
+    </link>
+    <gazebo reference="base_link">
+        <material>Gazebo/DarkGrey</material>
+        <!-- <maxVel>10</maxVel>
+        <minDepth>0.01</minDepth> -->
+        <selfCollide>0</selfCollide>
+    </gazebo>
+  </xacro:macro>
+</robot>


### PR DESCRIPTION
**Describe problem solved by this pull request**
This adds support to multivehicle simulation with `standard_vtol` by adding a xacro file which generates the sdf models

**Describe your solution**
Generate the sdf file of `standard_vtol` using xacro so that mavlink port / sysid can be configured

**Test data / coverage**
![ezgif com-video-to-gif(2)](https://user-images.githubusercontent.com/5248102/72689212-57189b00-3b0f-11ea-82aa-bdbd13ce5353.gif)

Full video: [video](https://youtu.be/lAjjTFFZebI)

To run this, you can run with the following command
```
Tools/gazebo_sitl_multiple_run.sh -m standard_vtol
```

**Additional Context**
The motor / motor columns are not rendered since xacro inside px4 sitl doesn't seem to let you have multiple visual elements within the same link