### PR TITLE
Add optical flow mockup model

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -313,6 +313,7 @@ add_library(gazebo_geotagged_images_plugin SHARED src/gazebo_geotagged_images_pl
 add_library(gazebo_gps_plugin SHARED src/gazebo_gps_plugin.cpp)
 add_library(gazebo_irlock_plugin SHARED src/gazebo_irlock_plugin.cpp)
 add_library(gazebo_lidar_plugin SHARED src/gazebo_lidar_plugin.cpp)
+add_library(gazebo_opticalflow_mockup_plugin SHARED src/gazebo_opticalflow_mockup_plugin.cpp)
 add_library(gazebo_opticalflow_plugin SHARED src/gazebo_opticalflow_plugin.cpp)
 add_library(gazebo_sonar_plugin SHARED src/gazebo_sonar_plugin.cpp)
 add_library(gazebo_uuv_plugin SHARED src/gazebo_uuv_plugin.cpp)
@@ -332,6 +333,7 @@ set(plugins
   gazebo_gps_plugin
   gazebo_irlock_plugin
   gazebo_lidar_plugin
+  gazebo_opticalflow_mockup_plugin
   gazebo_opticalflow_plugin
   gazebo_sonar_plugin
   gazebo_uuv_plugin

--- a/include/gazebo_opticalflow_mockup_plugin.h
+++ b/include/gazebo_opticalflow_mockup_plugin.h
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2012-2017 Open Source Robotics Foundation
+ * Copyright (C) 2020 PX4 Pro Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+/**
+ * @brief Optical flow mockup Plugin
+ *
+ * This plugin publishes optical flow messages, but without rendering an image.
+ * It assumes a world with only plane ground.
+ *
+ * @author Kamil Ritz <ka.ritz@hotmail.com>
+ */
+
+#ifndef _GAZEBO_OPTICAL_FLOW_MOCKUP_PLUGIN_HH_
+#define _GAZEBO_OPTICAL_FLOW_MOCKUP_PLUGIN_HH_
+
+#include <math.h>
+#include <cstdio>
+#include <cstdlib>
+#include <queue>
+#include <random>
+
+#include <sdf/sdf.hh>
+#include <common.h>
+
+#include <gazebo/common/Plugin.hh>
+#include <gazebo/gazebo.hh>
+#include <gazebo/util/system.hh>
+#include <gazebo/transport/transport.hh>
+#include <gazebo/msgs/msgs.hh>
+#include <gazebo/physics/physics.hh>
+#include <ignition/math.hh>
+
+#include "OpticalFlow.pb.h"
+#include <Range.pb.h>
+
+namespace gazebo
+{
+class GAZEBO_VISIBLE OpticalFlowMockupPlugin : public ModelPlugin
+{
+public:
+  OpticalFlowMockupPlugin();
+  virtual ~OpticalFlowMockupPlugin();
+
+protected:
+  virtual void Load(physics::ModelPtr _model, sdf::ElementPtr _sdf);
+  virtual void OnUpdate(const common::UpdateInfo&);
+
+private:
+  std::string namespace_;
+
+  physics::ModelPtr model_;
+  physics::WorldPtr world_;
+  event::ConnectionPtr updateConnection_;
+
+  transport::NodePtr node_handle_;
+  transport::PublisherPtr opticalFlow_pub_;
+  transport::SubscriberPtr range_sub_;
+
+  sensor_msgs::msgs::OpticalFlow opticalFlow_message_;
+  sensor_msgs::msgs::Range distance_measurement_;
+  double range_measurement_ {0};
+  double integrated_flow_x {0};
+  double integrated_flow_y {0};
+  double integrated_time {0};
+
+  common::Time last_pub_time_;
+  common::Time last_time_;
+
+  double pub_rate_;
+
+  static constexpr double kDefaultPubRate 		= 30.0;	 // [Hz]
+
+  void rangeCallback(const boost::shared_ptr<const sensor_msgs::msgs::Range>& range_msg);
+
+
+
+};     // class GAZEBO_VISIBLE OpticalFlowMockupPlugin
+}      // namespace gazebo
+#endif // _GAZEBO_OPTICAL_FLOW_MOCKUp_PLUGIN_HH_

--- a/models/iris_opt_flow_mockup/iris_opt_flow_mockup.sdf
+++ b/models/iris_opt_flow_mockup/iris_opt_flow_mockup.sdf
@@ -1,0 +1,26 @@
+<sdf version='1.5'>
+  <model name='iris_opt_flow_mockup'>
+    <include>
+      <uri>model://iris</uri>
+    </include>
+
+    <plugin name="opticalflow_mockup_plugin" filename="libgazebo_opticalflow_mockup_plugin.so">
+        <robotNamespace></robotNamespace>
+        <pubRate>20</pubRate>
+    </plugin>
+
+    <!--lidar-->
+    <include>
+      <uri>model://lidar</uri>
+      <pose>0 0 -0.05 0 0 0</pose>
+    </include>
+
+    <joint name="lidar_joint" type="fixed">
+      <parent>iris::base_link</parent>
+      <child>lidar::link</child>
+    </joint>
+
+  </model>
+</sdf>
+
+<!-- vim: set et ft=xml fenc=utf-8 ff=unix sts=0 sw=2 ts=2 : -->

--- a/models/iris_opt_flow_mockup/model.config
+++ b/models/iris_opt_flow_mockup/model.config
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<model>
+  <name>3DR Iris with lidar and optical flow mockup</name>
+  <version>1.0</version>
+  <sdf version='1.4'>iris_opt_flow_mockup.sdf</sdf>
+
+  <author>
+   <name>Kamil Ritz</name>
+   <email>ka.ritz@hotmail.com</email>
+  </author>
+
+  <description>
+    This is a model of the 3DR Iris Quadrotor with lidar and a mockup optical flow sensors. The mockup optical flow
+    does not render images and is therefore suited to run faster than real time.
+  </description>
+</model>

--- a/src/gazebo_opticalflow_mockup_plugin.cpp
+++ b/src/gazebo_opticalflow_mockup_plugin.cpp
@@ -1,0 +1,153 @@
+/*
+ * Copyright (C) 2012 Open Source Robotics Foundation
+ * Copyright (C) 2017-2018 PX4 Pro Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+/**
+ * @brief GPS Plugin
+ *
+ * This plugin publishes optical flow messages, but without rendering an image.
+ * It assumes a world with only plane ground.
+ *
+ * @author Kamil Ritz <ka.ritz@hotmail.com>
+ */
+
+#include <gazebo_opticalflow_mockup_plugin.h>
+
+namespace gazebo {
+GZ_REGISTER_MODEL_PLUGIN(OpticalFlowMockupPlugin)
+
+OpticalFlowMockupPlugin::OpticalFlowMockupPlugin() : ModelPlugin()
+{
+}
+
+OpticalFlowMockupPlugin::~OpticalFlowMockupPlugin()
+{
+    if (updateConnection_)
+      updateConnection_->~Connection();
+}
+
+void OpticalFlowMockupPlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf)
+{
+  // Store the pointer to the model.
+  model_ = _model;
+
+  world_ = model_->GetWorld();
+#if GAZEBO_MAJOR_VERSION >= 9
+  last_time_ = world_->SimTime();
+  last_pub_time_ = world_->SimTime();
+#else
+  last_time_ = world_->GetSimTime();
+  last_pub_time_ = world_->GetSimTime();
+#endif
+
+  namespace_.clear();
+  if (_sdf->HasElement("robotNamespace")) {
+    namespace_ = _sdf->GetElement("robotNamespace")->Get<std::string>();
+  } else {
+    gzerr << "[gazebo_gps_plugin] Please specify a robotNamespace.\n";
+  }
+
+if (_sdf->HasElement("pubRate")) {
+    pub_rate_ = _sdf->GetElement("pubRate")->Get<int>();
+  } else {
+    pub_rate_ = kDefaultPubRate;
+    gzwarn << "[gazebo_vision_plugin] Using default publication rate of " << pub_rate_ << " Hz\n";
+  }
+
+  node_handle_ = transport::NodePtr(new transport::Node());
+  node_handle_->Init(namespace_);
+
+  range_sub_ = node_handle_->Subscribe("~/" + model_->GetName() + "/link/lidar", &OpticalFlowMockupPlugin::rangeCallback, this);
+  opticalFlow_pub_ = node_handle_->Advertise<sensor_msgs::msgs::OpticalFlow>("~/" + model_->GetName() + "/px4flow/link/opticalFlow", 10);
+
+    // Listen to the update event. This event is broadcast every simulation iteration.
+  updateConnection_ = event::Events::ConnectWorldUpdateBegin(
+      boost::bind(&OpticalFlowMockupPlugin::OnUpdate, this, _1));
+}
+
+void OpticalFlowMockupPlugin::OnUpdate(const common::UpdateInfo&)
+{
+#if GAZEBO_MAJOR_VERSION >= 9
+  common::Time current_time = world_->SimTime();
+#else
+  common::Time current_time = world_->GetSimTime();
+#endif
+
+
+    double dt = (current_time - last_time_).Double();
+
+  // get pose of the model that the plugin is attached to
+#if GAZEBO_MAJOR_VERSION >= 9
+    ignition::math::Pose3d pose_model_world = model_->WorldPose();
+    ignition::math::Vector3d velocity_model_world = model_->WorldLinearVel();
+    ignition::math::Vector3d angular_velocity_model = model_->RelativeAngularVel();
+#else
+    ignition::math::Pose3d pose_model_world = ignitionFromGazeboMath(model_->GetWorldPose());
+    ignition::math::Vector3d velocity_model_world = ignitionFromGazeboMath(model_->GetWorldLinearVel());
+    ignition::math::Vector3d angular_velocity_model = ignitionFromGazeboMath(model_->GetRelativeAngularVel());
+#endif
+    // Compute velocities in body FRD frame
+    ignition::math::Vector3d angular_velocity = q_br.Inverse().RotateVector(angular_velocity_model);
+    ignition::math::Vector3d linear_velocity = q_br.Inverse().RotateVector(
+                                         pose_model_world.Rot().Inverse().RotateVector(velocity_model_world));
+
+  // Compute flow
+    float flow_x_ang = angular_velocity.X() - linear_velocity.Y() / range_measurement_;
+    float flow_y_ang = angular_velocity.Y() + linear_velocity.X() / range_measurement_;
+
+
+  // Integrate flow
+  integrated_time += dt;
+  integrated_flow_x += flow_x_ang * dt;
+  integrated_flow_y += flow_y_ang * dt;
+
+  double dt_pub = (current_time - last_pub_time_).Double();
+
+  if (dt_pub > 1.0 / pub_rate_) {
+
+    // Fill message
+    opticalFlow_message_.set_time_usec(current_time.Double() * 1e6);
+    opticalFlow_message_.set_sensor_id(2.0);
+    opticalFlow_message_.set_integration_time_us(integrated_time * 1e6);
+    opticalFlow_message_.set_integrated_x(integrated_flow_x);
+    opticalFlow_message_.set_integrated_y(integrated_flow_y);
+    opticalFlow_message_.set_integrated_xgyro(NAN);
+    opticalFlow_message_.set_integrated_ygyro(NAN);
+    opticalFlow_message_.set_integrated_zgyro(NAN);
+    opticalFlow_message_.set_temperature(20.0f);
+    opticalFlow_message_.set_quality(180.0f);
+    opticalFlow_message_.set_time_delta_distance_us(0);
+    opticalFlow_message_.set_distance(0.0f); //get real values in gazebo_mavlink_interface.cpp
+    //send message
+    opticalFlow_pub_->Publish(opticalFlow_message_);
+
+    // Reset integrators
+    integrated_flow_x = 0;
+    integrated_flow_y = 0;
+    integrated_time = 0;
+    last_pub_time_ = current_time;
+  }
+
+  last_time_ = current_time;
+}
+
+void OpticalFlowMockupPlugin::rangeCallback(const boost::shared_ptr<const sensor_msgs::msgs::Range>& range_msg)
+{
+  range_measurement_ = range_msg->current_distance();  //[m]
+}
+
+
+} // namespace gazebo

--- a/worlds/iris_opt_flow_mockup.world
+++ b/worlds/iris_opt_flow_mockup.world
@@ -1,0 +1,53 @@
+<?xml version="1.0" ?>
+<sdf version="1.5">
+  <world name="default">
+    <!-- A global light source -->
+    <include>
+      <uri>model://sun</uri>
+    </include>
+    <!-- A ground plane -->
+    <include>
+      <uri>model://ground_plane</uri>
+    </include>
+    <!-- An asphalt plane -->
+    <include>
+      <uri>model://asphalt_plane</uri>
+    </include>
+    <include>
+      <uri>model://iris_opt_flow_mockup</uri>
+      <pose>1.01 0.98 0.83 0 0 1.14</pose>
+    </include>
+    <physics name='default_physics' default='0' type='ode'>
+      <gravity>0 0 -9.8066</gravity>
+      <ode>
+        <solver>
+          <type>quick</type>
+          <iters>10</iters>
+          <sor>1.3</sor>
+          <use_dynamic_moi_rescaling>0</use_dynamic_moi_rescaling>
+        </solver>
+        <constraints>
+          <cfm>0</cfm>
+          <erp>0.2</erp>
+          <contact_max_correcting_vel>100</contact_max_correcting_vel>
+          <contact_surface_layer>0.001</contact_surface_layer>
+        </constraints>
+      </ode>
+      <max_step_size>0.004</max_step_size>
+      <real_time_factor>1</real_time_factor>
+      <real_time_update_rate>250</real_time_update_rate>
+      <magnetic_field>6.0e-6 2.3e-5 -4.2e-5</magnetic_field>
+    </physics>
+    <gui fullscreen='0'>
+      <camera name='user_camera'>
+        <pose>-10 0 6 0 0.3 0</pose>
+        <!-- <view_controller>orbit</view_controller>
+        <projection_type>perspective</projection_type>
+        <track_visual>
+          <name>iris_opt_flow</name>
+          <use_model_frame>1</use_model_frame>
+        </track_visual> -->
+      </camera>
+    </gui>
+  </world>
+</sdf>


### PR DESCRIPTION
This PR adds a mockup optical flow sensor, that computes a flow measurement without rendering an image.
This is useful for CI SITL tests, where we want to speed up the simulation. This is not possible with the existing image based optical flow plugin as it relies on the camera plugin.