### PR TITLE
Fixing error in gazebo_opticalflow_plugin.h

### DIFF
--- a/include/gazebo_opticalflow_plugin.h
+++ b/include/gazebo_opticalflow_plugin.h
@@ -40,7 +40,7 @@
 #include "flow_px4.hpp"
 
 #define DEFAULT_RATE 20
-#define HAS_GYRO TRUE
+#define HAS_GYRO true
 
 using namespace cv;
 using namespace std;


### PR DESCRIPTION
error: ‘TRUE’ was not declared in this scope
#define HAS_GYRO TRUE

changing this to:
#define HAS_GYRO true

