### PR TITLE
Feature: add multi sensor subscription

### DIFF
--- a/include/gazebo_mavlink_interface.h
+++ b/include/gazebo_mavlink_interface.h
@@ -248,8 +248,8 @@ private:
   void ImuCallback(ImuPtr& imu_msg);
   void GpsCallback(GpsPtr& gps_msg);
   void GroundtruthCallback(GtPtr& groundtruth_msg);
-  void LidarCallback(LidarPtr& lidar_msg, uint8_t id);
-  void SonarCallback(SonarPtr& sonar_msg, uint8_t id);
+  void LidarCallback(LidarPtr& lidar_msg, const uint8_t& id);
+  void SonarCallback(SonarPtr& sonar_msg, const uint8_t& id);
   void OpticalFlowCallback(OpticalFlowPtr& opticalFlow_msg);
   void IRLockCallback(IRLockPtr& irlock_msg);
   void VisionCallback(OdomPtr& odom_msg);
@@ -285,7 +285,7 @@ private:
    */
   template <typename GazeboMsgT>
   void CreateSensorSubscription(
-      void (GazeboMavlinkInterface::*fp)(const boost::shared_ptr<GazeboMsgT const>&, uint8_t),
+      void (GazeboMavlinkInterface::*fp)(const boost::shared_ptr<GazeboMsgT const>&, const uint8_t&),
       GazeboMavlinkInterface* ptr);
 
   // Serial interface

--- a/include/gazebo_mavlink_interface.h
+++ b/include/gazebo_mavlink_interface.h
@@ -19,6 +19,7 @@
  * limitations under the License.
  */
 #include <vector>
+#include <regex>
 #include <thread>
 #include <mutex>
 #include <condition_variable>
@@ -162,7 +163,7 @@ public:
     groundtruth_lat_rad(0.0),
     groundtruth_lon_rad(0.0),
     groundtruth_altitude(0.0),
-    lidar_orientation_ {},
+    lidar_orientations_ {},
     sonar_orientation_ {},
     mavlink_udp_port_(kDefaultMavlinkUdpPort),
     mavlink_tcp_port_(kDefaultMavlinkTcpPort),
@@ -248,7 +249,7 @@ private:
   void ImuCallback(ImuPtr& imu_msg);
   void GpsCallback(GpsPtr& gps_msg);
   void GroundtruthCallback(GtPtr& groundtruth_msg);
-  void LidarCallback(LidarPtr& lidar_msg);
+  void LidarCallback(LidarPtr& lidar_msg, uint8_t id);
   void SonarCallback(SonarPtr& sonar_msg);
   void OpticalFlowCallback(OpticalFlowPtr& opticalFlow_msg);
   void IRLockCallback(IRLockPtr& irlock_msg);
@@ -298,7 +299,6 @@ private:
   transport::PublisherPtr joint_control_pub_[n_out_max];
 
   transport::SubscriberPtr imu_sub_;
-  transport::SubscriberPtr lidar_sub_;
   transport::SubscriberPtr sonar_sub_;
   transport::SubscriberPtr opticalFlow_sub_;
   transport::SubscriberPtr irlock_sub_;
@@ -307,6 +307,9 @@ private:
   transport::SubscriberPtr vision_sub_;
   transport::SubscriberPtr mag_sub_;
   transport::SubscriberPtr baro_sub_;
+
+  // array of SubscriberPtrs to multiple lidar subscriptions
+  std::vector<transport::SubscriberPtr> lidar_subs_;
 
   std::string imu_sub_topic_;
   std::string lidar_sub_topic_;
@@ -332,8 +335,10 @@ private:
 
   double imu_update_interval_ = 0.004; ///< Used for non-lockstep
 
-  ignition::math::Quaterniond lidar_orientation_;	///< Lidar link orientation with respect to the base_link
-  ignition::math::Quaterniond sonar_orientation_;	///< Sonar link orientation with respect to the base_link
+  std::vector<ignition::math::Quaterniond> lidar_orientations_;	///< Lidars link orientations with respect to the base_link
+  ignition::math::Quaterniond sonar_orientation_;		///< Sonar link orientation with respect to the base_link
+
+  std::vector<uint8_t> lidar_ids_;
 
   ignition::math::Vector3d gravity_W_;
   ignition::math::Vector3d velocity_prev_W_;

--- a/models/iris_obs_avoid/iris_obs_avoid.sdf
+++ b/models/iris_obs_avoid/iris_obs_avoid.sdf
@@ -21,5 +21,80 @@
       </axis>
     </joint>
 
-</model>
+    <!--downward-facing lidar-->
+    <include>
+      <uri>model://lidar</uri>
+      <pose>0 0 -0.05 0 0 0</pose>
+      <name>lidar0</name>
+    </include>
+
+    <joint name="lidar0_joint" type="fixed">
+      <parent>iris::base_link</parent>
+      <child>lidar0::link</child>
+    </joint>
+
+    <!--forward-facing lidar-->
+    <include>
+      <uri>model://lidar</uri>
+      <pose>0 0 -0.05 0 -1.57079633 0</pose>
+      <name>lidar1</name>
+    </include>
+
+    <joint name="lidar1_joint" type="fixed">
+      <parent>iris::base_link</parent>
+      <child>lidar1::link</child>
+    </joint>
+
+    <!--right-facing lidar-->
+    <include>
+      <uri>model://lidar</uri>
+      <pose>0 0 -0.05 -1.57079633 0 0</pose>
+      <name>lidar2</name>
+    </include>
+
+    <joint name="lidar2_joint" type="fixed">
+      <parent>iris::base_link</parent>
+      <child>lidar2::link</child>
+    </joint>
+
+    <!--left-facing lidar-->
+    <include>
+      <uri>model://lidar</uri>
+      <pose>0 0 -0.05 1.57079633 0 0</pose>
+      <name>lidar3</name>
+    </include>
+
+    <joint name="lidar3_joint" type="fixed">
+      <parent>iris::base_link</parent>
+      <child>lidar3::link</child>
+    </joint>
+
+    <!-- NOTE: PX4 uORB is currently limited to a max of 4 instances per topic
+         which doesn't allow to add more sensor data stream -->
+
+    <!--backward-facing lidar-->
+    <!-- <include>
+      <uri>model://lidar</uri>
+      <pose>0 0 -0.05 0 1.57079633 0</pose>
+      <name>lidar4</name>
+    </include>
+
+    <joint name="lidar4_joint" type="fixed">
+      <parent>iris::base_link</parent>
+      <child>lidar4::link</child>
+    </joint> -->
+
+    <!--upward-facing lidar-->
+    <!-- <include>
+      <uri>model://lidar</uri>
+      <pose>0 0 -0.05 3.14159265 0 0</pose>
+      <name>lidar5</name>
+    </include>
+
+    <joint name="lidar5_joint" type="fixed">
+      <parent>iris::base_link</parent>
+      <child>lidar5::link</child>
+    </joint> -->
+
+  </model>
 </sdf>

--- a/src/gazebo_mavlink_interface.cpp
+++ b/src/gazebo_mavlink_interface.cpp
@@ -38,7 +38,7 @@ struct SensorHelperStorage {
   GazeboMavlinkInterface* ptr;
 
   /// \brief    Function pointer to the subscriber callback with additional parameters.
-  void (GazeboMavlinkInterface::*fp)(const boost::shared_ptr<GazeboMsgT const>&, uint8_t);
+  void (GazeboMavlinkInterface::*fp)(const boost::shared_ptr<GazeboMsgT const>&, const uint8_t&);
 
   /// \brief    The sensor ID.
   uint8_t sensor_id;
@@ -53,7 +53,7 @@ struct SensorHelperStorage {
 
 template <typename GazeboMsgT>
 void GazeboMavlinkInterface::CreateSensorSubscription(
-    void (GazeboMavlinkInterface::*fp)(const boost::shared_ptr<GazeboMsgT const>&, uint8_t),
+    void (GazeboMavlinkInterface::*fp)(const boost::shared_ptr<GazeboMsgT const>&, const uint8_t&),
     GazeboMavlinkInterface* ptr) {
 
   // Adjust regex according to the function pointer
@@ -1025,7 +1025,7 @@ void GazeboMavlinkInterface::GroundtruthCallback(GtPtr& groundtruth_msg) {
   // the FCU
 }
 
-void GazeboMavlinkInterface::LidarCallback(LidarPtr& lidar_message, uint8_t id) {
+void GazeboMavlinkInterface::LidarCallback(LidarPtr& lidar_message, const uint8_t& id) {
   mavlink_distance_sensor_t sensor_msg;
   sensor_msg.time_boot_ms = lidar_message->time_usec() / 1e3;   // [ms]
   sensor_msg.min_distance = lidar_message->min_distance() * 100.0;  // [cm]
@@ -1100,7 +1100,7 @@ void GazeboMavlinkInterface::OpticalFlowCallback(OpticalFlowPtr& opticalFlow_mes
   send_mavlink_message(&msg);
 }
 
-void GazeboMavlinkInterface::SonarCallback(SonarPtr& sonar_message, uint8_t id) {
+void GazeboMavlinkInterface::SonarCallback(SonarPtr& sonar_message, const uint8_t& id) {
   mavlink_distance_sensor_t sensor_msg = {};
   sensor_msg.time_boot_ms = sonar_message->time_usec() / 1e3;
   sensor_msg.min_distance = sonar_message->min_distance() * 100.0;


### PR DESCRIPTION
This adds the possibility to the `gazebo_mavlink_interface` to subscribe dynamically to multiple sensor sources connected to a model. I started with the lidar sensors, but this can be extended to multiple other sources (like GPS's, multiple camera sources, others).

To do:
- [x] Extend to sonars and other sensors;
- [x] Add a model example with an array of multiple distance sensors.

This feature potentiates the development of onboard sense-and-avoid algorithms. Some changes were also required on the `simulator` module in PX4. PR following upstream.

@dagar @jkflying @Jaeyoung-Lim @mrivi @baumanta FYI.