### PR TITLE
travis: remove unnecessary, failing pip checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -128,14 +128,6 @@ after_install:
 script:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       echo $PYTHONPATH;
-      which python;
-      python --version;
-      which pip;
-      pip --version;
-      which python3;
-      python3 --version;
-      which pip3;
-      pip3 --version;
       mkdir build;
       (cd build && cmake -DENABLE_UNIT_TESTS=On .. &&
       make -j$(sysctl -n hw.physicalcpu) -l$(sysctl -n hw.physicalcpu) &&


### PR DESCRIPTION
pip is not available anymore, so we need to remove this checks.