### PR TITLE
Handle videostream info and mode switches for geotagged images plugin

### DIFF
--- a/include/gazebo_geotagged_images_plugin.h
+++ b/include/gazebo_geotagged_images_plugin.h
@@ -64,6 +64,7 @@ private:
     void _handle_request_camera_settings(const mavlink_message_t *pMsg, struct sockaddr* srcaddr);
     void _handle_request_video_stream_information(const mavlink_message_t *pMsg, struct sockaddr* srcaddr);
     void _handle_request_video_stream_status(const mavlink_message_t *pMsg, struct sockaddr* srcaddr);
+    void _handle_set_camera_mode(const mavlink_message_t *pMsg, struct sockaddr* srcaddr);
     void _handle_camera_zoom(const mavlink_message_t *pMsg, struct sockaddr* srcaddr);
     void _send_capture_status(struct sockaddr* srcaddr = NULL);
     void _send_cmd_ack(uint8_t target_sysid, uint8_t target_compid, uint16_t cmd, unsigned char result, struct sockaddr* srcaddr);
@@ -73,6 +74,7 @@ private:
 private:
 
     int         _imageCounter;
+    uint8_t     _mode;
     uint32_t    _width;
     uint32_t    _height;
     uint32_t    _depth;

--- a/include/gazebo_geotagged_images_plugin.h
+++ b/include/gazebo_geotagged_images_plugin.h
@@ -62,6 +62,8 @@ private:
     void _handle_take_photo(const mavlink_message_t *pMsg, struct sockaddr* srcaddr);
     void _handle_stop_take_photo(const mavlink_message_t *pMsg, struct sockaddr* srcaddr);
     void _handle_request_camera_settings(const mavlink_message_t *pMsg, struct sockaddr* srcaddr);
+    void _handle_request_video_stream_information(const mavlink_message_t *pMsg, struct sockaddr* srcaddr);
+    void _handle_request_video_stream_status(const mavlink_message_t *pMsg, struct sockaddr* srcaddr);
     void _handle_camera_zoom(const mavlink_message_t *pMsg, struct sockaddr* srcaddr);
     void _send_capture_status(struct sockaddr* srcaddr = NULL);
     void _send_cmd_ack(uint8_t target_sysid, uint8_t target_compid, uint16_t cmd, unsigned char result, struct sockaddr* srcaddr);


### PR DESCRIPTION
This PR improves handling the mavlink camera protocol in the `geotagged_images_plugin`, by handling the following mavlink messages
- `MAV_CMD_REQUEST_VIDEO_STREAM_STATUS`
- `MAV_CMD_REQUEST_VIDEO_STREAM_INFORMATION`
- [`MAV_CMD_SET_CAMERA_MODE`](https://mavlink.io/en/services/camera.html#camera-modes)
 

To test:
```
make px4_sitl gazebo_typhoon_h480
```