### PR TITLE
Fix typhoon not taking off

### DIFF
--- a/worlds/typhoon_h480.world
+++ b/worlds/typhoon_h480.world
@@ -34,9 +34,9 @@
           <contact_surface_layer>0.001</contact_surface_layer>
         </constraints>
       </ode>
-      <max_step_size>0.002</max_step_size>
+      <max_step_size>0.004</max_step_size>
       <real_time_factor>1</real_time_factor>
-      <real_time_update_rate>500</real_time_update_rate>
+      <real_time_update_rate>250</real_time_update_rate>
       <magnetic_field>6.0e-6 2.3e-5 -4.2e-5</magnetic_field>
     </physics>
   </world>


### PR DESCRIPTION
This PR fixes the typhoon_h480 model not being able to take off. This was a regression introduced from #415. @julianoes FYI

I suspect this is coming from the retractable landing gear of the typhoon

```
pxh> commander takeoff
WARN  [commander] Takeoff denied! Please disarm and retry
WARN  [commander] Failsafe enabled: no RC
INFO  [commander] Takeoff detected
ERROR [commander] Critical navigation failure! Check sensor calibration
WARN  [ecl/EKF] 44604000: baro hgt timeout - reset to baro
```

The fix is reverting #415 just for the typhoon model
