### PR TITLE
Update usv_dynamics_plugin license to Apache

### DIFF
--- a/src/gazebo_usv_dynamics_plugin.cpp
+++ b/src/gazebo_usv_dynamics_plugin.cpp
@@ -1,24 +1,18 @@
 /*
-
-Copyright (c) 2017, Brian Bingham
-All rights reserved
-
-This file is part of the usv_gazebo_dynamics_plugin package,
-known as this Package.
-
-This Package free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-This Package s distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this package.  If not, see <http://www.gnu.org/licenses/>.
-
+ * Copyright (C) 2017  Brian Bingham
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
 */
 
 #include <cmath>


### PR DESCRIPTION
The usv dynamics plugin distributed from the osrf/vrx project has GPL headers, although the project was distributed under the Apache license.

Communicated with [osrf/vrx](https://bitbucket.org/osrf/vrx/src/default/) project that the GPL headers was coming from a copy paste mistake, and the fix was done in this [PR ](https://bitbucket.org/osrf/vrx/pull-requests/224/update-license-from-gpl-to-apache-2/diff)

This PR brings in the [fix ](https://bitbucket.org/osrf/vrx/pull-requests/224/update-license-from-gpl-to-apache-2/diff) to the sitl_gazebo repo