### PR TITLE
Add spherical coordinates to the world files

### DIFF
--- a/include/gazebo_gps_plugin.h
+++ b/include/gazebo_gps_plugin.h
@@ -64,6 +64,8 @@ protected:
   std::pair<double, double> reproject(ignition::math::Vector3d& pos);
 
 private:
+  bool checkWorldHomePosition(physics::WorldPtr world);
+
   std::string namespace_;
   std::default_random_engine random_generator_;
   std::normal_distribution<float> standard_normal_distribution_;

--- a/include/gazebo_gps_plugin.h
+++ b/include/gazebo_gps_plugin.h
@@ -64,6 +64,11 @@ protected:
   std::pair<double, double> reproject(ignition::math::Vector3d& pos);
 
 private:
+  /**
+   * @brief     Check if the <sperical_coordinates> tag was defined in the world file
+   * @param     world pointer to gazebo world
+   * @returns   whether if <sperical_coordinates> tag exists in the world file
+   **/
   bool checkWorldHomePosition(physics::WorldPtr world);
 
   std::string namespace_;
@@ -98,6 +103,9 @@ private:
   double lat_home = 47.397742 * M_PI / 180.0;  // rad
   double lon_home = 8.545594 * M_PI / 180.0;   // rad
   double alt_home = 488.0;                     // meters
+  double world_latitude_ = 0.0;
+  double world_longitude_ = 0.0;
+  double world_altitude_ = 0.0;
   // Seattle downtown (15 deg declination): 47.592182, -122.316031
   // static const double lat_home = 47.592182 * M_PI / 180;    // rad
   // static const double lon_home = -122.316031 * M_PI / 180;  // rad

--- a/worlds/sonoma_raceway.world
+++ b/worlds/sonoma_raceway.world
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<sdf version="1.5">
+<sdf version="1.6">
   <world name="default">
     <!-- A global light source -->
     <include>
@@ -7,7 +7,7 @@
     </include>
     <include>
       <uri>model://sonoma_raceway</uri>
-      <pose>-295 150 -7 0 0</pose>
+      <pose>-295 150 -7 0 0 0</pose>
     </include>
     <spherical_coordinates>
       <surface_model>EARTH_WGS84</surface_model>

--- a/worlds/sonoma_raceway.world
+++ b/worlds/sonoma_raceway.world
@@ -1,0 +1,40 @@
+<?xml version="1.0" ?>
+<sdf version="1.5">
+  <world name="default">
+    <!-- A global light source -->
+    <include>
+      <uri>model://sun</uri>
+    </include>
+    <include>
+      <uri>model://sonoma_raceway</uri>
+      <pose>-295 150 -7 0 0</pose>
+    </include>
+    <spherical_coordinates>
+      <surface_model>EARTH_WGS84</surface_model>
+      <latitude_deg>38.161479</latitude_deg>
+      <longitude_deg>-122.454630</longitude_deg>
+      <elevation>488.0</elevation>
+    </spherical_coordinates>
+    <physics name='default_physics' default='0' type='ode'>
+      <gravity>0 0 -9.8066</gravity>
+      <ode>
+        <solver>
+          <type>quick</type>
+          <iters>10</iters>
+          <sor>1.3</sor>
+          <use_dynamic_moi_rescaling>0</use_dynamic_moi_rescaling>
+        </solver>
+        <constraints>
+          <cfm>0</cfm>
+          <erp>0.2</erp>
+          <contact_max_correcting_vel>100</contact_max_correcting_vel>
+          <contact_surface_layer>0.001</contact_surface_layer>
+        </constraints>
+      </ode>
+      <max_step_size>0.004</max_step_size>
+      <real_time_factor>1</real_time_factor>
+      <real_time_update_rate>250</real_time_update_rate>
+      <magnetic_field>6.0e-6 2.3e-5 -4.2e-5</magnetic_field>
+    </physics>
+  </world>
+</sdf>


### PR DESCRIPTION
This PR adds the ability to utilze the `spherical_coordinate` tag defined in the `.world` file so that we can define the world location. This allows easily aligning the gazebo world with the map in ground station as shown in the video below. 

This PR is a continuation of #438 , and the `sonoma_raceway.world` has been added to demo how to use the `spherical_coordinate` tag

[![Demo](https://img.youtube.com/vi/caPbIHKRUCs/0.jpg)](https://youtu.be/caPbIHKRUCs)

To try the demo shown above, use https://github.com/PX4/Firmware/pull/14462 and run
```
make px4_sitl gazebo_rover__sonoma_raceway
```