### PR TITLE
Add plane_lidar model for testing terrain estimated landing

### DIFF
--- a/models/plane_lidar/model.config
+++ b/models/plane_lidar/model.config
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<model>
+  <name>plane_lidar</name>
+  <version>1.0</version>
+  <sdf version='1.6'>plane_lidar.sdf</sdf>
+
+  <author>
+   <name>Jaeyoung Lim</name>
+   <email>jaeyoung@auterion.com</email>
+  </author>
+
+  <description>
+    This is a model of a standard plane equipped with a lidar sensor
+  </description>
+</model>

--- a/models/plane_lidar/plane_lidar.sdf
+++ b/models/plane_lidar/plane_lidar.sdf
@@ -1,0 +1,18 @@
+<sdf version='1.6'>
+  <model name='plane_lidar'>
+    <include>
+      <uri>model://plane</uri>
+    </include>
+
+    <!--lidar-->
+    <include>
+      <uri>model://lidar</uri>
+      <pose>0 0 0.15 0 0 0</pose>
+    </include>
+
+    <joint name="lidar_joint" type="fixed">
+      <parent>plane::base_link</parent>
+      <child>lidar::link</child>
+    </joint>
+  </model>
+</sdf>


### PR DESCRIPTION
This PR attaches a lidar to the plane model, so that we can test terrain estimated landing. This change is included in https://github.com/PX4/Firmware/pull/14480