### PR TITLE
more realistic rotor drag for iris model

### DIFF
--- a/models/rotors_description/urdf/iris.xacro
+++ b/models/rotors_description/urdf/iris.xacro
@@ -25,7 +25,7 @@
   <xacro:property name="sin30" value="0.5" />
   <xacro:property name="cos30" value="0.866025403784" />
   <xacro:property name="sqrt2" value="1.4142135623730951" />
-  <xacro:property name="rotor_drag_coefficient" value="8.06428e-04" />
+  <xacro:property name="rotor_drag_coefficient" value="1.75e-04" />
   <xacro:property name="rolling_moment_coefficient" value="0.000001" />
   <xacro:property name="color" value="$(arg visual_material)" />
 


### PR DESCRIPTION
In a log from the pixhawk vision I found that it shows a pitch of 0.22rad @ 5m/s straight flight.
I just tuned the rotor drag of the iris until it showed the same behavior. With the previous drag value it had 0.6 rad pitch @ 5m/s.