### PR TITLE
Fix race condition in gimbal_controller_plugin

### DIFF
--- a/include/gazebo_gimbal_controller_plugin.hh
+++ b/include/gazebo_gimbal_controller_plugin.hh
@@ -23,6 +23,7 @@
 
 #include <string>
 #include <vector>
+#include <mutex>
 
 #include <gazebo/common/PID.hh>
 #include <gazebo/common/Plugin.hh>
@@ -91,6 +92,7 @@ namespace gazebo
     private: void OnRollStringMsg(ConstGzStringPtr &_msg);
     private: void OnYawStringMsg(ConstGzStringPtr &_msg);
 #endif
+    private: std::mutex cmd_mutex;
 
     private: sdf::ElementPtr sdf;
 

--- a/src/gazebo_gimbal_controller_plugin.cpp
+++ b/src/gazebo_gimbal_controller_plugin.cpp
@@ -401,6 +401,7 @@ void GimbalControllerPlugin::Init()
 
 void GimbalControllerPlugin::ImuCallback(ImuPtr& imu_message)
 {
+  const std::lock_guard<std::mutex> lock(cmd_mutex);
   this->lastImuYaw = ignition::math::Quaterniond(imu_message->orientation().w(),
 						 imu_message->orientation().x(),
 						 imu_message->orientation().y(),
@@ -412,6 +413,7 @@ void GimbalControllerPlugin::ImuCallback(ImuPtr& imu_message)
 /////////////////////////////////////////////////
 void GimbalControllerPlugin::OnPitchStringMsg(ConstAnyPtr &_msg)
 {
+  const std::lock_guard<std::mutex> lock(cmd_mutex);
 //  gzdbg << "pitch command received " << _msg->double_value() << std::endl;
   this->pitchCommand = _msg->double_value();
 }
@@ -419,6 +421,7 @@ void GimbalControllerPlugin::OnPitchStringMsg(ConstAnyPtr &_msg)
 /////////////////////////////////////////////////
 void GimbalControllerPlugin::OnRollStringMsg(ConstAnyPtr &_msg)
 {
+  const std::lock_guard<std::mutex> lock(cmd_mutex);
 //  gzdbg << "roll command received " << _msg->double_value() << std::endl;
   this->rollCommand = _msg->double_value();
 }
@@ -426,6 +429,7 @@ void GimbalControllerPlugin::OnRollStringMsg(ConstAnyPtr &_msg)
 /////////////////////////////////////////////////
 void GimbalControllerPlugin::OnYawStringMsg(ConstAnyPtr &_msg)
 {
+  const std::lock_guard<std::mutex> lock(cmd_mutex);
 //  gzdbg << "yaw command received " << _msg->double_value() << std::endl;
   this->yawCommand = _msg->double_value();
 }
@@ -433,6 +437,7 @@ void GimbalControllerPlugin::OnYawStringMsg(ConstAnyPtr &_msg)
 /////////////////////////////////////////////////
 void GimbalControllerPlugin::OnPitchStringMsg(ConstGzStringPtr &_msg)
 {
+  const std::lock_guard<std::mutex> lock(cmd_mutex);
 //  gzdbg << "pitch command received " << _msg->data() << std::endl;
   this->pitchCommand = atof(_msg->data().c_str());
 }
@@ -440,6 +445,7 @@ void GimbalControllerPlugin::OnPitchStringMsg(ConstGzStringPtr &_msg)
 /////////////////////////////////////////////////
 void GimbalControllerPlugin::OnRollStringMsg(ConstGzStringPtr &_msg)
 {
+  const std::lock_guard<std::mutex> lock(cmd_mutex);
 //  gzdbg << "roll command received " << _msg->data() << std::endl;
   this->rollCommand = atof(_msg->data().c_str());
 }
@@ -447,6 +453,7 @@ void GimbalControllerPlugin::OnRollStringMsg(ConstGzStringPtr &_msg)
 /////////////////////////////////////////////////
 void GimbalControllerPlugin::OnYawStringMsg(ConstGzStringPtr &_msg)
 {
+  const std::lock_guard<std::mutex> lock(cmd_mutex);
 //  gzdbg << "yaw command received " << _msg->data() << std::endl;
   this->yawCommand = atof(_msg->data().c_str());
 }
@@ -455,6 +462,8 @@ void GimbalControllerPlugin::OnYawStringMsg(ConstGzStringPtr &_msg)
 /////////////////////////////////////////////////
 void GimbalControllerPlugin::OnUpdate()
 {
+  const std::lock_guard<std::mutex> lock(cmd_mutex);
+
   if (!this->pitchJoint || !this->rollJoint || !this->yawJoint)
     return;
 


### PR DESCRIPTION
This Fixes #422 where the race condition on the yaw command in the `gimbal_controller_plugin` was introducing oscillations. The race conditon was caused when a new roll / pitch / yaw command was received while the gimbal control was calculating the gimbal commands in the `OnUpdate` method. 

@jannsta1 Thanks for reporting the issue!

**Additional Context**
H520 still shows some oscillations, but this seems to be introduced when the landing gear is up. Will be addressed on a separate PR