### PR TITLE
Remove boat from boat world

### DIFF
--- a/worlds/boat.world
+++ b/worlds/boat.world
@@ -8,9 +8,6 @@
     <include>
       <uri>model://water_level</uri>
     </include>
-    <include>
-      <uri>model://boat</uri>
-    </include>
      <physics name='default_physics' default='0' type='ode'>
       <gravity>0 0 -9.8066</gravity>
       <ode>


### PR DESCRIPTION
Boat was getting spawned twice after https://github.com/PX4/Firmware/pull/14166. 