### PR TITLE
Remove uuv_hippocampus from uuv_hippocampus world

### DIFF
--- a/worlds/uuv_hippocampus.world
+++ b/worlds/uuv_hippocampus.world
@@ -23,13 +23,6 @@
         <direction>-0.001 0.001 -0.9</direction>
     </light>
 
-    <!--
-        Include the model of the Hippocampus from TUHH.
-        The pose is chosen that the hippocampus starts at position (0,0,0) with its own coordinate frame equal to the
-        NED World frame.
-        Above is currently broken.
-    -->
-
     <!-- Add World Coordinate Frame -->
     <scene>
      <origin_visual>false</origin_visual>

--- a/worlds/uuv_hippocampus.world
+++ b/worlds/uuv_hippocampus.world
@@ -27,12 +27,8 @@
         Include the model of the Hippocampus from TUHH.
         The pose is chosen that the hippocampus starts at position (0,0,0) with its own coordinate frame equal to the
         NED World frame.
+        Above is currently broken.
     -->
-
-    <include>
-      <uri>model://uuv_hippocampus</uri>
-      <pose>0.5 0.5 0 0 0 3.1415</pose>
-    </include>
 
     <!-- Add World Coordinate Frame -->
     <scene>


### PR DESCRIPTION
uuv_hippocampus was also getting spawned twice after https://github.com/PX4/Firmware/pull/14166 

This PR is a quick fix for that. Unfortunately because of the recent changes in the sitl run logic it looks like a part of this simulation is broken because according to the comments it looks like the model needs to be spawned in a certain location. If there's a better solution for this let me know.

@Jaeyoung-Lim FYI.