### PR TITLE
Add px4vision_less Model

### DIFF
--- a/models/px4vision_less/model.config
+++ b/models/px4vision_less/model.config
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<model>
+  <name>PX4 Vision Less</name>
+  <version>1.0</version>
+  <sdf version='1.6'>px4vision_less.sdf</sdf>
+
+  <author>
+   <name>Stone White</name>
+   <email>stone@thone.io</email>
+  </author>
+
+  <description>
+    This is a model of the Holybro PX4 Vision and will not enable vision features in parameters.
+    For non-ROS environment and showcase usage.
+  </description>
+</model>

--- a/models/px4vision_less/px4vision_less.sdf
+++ b/models/px4vision_less/px4vision_less.sdf
@@ -1,0 +1,7 @@
+<sdf version='1.6'>
+  <model name='px4vision_less'>
+    <include>
+      <uri>model://px4vision</uri>
+    </include>
+  </model>
+</sdf>


### PR DESCRIPTION
For non-ROS environment and showcase usage.

Naming explains:
1. Visionless means without vision feature.
2. Less is more, more potential usage in normal simulation environment.