### PR TITLE
Add influence of wind to rotor drag

### DIFF
--- a/include/gazebo_motor_model.h
+++ b/include/gazebo_motor_model.h
@@ -34,6 +34,7 @@
 #include "gazebo/msgs/msgs.hh"
 #include "MotorSpeed.pb.h"
 #include "Float.pb.h"
+#include "Wind.pb.h"
 
 #include "common.h"
 
@@ -49,8 +50,10 @@ static const std::string kDefaultNamespace = "";
 static const std::string kDefaultCommandSubTopic = "/gazebo/command/motor_speed";
 static const std::string kDefaultMotorFailureNumSubTopic = "/gazebo/motor_failure_num";
 static const std::string kDefaultMotorVelocityPubTopic = "/motor_speed";
+std::string wind_sub_topic_ = "/wind";
 
 typedef const boost::shared_ptr<const mav_msgs::msgs::CommandMotorSpeed> CommandMotorSpeedPtr;
+typedef const boost::shared_ptr<const physics_msgs::msgs::Wind> WindPtr;
 
 /*
 // Protobuf test
@@ -137,6 +140,9 @@ class GazeboMotorModel : public MotorModel, public ModelPlugin {
   transport::PublisherPtr motor_velocity_pub_;
   transport::SubscriberPtr command_sub_;
   transport::SubscriberPtr motor_failure_sub_; /*!< Subscribing to motor_failure_sub_topic_; receiving motor number to fail, as an integer */
+  transport::SubscriberPtr wind_sub_;
+
+  ignition::math::Vector3d wind_vel_;
 
   physics::ModelPtr model_;
   physics::JointPtr joint_;
@@ -151,6 +157,8 @@ class GazeboMotorModel : public MotorModel, public ModelPlugin {
   std_msgs::msgs::Float turning_velocity_msg_;
   void VelocityCallback(CommandMotorSpeedPtr &rot_velocities);
   void MotorFailureCallback(const boost::shared_ptr<const msgs::Int> &fail_msg);  /*!< Callback for the motor_failure_sub_ subscriber */
+  void WindVelocityCallback(const boost::shared_ptr<const physics_msgs::msgs::Wind> &msg);
+
   std::unique_ptr<FirstOrderFilter<double>>  rotor_velocity_filter_;
 /*
   // Protobuf test

--- a/src/gazebo_motor_model.cpp
+++ b/src/gazebo_motor_model.cpp
@@ -150,6 +150,7 @@ void GazeboMotorModel::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf) {
   motor_failure_sub_ = node_handle_->Subscribe<msgs::Int>(motor_failure_sub_topic_, &GazeboMotorModel::MotorFailureCallback, this);
   // FIXME: Commented out to prevent warnings about queue limit reached.
   //motor_velocity_pub_ = node_handle_->Advertise<std_msgs::msgs::Float>("~/" + model_->GetName() + motor_speed_pub_topic_, 1);
+  wind_sub_ = node_handle_->Subscribe("~/" + model_->GetName() + wind_sub_topic_, &GazeboMotorModel::WindVelocityCallback, this);
 
   // Create the first order filter.
   rotor_velocity_filter_.reset(new FirstOrderFilter<double>(time_constant_up_, time_constant_down_, ref_motor_rot_vel_));
@@ -199,9 +200,9 @@ void GazeboMotorModel::UpdateForcesAndMoments() {
   // XXX this has to be modelled better
   //
 #if GAZEBO_MAJOR_VERSION >= 9
-  ignition::math::Vector3d body_velocity = link_->WorldLinearVel();
+  ignition::math::Vector3d body_velocity = link_->WorldLinearVel() - wind_vel_;
 #else
-  ignition::math::Vector3d body_velocity = ignitionFromGazeboMath(link_->GetWorldLinearVel());
+  ignition::math::Vector3d body_velocity = ignitionFromGazeboMath(link_->GetWorldLinearVel())  - wind_vel_;
 #endif
   double vel = body_velocity.Length();
   double scalar = 1 - vel / 25.0; // at 50 m/s the rotor will not produce any force anymore
@@ -288,6 +289,12 @@ void GazeboMotorModel::UpdateMotorFail() {
        screen_msg_flag = 1;
      }
   }
+}
+
+void GazeboMotorModel::WindVelocityCallback(WindPtr& msg) {
+  wind_vel_ = ignition::math::Vector3d(msg->velocity().x(),
+            msg->velocity().y(),
+            msg->velocity().z());
 }
 
 GZ_REGISTER_MODEL_PLUGIN(GazeboMotorModel);


### PR DESCRIPTION
This PR adds the influence of the wind to the motor model, by considering wind as part of the calculation of rotor drag. This is important since the majority of the drag is usually generated from the rotors in case of multirotors, and is influenced by wind. Thrust variations are not considered.  

Also, @MaEtUgR have brought up examples where some issues only appear under the influence of wind. This PR would make it easier to see wind influence of multirotor models. 

**Testing**
Below shows the model taking off and being influenced under the wind of 5m/s

![ezgif com-video-to-gif(7)](https://user-images.githubusercontent.com/5248102/79641776-df075300-8199-11ea-9db3-d3d19fa0ef13.gif)

**Additional Context**
This is a follow up PR of https://github.com/PX4/sitl_gazebo/pull/375 , which added wind influence to the lift drag model