### PR TITLE
Change wind gust to publish velocity instead of force

### DIFF
--- a/include/gazebo_wind_plugin.h
+++ b/include/gazebo_wind_plugin.h
@@ -41,9 +41,9 @@ static const std::string kDefaultLinkName = "base_link";
 static constexpr double kDefaultWindVelocityMean = 0.0;
 static constexpr double kDefaultWindVelocityMax = 100.0;
 static constexpr double kDefaultWindVelocityVariance = 0.0;
-static constexpr double kDefaultWindGustForceMean = 0.0;
-static constexpr double kDefaultWindGustForceMax = 100.0;
-static constexpr double kDefaultWindGustForceVariance = 0.0;
+static constexpr double kDefaultWindGustVelocityMean = 0.0;
+static constexpr double kDefaultWindGustVelocityMax = 10.0;
+static constexpr double kDefaultWindGustVelocityVariance = 0.0;
 
 static constexpr double kDefaultWindGustStart = 10.0;
 static constexpr double kDefaultWindGustDuration = 0.0;
@@ -63,9 +63,9 @@ class GazeboWindPlugin : public ModelPlugin {
         wind_velocity_mean_(kDefaultWindVelocityMean),
         wind_velocity_max_(kDefaultWindVelocityMax),
         wind_velocity_variance_(kDefaultWindVelocityVariance),
-        wind_gust_force_mean_(kDefaultWindGustForceMean),
-        wind_gust_force_max_(kDefaultWindGustForceMax),
-        wind_gust_force_variance_(kDefaultWindGustForceVariance),
+        wind_gust_velocity_mean_(kDefaultWindGustVelocityMean),
+        wind_gust_velocity_max_(kDefaultWindGustVelocityMax),
+        wind_gust_velocity_variance_(kDefaultWindGustVelocityVariance),
         wind_direction_mean_(kDefaultWindDirectionMean),
         wind_direction_variance_(kDefaultWindDirectionVariance),
         wind_gust_direction_mean_(kDefaultWindGustDirectionMean),
@@ -103,13 +103,13 @@ class GazeboWindPlugin : public ModelPlugin {
   double wind_velocity_mean_;
   double wind_velocity_max_;
   double wind_velocity_variance_;
-  double wind_gust_force_mean_;
-  double wind_gust_force_max_;
-  double wind_gust_force_variance_;
+  double wind_gust_velocity_mean_;
+  double wind_gust_velocity_max_;
+  double wind_gust_velocity_variance_;
   std::default_random_engine wind_velocity_generator_;
   std::normal_distribution<double> wind_velocity_distribution_;
-  std::default_random_engine wind_gust_force_generator_;
-  std::normal_distribution<double> wind_gust_force_distribution_;
+  std::default_random_engine wind_gust_velocity_generator_;
+  std::normal_distribution<double> wind_gust_velocity_distribution_;
 
   ignition::math::Vector3d xyz_offset_;
   ignition::math::Vector3d wind_direction_mean_;

--- a/models/plane/plane.sdf
+++ b/models/plane/plane.sdf
@@ -480,7 +480,7 @@
       <windGustDirection>0 0 0</windGustDirection>
       <windGustDuration>0</windGustDuration>
       <windGustStart>0</windGustStart>
-      <windGustForceMean>0</windGustForceMean>
+      <windGustVelocityMean>0</windGustVelocityMean>
       <windPubTopic>/wind</windPubTopic>
     </plugin>
     <plugin name="gps_plugin" filename="libgazebo_gps_plugin.so">

--- a/models/rotors_description/urdf/component_snippets.xacro
+++ b/models/rotors_description/urdf/component_snippets.xacro
@@ -588,11 +588,11 @@
         <robotNamespace>${namespace}</robotNamespace>
         <xyzOffset>${xyz_offset}</xyzOffset> <!-- [m] [m] [m] -->
         <windDirection>${wind_direction}</windDirection>
-        <windForceMean>${wind_force_mean}</windForceMean> <!-- [N] -->
+        <windVelocityMean>${wind_force_mean}</windVelocityMean> <!-- [N] -->
         <windGustDirection>${wind_gust_direction}</windGustDirection>
         <windGustDuration>${wind_gust_duration}</windGustDuration> <!-- [s] -->
         <windGustStart>${wind_gust_start}</windGustStart> <!-- [s] -->
-        <windGustForceMean>${wind_gust_force_mean}</windGustForceMean> <!-- [N] -->
+        <windGustVelocityMean>${wind_gust_force_mean}</windGustVelocityMean> <!-- [N] -->
       </plugin>
     </gazebo>
   </xacro:macro>

--- a/models/standard_vtol/standard_vtol.sdf
+++ b/models/standard_vtol/standard_vtol.sdf
@@ -853,20 +853,6 @@
       <accelerometerBiasCorrelationTime>300.0</accelerometerBiasCorrelationTime>
       <accelerometerTurnOnBiasSigma>0.196</accelerometerTurnOnBiasSigma>
     </plugin>
-    <!--
-    <plugin name='wind_plugin' filename='libgazebo_wind_plugin.so'>
-      <frameId>base_link</frameId>
-      <linkName>base_link</linkName>
-      <robotNamespace/>
-      <xyzOffset>1 0 0</xyzOffset>
-      <windDirection>0 1 0</windDirection>
-      <windForceMean>0.7</windForceMean>
-      <windGustDirection>0 0 0</windGustDirection>
-      <windGustDuration>0</windGustDuration>
-      <windGustStart>0</windGustStart>
-      <windGustForceMean>0</windGustForceMean>
-    </plugin>
-    -->
     <plugin name="gps_plugin" filename="libgazebo_gps_plugin.so">
         <robotNamespace></robotNamespace>
         <gpsNoise>true</gpsNoise>

--- a/models/tiltrotor/tiltrotor.sdf
+++ b/models/tiltrotor/tiltrotor.sdf
@@ -989,20 +989,6 @@
       <accelerometerBiasCorrelationTime>300.0</accelerometerBiasCorrelationTime>
       <accelerometerTurnOnBiasSigma>0.196</accelerometerTurnOnBiasSigma>
     </plugin>
-    <!--
-    <plugin name='wind_plugin' filename='libgazebo_wind_plugin.so'>
-      <frameId>base_link</frameId>
-      <linkName>base_link</linkName>
-      <robotNamespace/>
-      <xyzOffset>1 0 0</xyzOffset>
-      <windDirection>0 1 0</windDirection>
-      <windForceMean>0.7</windForceMean>
-      <windGustDirection>0 0 0</windGustDirection>
-      <windGustDuration>0</windGustDuration>
-      <windGustStart>0</windGustStart>
-      <windGustForceMean>0</windGustForceMean>
-    </plugin>
-    -->
     <plugin name="gps_plugin" filename="libgazebo_gps_plugin.so">
         <robotNamespace></robotNamespace>
         <gpsNoise>true</gpsNoise>

--- a/msgs/Wind.proto
+++ b/msgs/Wind.proto
@@ -6,6 +6,5 @@ message Wind
 {
   required string frame_id = 1;
   required int64 time_usec = 2;
-  required gazebo.msgs.Vector3d force = 3;
-  required gazebo.msgs.Vector3d velocity = 4;
+  required gazebo.msgs.Vector3d velocity = 3;
 }

--- a/src/gazebo_wind_plugin.cpp
+++ b/src/gazebo_wind_plugin.cpp
@@ -62,9 +62,9 @@ void GazeboWindPlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf) {
   // Get the wind gust params from SDF.
   getSdfParam<double>(_sdf, "windGustStart", wind_gust_start, wind_gust_start);
   getSdfParam<double>(_sdf, "windGustDuration", wind_gust_duration, wind_gust_duration);
-  getSdfParam<double>(_sdf, "windGustForceMean", wind_gust_force_mean_, wind_gust_force_mean_);
-  getSdfParam<double>(_sdf, "windGustForceMax", wind_gust_force_max_, wind_gust_force_max_);
-  getSdfParam<double>(_sdf, "windGustForceVariance", wind_gust_force_variance_, wind_gust_force_variance_);
+  getSdfParam<double>(_sdf, "windGustVeloctiyMean", wind_gust_velocity_mean_, wind_gust_velocity_mean_);
+  getSdfParam<double>(_sdf, "windGustVelocityMax", wind_gust_velocity_max_, wind_gust_velocity_max_);
+  getSdfParam<double>(_sdf, "windGustVelocityVariance", wind_gust_velocity_variance_, wind_gust_velocity_variance_);
   getSdfParam<ignition::math::Vector3d>(_sdf, "windGustDirectionMean", wind_gust_direction_mean_, wind_gust_direction_mean_);
   getSdfParam<double>(_sdf, "windGustDirectionVariance", wind_gust_direction_variance_, wind_gust_direction_variance_);
 
@@ -72,14 +72,14 @@ void GazeboWindPlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf) {
   wind_gust_direction_mean_.Normalize();
   wind_gust_start_ = common::Time(wind_gust_start);
   wind_gust_end_ = common::Time(wind_gust_start + wind_gust_duration);
-  // Set random wind force mean and standard deviation
+  // Set random wind velocity mean and standard deviation
   wind_velocity_distribution_.param(std::normal_distribution<double>::param_type(wind_velocity_mean_, sqrt(wind_velocity_variance_)));
   // Set random wind direction mean and standard deviation
   wind_direction_distribution_X_.param(std::normal_distribution<double>::param_type(wind_direction_mean_.X(), sqrt(wind_direction_variance_)));
   wind_direction_distribution_Y_.param(std::normal_distribution<double>::param_type(wind_direction_mean_.Y(), sqrt(wind_direction_variance_)));
   wind_direction_distribution_Z_.param(std::normal_distribution<double>::param_type(wind_direction_mean_.Z(), sqrt(wind_direction_variance_)));
-  // Set random wind gust force mean and standard deviation
-  wind_gust_force_distribution_.param(std::normal_distribution<double>::param_type(wind_gust_force_mean_, sqrt(wind_gust_force_variance_)));
+  // Set random wind gust velocity mean and standard deviation
+  wind_gust_velocity_distribution_.param(std::normal_distribution<double>::param_type(wind_gust_velocity_mean_, sqrt(wind_gust_velocity_variance_)));
   // Set random wind gust direction mean and standard deviation
   wind_gust_direction_distribution_X_.param(std::normal_distribution<double>::param_type(wind_gust_direction_mean_.X(), sqrt(wind_gust_direction_variance_)));
   wind_gust_direction_distribution_Y_.param(std::normal_distribution<double>::param_type(wind_gust_direction_mean_.Y(), sqrt(wind_gust_direction_variance_)));
@@ -118,35 +118,26 @@ void GazeboWindPlugin::OnUpdate(const common::UpdateInfo& _info) {
   ignition::math::Vector3d wind = wind_strength * wind_direction;
 
   ignition::math::Vector3d wind_gust(0, 0, 0);
-  // Calculate the wind gust force.
+  // Calculate the wind gust velocity.
   if (now >= wind_gust_start_ && now < wind_gust_end_) {
     // Get normal distribution wind gust strength
-    double wind_gust_strength = wind_gust_force_distribution_(wind_gust_force_generator_);
-    wind_gust_strength = (wind_gust_strength > wind_gust_force_max_) ? wind_gust_force_max_ : wind_gust_strength;
+    double wind_gust_strength = wind_gust_velocity_distribution_(wind_gust_velocity_generator_);
+    wind_gust_strength = (wind_gust_strength > wind_gust_velocity_max_) ? wind_gust_velocity_max_ : wind_gust_strength;
     // Get normal distribution wind gust direction
     ignition::math::Vector3d wind_gust_direction;
     wind_gust_direction.X() = wind_gust_direction_distribution_X_(wind_gust_direction_generator_);
     wind_gust_direction.Y() = wind_gust_direction_distribution_Y_(wind_gust_direction_generator_);
     wind_gust_direction.Z() = wind_gust_direction_distribution_Z_(wind_gust_direction_generator_);
     wind_gust = wind_gust_strength * wind_gust_direction;
-    // Apply a force from the wind gust to the link.
-    link_->AddForceAtRelativePosition(wind_gust, xyz_offset_);
   }
 
-  gazebo::msgs::Vector3d* force = new gazebo::msgs::Vector3d();
-
-  force->set_x(wind_gust.X());
-  force->set_y(wind_gust.Y());
-  force->set_z(wind_gust.Z());
-
   gazebo::msgs::Vector3d* wind_v = new gazebo::msgs::Vector3d();
-  wind_v->set_x(wind.X());
-  wind_v->set_y(wind.Y());
-  wind_v->set_z(wind.Z());
+  wind_v->set_x(wind.X() + wind_gust.X());
+  wind_v->set_y(wind.Y() + wind_gust.Y());
+  wind_v->set_z(wind.Z() + wind_gust.Z());
 
   wind_msg.set_frame_id(frame_id_);
   wind_msg.set_time_usec(now.Double() * 1e6);
-  wind_msg.set_allocated_force(force);
   wind_msg.set_allocated_velocity(wind_v);
 
   wind_pub_->Publish(wind_msg);

--- a/src/gazebo_wind_plugin.cpp
+++ b/src/gazebo_wind_plugin.cpp
@@ -107,7 +107,7 @@ void GazeboWindPlugin::OnUpdate(const common::UpdateInfo& _info) {
 
   // Calculate the wind force.
   // Get normal distribution wind strength
-  double wind_strength = wind_velocity_distribution_(wind_velocity_generator_);
+  double wind_strength = std::abs(wind_velocity_distribution_(wind_velocity_generator_));
   wind_strength = (wind_strength > wind_velocity_max_) ? wind_velocity_max_ : wind_strength;
   // Get normal distribution wind direction
   ignition::math::Vector3d wind_direction;
@@ -121,7 +121,7 @@ void GazeboWindPlugin::OnUpdate(const common::UpdateInfo& _info) {
   // Calculate the wind gust velocity.
   if (now >= wind_gust_start_ && now < wind_gust_end_) {
     // Get normal distribution wind gust strength
-    double wind_gust_strength = wind_gust_velocity_distribution_(wind_gust_velocity_generator_);
+    double wind_gust_strength = std::abs(wind_gust_velocity_distribution_(wind_gust_velocity_generator_));
     wind_gust_strength = (wind_gust_strength > wind_gust_velocity_max_) ? wind_gust_velocity_max_ : wind_gust_strength;
     // Get normal distribution wind gust direction
     ignition::math::Vector3d wind_gust_direction;


### PR DESCRIPTION
This is a follow up PR of #375 which switches the wind gust to publish wind velocity instead of force.This was part of a comment from @jkflying 

As the effect of wind gust on the vehicle can be effectively modeled closer to the real physics through #461, applying force directly through the wind plugin is deprecated

