### PR TITLE
Fix winddirection sdf tag

### DIFF
--- a/models/plane/plane.sdf
+++ b/models/plane/plane.sdf
@@ -475,7 +475,7 @@
       <linkName>base_link</linkName>
       <robotNamespace/>
       <xyzOffset>1 0 0</xyzOffset>
-      <windDirection>0 1 0</windDirection>
+      <windDirectionMean>0 1 0</windDirectionMean>
       <windVelocityMean>0.7</windVelocityMean>
       <windGustDirection>0 0 0</windGustDirection>
       <windGustDuration>0</windGustDuration>

--- a/models/rotors_description/urdf/component_snippets.xacro
+++ b/models/rotors_description/urdf/component_snippets.xacro
@@ -587,7 +587,7 @@
         <linkName>base_link</linkName>
         <robotNamespace>${namespace}</robotNamespace>
         <xyzOffset>${xyz_offset}</xyzOffset> <!-- [m] [m] [m] -->
-        <windDirection>${wind_direction}</windDirection>
+        <windDirectionMean>${wind_direction}</windDirectionMean>
         <windVelocityMean>${wind_force_mean}</windVelocityMean> <!-- [N] -->
         <windGustDirection>${wind_gust_direction}</windGustDirection>
         <windGustDuration>${wind_gust_duration}</windGustDuration> <!-- [s] -->


### PR DESCRIPTION
The winddirection tag on the `plane` plugin was misleading, since `windDirection` tag doesn't exist.
The correct tag is `windDirectionMean` 

This is a regression from https://github.com/PX4/sitl_gazebo/pull/245