### PR TITLE
Make wind plugin a world plugin

### DIFF
--- a/include/gazebo_mavlink_interface.h
+++ b/include/gazebo_mavlink_interface.h
@@ -124,7 +124,7 @@ static const std::string kDefaultVisionTopic = "/vision_odom";
 static const std::string kDefaultMagTopic = "/mag";
 static const std::string kDefaultAirspeedTopic = "/airspeed";
 static const std::string kDefaultBarometerTopic = "/baro";
-static const std::string kDefaultWindTopic = "/wind";
+static const std::string kDefaultWindTopic = "/world_wind";
 
 //! Rx packer framing status. (same as @p mavlink::mavlink_framing_t)
 enum class Framing : uint8_t {

--- a/include/gazebo_motor_model.h
+++ b/include/gazebo_motor_model.h
@@ -50,7 +50,7 @@ static const std::string kDefaultNamespace = "";
 static const std::string kDefaultCommandSubTopic = "/gazebo/command/motor_speed";
 static const std::string kDefaultMotorFailureNumSubTopic = "/gazebo/motor_failure_num";
 static const std::string kDefaultMotorVelocityPubTopic = "/motor_speed";
-std::string wind_sub_topic_ = "/wind";
+std::string wind_sub_topic_ = "/world_wind";
 
 typedef const boost::shared_ptr<const mav_msgs::msgs::CommandMotorSpeed> CommandMotorSpeedPtr;
 typedef const boost::shared_ptr<const physics_msgs::msgs::Wind> WindPtr;

--- a/include/gazebo_wind_plugin.h
+++ b/include/gazebo_wind_plugin.h
@@ -36,7 +36,6 @@ namespace gazebo {
 // Default values
 static const std::string kDefaultNamespace = "";
 static const std::string kDefaultFrameId = "world";
-static const std::string kDefaultLinkName = "base_link";
 
 static constexpr double kDefaultWindVelocityMean = 0.0;
 static constexpr double kDefaultWindVelocityMax = 100.0;
@@ -54,10 +53,10 @@ static constexpr double kDefaultWindDirectionVariance = 0.0;
 static constexpr double kDefaultWindGustDirectionVariance = 0.0;
 
 /// \brief This gazebo plugin simulates wind acting on a model.
-class GazeboWindPlugin : public ModelPlugin {
+class GazeboWindPlugin : public WorldPlugin {
  public:
   GazeboWindPlugin()
-      : ModelPlugin(),
+      : WorldPlugin(),
         namespace_(kDefaultNamespace),
         wind_pub_topic_("wind"),
         wind_velocity_mean_(kDefaultWindVelocityMean),
@@ -71,7 +70,6 @@ class GazeboWindPlugin : public ModelPlugin {
         wind_gust_direction_mean_(kDefaultWindGustDirectionMean),
         wind_gust_direction_variance_(kDefaultWindGustDirectionVariance),
         frame_id_(kDefaultFrameId),
-        link_name_(kDefaultLinkName),
         node_handle_(NULL) {}
 
   virtual ~GazeboWindPlugin();
@@ -80,7 +78,7 @@ class GazeboWindPlugin : public ModelPlugin {
   /// \brief Load the plugin.
   /// \param[in] _model Pointer to the model that loaded this plugin.
   /// \param[in] _sdf SDF element that describes the plugin.
-  void Load(physics::ModelPtr _model, sdf::ElementPtr _sdf);
+  void Load(physics::WorldPtr world, sdf::ElementPtr sdf);
 
   /// \brief Called when the world is updated.
   /// \param[in] _info Update timing information.
@@ -91,13 +89,10 @@ class GazeboWindPlugin : public ModelPlugin {
   event::ConnectionPtr update_connection_;
 
   physics::WorldPtr world_;
-  physics::ModelPtr model_;
-  physics::LinkPtr link_;
 
   std::string namespace_;
 
   std::string frame_id_;
-  std::string link_name_;
   std::string wind_pub_topic_;
 
   double wind_velocity_mean_;

--- a/include/liftdrag_plugin/liftdrag_plugin.h
+++ b/include/liftdrag_plugin/liftdrag_plugin.h
@@ -140,11 +140,11 @@ namespace gazebo
     protected: sdf::ElementPtr sdf;
 
     private: void WindVelocityCallback(const boost::shared_ptr<const physics_msgs::msgs::Wind> &msg);
-    
+
     private: transport::NodePtr node_handle_;
     private: transport::SubscriberPtr wind_sub_;
     private: std::string namespace_;
-    private: std::string wind_sub_topic_;
+    private: std::string wind_sub_topic_ = "world_wind";
     private: ignition::math::Vector3d wind_vel_;
   };
 }

--- a/models/plane/plane.sdf
+++ b/models/plane/plane.sdf
@@ -516,7 +516,7 @@
       </control_joint_name>
       <control_joint_rad_to_cl>-0.5</control_joint_rad_to_cl>
       <robotNamespace></robotNamespace>
-      <windSubTopic>/wind</windSubTopic>
+      <windSubTopic>world_wind</windSubTopic>
     </plugin>
     <plugin name="right_wing" filename="libLiftDragPlugin.so">
       <a0>0.05984281113</a0>
@@ -538,7 +538,7 @@
       </control_joint_name>
       <control_joint_rad_to_cl>-0.5</control_joint_rad_to_cl>
       <robotNamespace></robotNamespace>
-      <windSubTopic>/wind</windSubTopic>
+      <windSubTopic>world_wind</windSubTopic>
     </plugin>
     <plugin name="left_flap" filename="libLiftDragPlugin.so">
       <a0>0.05984281113</a0>
@@ -604,7 +604,7 @@
       </control_joint_name>
       <control_joint_rad_to_cl>-4.0</control_joint_rad_to_cl>
       <robotNamespace></robotNamespace>
-      <windSubTopic>/wind</windSubTopic>
+      <windSubTopic>world_wind</windSubTopic>
     </plugin>
     <plugin name="rudder" filename="libLiftDragPlugin.so">
       <a0>0.0</a0>
@@ -622,7 +622,7 @@
       <upward>0 1 0</upward>
       <link_name>base_link</link_name>
       <robotNamespace></robotNamespace>
-      <windSubTopic>/wind</windSubTopic>
+      <windSubTopic>world_wind</windSubTopic>
     </plugin>
     <plugin name='puller' filename='libgazebo_motor_model.so'>
       <robotNamespace></robotNamespace>
@@ -641,7 +641,7 @@
       <motorSpeedPubTopic>/motor_speed/4</motorSpeedPubTopic>
       <rotorVelocitySlowdownSim>10</rotorVelocitySlowdownSim>
       <robotNamespace></robotNamespace>
-      <windSubTopic>/wind</windSubTopic>
+      <windSubTopic>world_wind</windSubTopic>
     </plugin>
     <plugin name='gazebo_imu_plugin' filename='libgazebo_imu_plugin.so'>
       <robotNamespace></robotNamespace>
@@ -655,19 +655,6 @@
       <accelerometerRandomWalk>0.006</accelerometerRandomWalk>
       <accelerometerBiasCorrelationTime>300.0</accelerometerBiasCorrelationTime>
       <accelerometerTurnOnBiasSigma>0.196</accelerometerTurnOnBiasSigma>
-    </plugin>
-    <plugin name='wind_plugin' filename='libgazebo_wind_plugin.so'>
-      <frameId>base_link</frameId>
-      <linkName>base_link</linkName>
-      <robotNamespace/>
-      <xyzOffset>1 0 0</xyzOffset>
-      <windDirectionMean>0 1 0</windDirectionMean>
-      <windVelocityMean>0.7</windVelocityMean>
-      <windGustDirection>0 0 0</windGustDirection>
-      <windGustDuration>0</windGustDuration>
-      <windGustStart>0</windGustStart>
-      <windGustVelocityMean>0</windGustVelocityMean>
-      <windPubTopic>/wind</windPubTopic>
     </plugin>
     <plugin name='groundtruth_plugin' filename='libgazebo_groundtruth_plugin.so'>
       <robotNamespace/>

--- a/src/gazebo_motor_model.cpp
+++ b/src/gazebo_motor_model.cpp
@@ -150,7 +150,7 @@ void GazeboMotorModel::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf) {
   motor_failure_sub_ = node_handle_->Subscribe<msgs::Int>(motor_failure_sub_topic_, &GazeboMotorModel::MotorFailureCallback, this);
   // FIXME: Commented out to prevent warnings about queue limit reached.
   //motor_velocity_pub_ = node_handle_->Advertise<std_msgs::msgs::Float>("~/" + model_->GetName() + motor_speed_pub_topic_, 1);
-  wind_sub_ = node_handle_->Subscribe("~/" + model_->GetName() + wind_sub_topic_, &GazeboMotorModel::WindVelocityCallback, this);
+  wind_sub_ = node_handle_->Subscribe("~/" + wind_sub_topic_, &GazeboMotorModel::WindVelocityCallback, this);
 
   // Create the first order filter.
   rotor_velocity_filter_.reset(new FirstOrderFilter<double>(time_constant_up_, time_constant_down_, ref_motor_rot_vel_));

--- a/src/liftdrag_plugin/liftdrag_plugin.cpp
+++ b/src/liftdrag_plugin/liftdrag_plugin.cpp
@@ -168,7 +168,7 @@ void LiftDragPlugin::Load(physics::ModelPtr _model,
 
   if (_sdf->HasElement("windSubTopic")){
     this->wind_sub_topic_ = _sdf->Get<std::string>("windSubTopic");
-    wind_sub_ = node_handle_->Subscribe("~/" + _model->GetName() + wind_sub_topic_, &LiftDragPlugin::WindVelocityCallback, this);
+    wind_sub_ = node_handle_->Subscribe("~/" + wind_sub_topic_, &LiftDragPlugin::WindVelocityCallback, this);
   }
 
   if (_sdf->HasElement("control_joint_name"))

--- a/worlds/windy.world
+++ b/worlds/windy.world
@@ -1,0 +1,49 @@
+<?xml version="1.0" ?>
+<sdf version="1.5">
+  <world name="default">
+    <!-- A global light source -->
+    <include>
+      <uri>model://sun</uri>
+    </include>
+    <!-- A ground plane -->
+    <include>
+      <uri>model://ground_plane</uri>
+    </include>
+    <include>
+      <uri>model://asphalt_plane</uri>
+    </include>
+    <plugin name='wind_plugin' filename='libgazebo_wind_plugin.so'>
+      <frameId>base_link</frameId>
+      <robotNamespace/>
+      <xyzOffset>1 0 0</xyzOffset>
+      <windDirectionMean>0 1 0</windDirectionMean>
+      <windVelocityMean>4.0</windVelocityMean>
+      <windGustDirection>0 0 0</windGustDirection>
+      <windGustDuration>0</windGustDuration>
+      <windGustStart>0</windGustStart>
+      <windGustVelocityMean>0</windGustVelocityMean>
+      <windPubTopic>/wind</windPubTopic>
+    </plugin>
+    <physics name='default_physics' default='0' type='ode'>
+      <gravity>0 0 -9.8066</gravity>
+      <ode>
+        <solver>
+          <type>quick</type>
+          <iters>10</iters>
+          <sor>1.3</sor>
+          <use_dynamic_moi_rescaling>0</use_dynamic_moi_rescaling>
+        </solver>
+        <constraints>
+          <cfm>0</cfm>
+          <erp>0.2</erp>
+          <contact_max_correcting_vel>100</contact_max_correcting_vel>
+          <contact_surface_layer>0.001</contact_surface_layer>
+        </constraints>
+      </ode>
+      <max_step_size>0.004</max_step_size>
+      <real_time_factor>1</real_time_factor>
+      <real_time_update_rate>250</real_time_update_rate>
+      <magnetic_field>6.0e-6 2.3e-5 -4.2e-5</magnetic_field>
+    </physics>
+  </world>
+</sdf>


### PR DESCRIPTION
Previously, wind was a gazebo model plugin since wind was simulated by applying "force" on a link.  Since wind was a element inside the model, models could have different wind simulated even if they are in the same world. 

However, this has changed since #462. Therefore, we can make the wind a property of the "world" and make different vehicles be affected to this no matter which vehicle is spawned in the world.

This PR enables the following
- Define wind as a property of the world
- Enable SITL simulation to switch wind situations without editing the model.sdf. Simply run:
```
make px4_sitl gazebo_plane__windy
```