### PR TITLE
Fix gimbal jitters

### DIFF
--- a/models/typhoon_h480/typhoon_h480.sdf
+++ b/models/typhoon_h480/typhoon_h480.sdf
@@ -1578,7 +1578,7 @@
       <control_gimbal_channels>
         <channel>
           <joint_control_pid>
-            <p>0.8</p>
+            <p>0.6</p>
             <i>0.1</i>
             <d>0.02</d>
             <iMax>0</iMax>

--- a/src/gazebo_geotagged_images_plugin.cpp
+++ b/src/gazebo_geotagged_images_plugin.cpp
@@ -51,7 +51,7 @@ GeotaggedImagesPlugin::GeotaggedImagesPlugin()
     , _fd(-1)
     , _mode(CAMERA_MODE_VIDEO)
     , _captureMode(CAPTURE_DISABLED)
-    , _hfov(0.3)
+    , _hfov(1.57)
     , _zoom(1.0)
     , _maxZoom(8.0)
 {

--- a/src/gazebo_gimbal_controller_plugin.cpp
+++ b/src/gazebo_gimbal_controller_plugin.cpp
@@ -483,7 +483,7 @@ void GimbalControllerPlugin::OnUpdate()
     double dt = (time - this->lastUpdateTime).Double();
 
     // We want yaw to control in body frame, not in global.
-    this->yawCommand += this->lastImuYaw;
+    double yaw_command = this->yawCommand + this->lastImuYaw;
 
     // truncate command inside joint angle limits
 #if GAZEBO_MAJOR_VERSION >= 9
@@ -493,7 +493,7 @@ void GimbalControllerPlugin::OnUpdate()
     double pitchLimited = ignition::math::clamp(this->pitchCommand,
       pDir*this->pitchJoint->UpperLimit(0),
       pDir*this->pitchJoint->LowerLimit(0));
-    double yawLimited = ignition::math::clamp(this->yawCommand,
+    double yawLimited = ignition::math::clamp(yaw_command,
       yDir*this->yawJoint->LowerLimit(0),
 	  yDir*this->yawJoint->UpperLimit(0));
 #else
@@ -503,7 +503,7 @@ void GimbalControllerPlugin::OnUpdate()
     double pitchLimited = ignition::math::clamp(this->pitchCommand,
       pDir*this->pitchJoint->GetUpperLimit(0).Radian(),
       pDir*this->pitchJoint->GetLowerLimit(0).Radian());
-    double yawLimited = ignition::math::clamp(this->yawCommand,
+    double yawLimited = ignition::math::clamp(yaw_command,
       yDir*this->yawJoint->GetLowerLimit(0).Radian(),
 	  yDir*this->yawJoint->GetUpperLimit(0).Radian());
 #endif


### PR DESCRIPTION
The gimbal was oscillating even though the command input was not changed.

After looking into the issue, this was because arbitrarily large control inputs were being injected since the imu yaw message was being added twice, when there was additional update of the timestep with no yaw command update.

This PR fixes this issue by not saving the transformation in the member variable.

To improve video aesthetics, the default horizontal fov was also adjusted to something more reasonable (17deg to 90 deg)

**Before PR**
![ezgif com-video-to-gif(9)](https://user-images.githubusercontent.com/5248102/80271876-f62bd080-86c4-11ea-842e-144cfac961ee.gif)

**After PR**
![ezgif com-video-to-gif(8)](https://user-images.githubusercontent.com/5248102/80271880-f9bf5780-86c4-11ea-8d8d-0225e426416b.gif)

This is a follow up fix for https://github.com/PX4/sitl_gazebo/issues/422