### PR TITLE
Fix tiltrotor motor tilt oscillations

### DIFF
--- a/include/gazebo_mavlink_interface.h
+++ b/include/gazebo_mavlink_interface.h
@@ -273,6 +273,7 @@ private:
 
   std::vector<physics::JointPtr> joints_;
   std::vector<common::PID> pids_;
+  std::vector<double> joint_max_errors_;
 
   /// \brief Pointer to the update event connection.
   event::ConnectionPtr updateConnection_;

--- a/models/tiltrotor/tiltrotor.sdf
+++ b/models/tiltrotor/tiltrotor.sdf
@@ -1083,6 +1083,7 @@
             <iMin>0.0</iMin>
             <cmdMax>2</cmdMax>
             <cmdMin>-2</cmdMin>
+            <errMax>0.2</errMax>
           </joint_control_pid>
         </channel>
         <channel name="motor1_tilt">
@@ -1101,6 +1102,7 @@
             <iMin>0.0</iMin>
             <cmdMax>2</cmdMax>
             <cmdMin>-2</cmdMin>
+            <errMax>0.2</errMax>
           </joint_control_pid>
         </channel>
         <channel name="motor2_tilt">
@@ -1119,6 +1121,7 @@
             <iMin>0.0</iMin>
             <cmdMax>2</cmdMax>
             <cmdMin>-2</cmdMin>
+            <errMax>0.2</errMax>
           </joint_control_pid>
         </channel>
         <channel name="motor3_tilt">
@@ -1137,6 +1140,7 @@
             <iMin>0.0</iMin>
             <cmdMax>2</cmdMax>
             <cmdMin>-2</cmdMin>
+            <errMax>0.2</errMax>
           </joint_control_pid>
         </channel>
         <channel name="left_elevon">

--- a/models/tiltrotor/tiltrotor.sdf
+++ b/models/tiltrotor/tiltrotor.sdf
@@ -120,14 +120,14 @@
       <pose>0.35 -0.35 0.02 0 0 0</pose>
       <inertial>
         <pose>0 0 0 0 0 0</pose>
-        <mass>0.005</mass>
+        <mass>0.05</mass>
         <inertia>
-          <ixx>0.000166704</ixx>
+          <ixx>0.0166704</ixx>
           <ixy>0</ixy>
           <ixz>0</ixz>
-          <iyy>0.000166704</iyy>
+          <iyy>0.0166704</iyy>
           <iyz>0</iyz>
-          <izz>0.000167604</izz>
+          <izz>0.0167604</izz>
         </inertia>
       </inertial>
       <collision name='motor_0_collision'>
@@ -173,10 +173,11 @@
       <axis>
         <xyz>0 1 0</xyz>
         <limit>
-          <lower>-0.1</lower>
+          <lower>-1.5</lower>
           <upper>1.5</upper>
         </limit>
         <dynamics>
+          <friction>1.0</friction>
           <spring_reference>0</spring_reference>
           <spring_stiffness>0</spring_stiffness>
         </dynamics>
@@ -257,14 +258,14 @@
       <pose>-0.35 0.35 0.02 0 0 0</pose>
       <inertial>
         <pose>0 0 0 0 0 0</pose>
-        <mass>0.005</mass>
+        <mass>0.05</mass>
         <inertia>
-          <ixx>0.000166704</ixx>
+          <ixx>0.0166704</ixx>
           <ixy>0</ixy>
           <ixz>0</ixz>
-          <iyy>0.000166704</iyy>
+          <iyy>0.0166704</iyy>
           <iyz>0</iyz>
-          <izz>0.000167604</izz>
+          <izz>0.0167604</izz>
         </inertia>
       </inertial>
       <collision name='motor_1_collision'>
@@ -310,10 +311,11 @@
       <axis>
         <xyz>0 1 0</xyz>
         <limit>
-          <lower>-0.1</lower>
+          <lower>-1.5</lower>
           <upper>1.5</upper>
         </limit>
         <dynamics>
+          <friction>1.0</friction>
           <spring_reference>0</spring_reference>
           <spring_stiffness>0</spring_stiffness>
         </dynamics>
@@ -394,14 +396,14 @@
       <pose>0.35 0.35 0.02 0 0 0</pose>
       <inertial>
         <pose>0 0 0 0 0 0</pose>
-        <mass>0.005</mass>
+        <mass>0.05</mass>
         <inertia>
-          <ixx>0.000166704</ixx>
+          <ixx>0.0166704</ixx>
           <ixy>0</ixy>
           <ixz>0</ixz>
-          <iyy>0.000166704</iyy>
+          <iyy>0.0166704</iyy>
           <iyz>0</iyz>
-          <izz>0.000167604</izz>
+          <izz>0.0167604</izz>
         </inertia>
       </inertial>
       <collision name='motor_2_collision'>
@@ -447,10 +449,11 @@
       <axis>
         <xyz>0 1 0</xyz>
         <limit>
-          <lower>-0.1</lower>
+          <lower>-1.5</lower>
           <upper>1.5</upper>
         </limit>
         <dynamics>
+          <friction>1.0</friction>
           <spring_reference>0</spring_reference>
           <spring_stiffness>0</spring_stiffness>
         </dynamics>
@@ -530,14 +533,14 @@
        <pose>-0.35 -0.35 0.02 0 0 0</pose>
       <inertial>
         <pose>0 0 0 0 0 0</pose>
-        <mass>0.005</mass>
+        <mass>0.05</mass>
         <inertia>
-          <ixx>0.000166704</ixx>
+          <ixx>0.0166704</ixx>
           <ixy>0</ixy>
           <ixz>0</ixz>
-          <iyy>0.000166704</iyy>
+          <iyy>0.0166704</iyy>
           <iyz>0</iyz>
-          <izz>0.000167604</izz>
+          <izz>0.0167604</izz>
         </inertia>
       </inertial>
       <collision name='motor_3_collision'>
@@ -583,10 +586,11 @@
       <axis>
         <xyz>0 1 0</xyz>
         <limit>
-          <lower>-0.1</lower>
+          <lower>-1.5</lower>
           <upper>1.5</upper>
         </limit>
         <dynamics>
+          <friction>1.0</friction>
           <spring_reference>0</spring_reference>
           <spring_stiffness>0</spring_stiffness>
         </dynamics>
@@ -1065,14 +1069,14 @@
         </channel>
         <channel name="motor0_tilt">
           <input_index>4</input_index>
-          <input_offset>0</input_offset>
-          <input_scaling>3.141592</input_scaling>
+          <input_offset>0.785398</input_offset>
+          <input_scaling>0.785398</input_scaling>
           <zero_position_disarmed>0</zero_position_disarmed>
           <zero_position_armed>0</zero_position_armed>
           <joint_control_type>position</joint_control_type>
           <joint_name>motor_0_joint</joint_name>
            <joint_control_pid>
-            <p>80</p>
+            <p>10</p>
             <i>0</i>
             <d>0</d>
             <iMax>0.0</iMax>
@@ -1083,14 +1087,14 @@
         </channel>
         <channel name="motor1_tilt">
           <input_index>5</input_index>
-          <input_offset>0</input_offset>
-          <input_scaling>3.141592</input_scaling>
+          <input_offset>0.785398</input_offset>
+          <input_scaling>0.785398</input_scaling>
           <zero_position_disarmed>0</zero_position_disarmed>
           <zero_position_armed>0</zero_position_armed>
           <joint_control_type>position</joint_control_type>
           <joint_name>motor_1_joint</joint_name>
            <joint_control_pid>
-            <p>80</p>
+            <p>10</p>
             <i>0</i>
             <d>0</d>
             <iMax>0.0</iMax>
@@ -1101,14 +1105,14 @@
         </channel>
         <channel name="motor2_tilt">
           <input_index>6</input_index>
-          <input_offset>0</input_offset>
-          <input_scaling>3.141592</input_scaling>
+          <input_offset>0.785398</input_offset>
+          <input_scaling>0.785398</input_scaling>
           <zero_position_disarmed>0</zero_position_disarmed>
           <zero_position_armed>0</zero_position_armed>
           <joint_control_type>position</joint_control_type>
           <joint_name>motor_2_joint</joint_name>
            <joint_control_pid>
-            <p>80</p>
+            <p>10</p>
             <i>0</i>
             <d>0</d>
             <iMax>0.0</iMax>
@@ -1119,14 +1123,14 @@
         </channel>
         <channel name="motor3_tilt">
           <input_index>7</input_index>
-          <input_offset>0</input_offset>
-          <input_scaling>3.141592</input_scaling>
+          <input_offset>0.785398</input_offset>
+          <input_scaling>0.785398</input_scaling>
           <zero_position_disarmed>0</zero_position_disarmed>
           <zero_position_armed>0</zero_position_armed>
           <joint_control_type>position</joint_control_type>
           <joint_name>motor_3_joint</joint_name>
            <joint_control_pid>
-            <p>80</p>
+            <p>10</p>
             <i>0</i>
             <d>0</d>
             <iMax>0.0</iMax>

--- a/src/gazebo_mavlink_interface.cpp
+++ b/src/gazebo_mavlink_interface.cpp
@@ -156,6 +156,7 @@ void GazeboMavlinkInterface::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf
   input_reference_.resize(n_out_max);
   joints_.resize(n_out_max);
   pids_.resize(n_out_max);
+  joint_max_errors_.resize(n_out_max);
   for (int i = 0; i < n_out_max; ++i)
   {
     pids_[i].Init(0, 0, 0, 0, 0, 0, 0);
@@ -235,6 +236,9 @@ void GazeboMavlinkInterface::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf
             double cmdMin = 0;
             if (pid->HasElement("cmdMin"))
               cmdMin = pid->Get<double>("cmdMin");
+            if (pid->HasElement("errMax")) {
+              joint_max_errors_[index] = pid->Get<double>("errMax");
+            }
             pids_[index].Init(p, i, d, iMax, iMin, cmdMax, cmdMin);
           }
         }
@@ -1531,7 +1535,9 @@ void GazeboMavlinkInterface::handle_control(double _dt)
 #endif
 
         double err = current - target;
-        err = std::max(std::min(err, 0.2), -0.2);
+        if(joint_max_errors_[i]!=0.) {
+          err = std::max(std::min(err, joint_max_errors_[i]), -joint_max_errors_[i]);
+        }
         double force = pids_[i].Update(err, _dt);
         joints_[i]->SetForce(0, force);
       }

--- a/src/gazebo_mavlink_interface.cpp
+++ b/src/gazebo_mavlink_interface.cpp
@@ -1531,6 +1531,7 @@ void GazeboMavlinkInterface::handle_control(double _dt)
 #endif
 
         double err = current - target;
+        err = std::max(std::min(err, 0.2), -0.2);
         double force = pids_[i].Update(err, _dt);
         joints_[i]->SetForce(0, force);
       }


### PR DESCRIPTION
This PR fixes the tilt rotor motor tilts oscillating during flight and even during the vehicle is stationary. This was causing the joint position to be more or less random and was blocking a lot of functionalities to work that require joint position to be precise (e.g. controlling yaw based on tiltrotor tilt). Also, the flight shows instabilities due to the motors pointing in arbitrary directions during flight.

The oscillations were caused by the following reasons.

- Joint controllers becoming unstable very quickly due to large control errors with large gains.
- Inertia of the joints were too small
- Poor handling of joint limits in combination of actuator input scaling

To solve the problem the following is proposed
- Increase of motor inertia 
- Added friction to the tilt joints
- Clamp error of the joint controller to prevent pid controller becoming unstable with large errors

**Before PR**
![ezgif com-optimize(1)](https://user-images.githubusercontent.com/5248102/80366686-f628fd80-8889-11ea-86bc-a57029d71069.gif)


**After PR**
![ezgif com-optimize](https://user-images.githubusercontent.com/5248102/80366697-f923ee00-8889-11ea-9a11-a980158e3412.gif)
