### PR TITLE
Fix vision variance copying in mavlink message

### DIFF
--- a/src/gazebo_mavlink_interface.cpp
+++ b/src/gazebo_mavlink_interface.cpp
@@ -1258,8 +1258,9 @@ void GazeboMavlinkInterface::VisionCallback(OdomPtr& odom_message) {
       for (size_t y = x; y < 6; y++) {
         size_t index = 6 * x + y;
 
-        odom.pose_covariance[count++] = odom_message->pose_covariance().data()[index];
-        odom.velocity_covariance[count++] = odom_message->velocity_covariance().data()[index];
+        odom.pose_covariance[count] = odom_message->pose_covariance().data()[index];
+        odom.velocity_covariance[count] = odom_message->velocity_covariance().data()[index];
+        count++;
       }
     }
 


### PR DESCRIPTION
The copying of the vision covariances into the mavlink message was not done properly. The index variable `count` was incremented twice.  