### PR TITLE
Fix CI breaking on macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -93,6 +93,11 @@ matrix:
           cache:
             ccache: true
 
+before_cache:
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+      brew cleanup
+    fi
+
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       brew update;


### PR DESCRIPTION
Currently macOS fails to build with the following error:
```
dyld: Library not loaded: /usr/local/opt/bullet/lib/libBulletSoftBody.2.88.dylib
  Referenced from: /usr/local/bin/gz
  Reason: image not found
/bin/sh: line 1: 37521 Abort trap: 6           gz sdf -p /Users/travis/build/PX4/sitl_gazebo/models/rotors_description/urdf/iris_base.urdf >> /Users/travis/build/PX4/sitl_gazebo/models/iris/iris.sdf
make[2]: *** [../models/iris/iris.sdf] Error 134
```