### PR TITLE
Add iris_vision_velocity model

### DIFF
--- a/models/iris_vision_velocity/iris_vision_velocity.sdf
+++ b/models/iris_vision_velocity/iris_vision_velocity.sdf
@@ -1,0 +1,18 @@
+<sdf version='1.5'>
+  <model name='iris_vision_velocity'>
+    <plugin name="vision_plugin" filename="libgazebo_vision_plugin.so">
+        <robotNamespace></robotNamespace>
+        <pubRate>30</pubRate>
+        <randomWalk>0.1</randomWalk>
+        <noiseDensity>5e-04</noiseDensity>
+        <corellationTime>60.0</corellationTime>
+    </plugin>
+
+    <include>
+      <uri>model://iris</uri>
+    </include>
+
+  </model>
+</sdf>
+
+<!-- vim: set et ft=xml fenc=utf-8 ff=unix sts=0 sw=2 ts=2 : -->

--- a/models/iris_vision_velocity/model.config
+++ b/models/iris_vision_velocity/model.config
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<model>
+  <name>3DR Iris with external vision velocity estimation</name>
+  <version>1.0</version>
+  <sdf version='1.4'>iris_vision_velocity.sdf</sdf>
+
+  <author>
+   <name>Kamil Ritz</name>
+   <email>ka.ritz@hotmail.com</email>
+  </author>
+
+  <description>
+    This is a model of the 3DR Iris Quadrotor with external vision velocity estimation. The original model has been created by
+    Thomas Gubler and is maintained by Lorenz Meier. The external vision estimation has been created by Christoph Tobler
+  </description>
+</model>


### PR DESCRIPTION
I'd like to run some CI tests based on the iris_vision model. But for some of them I need different parameter configurations. For example I want to fuse vision velocity instead of position. 

The only way I know how to do this, is by adding also a new sdf model as suggested in this PR. But this is not that nice, since the added `iris_vision_velocity.sdf` does not differ from the `iris_vision.sdf`. Is there any other solution?