### PR TITLE
Rename rotation for ENU-NED & FLU-FRD

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -221,16 +221,18 @@ inline ignition::math::Pose3d ignitionFromGazeboMath(const gazebo::math::Pose &p
  *
  * NED to ENU: +PI/2 rotation about Z (Down) followed by a +PI rotation around X (old North/new East)
  * ENU to NED: +PI/2 rotation about Z (Up) followed by a +PI rotation about X (old East/new North)
+ * This rotation is symmetric, so q_ENU_to_NED == q_NED_to_ENU.
  */
-static const auto q_ng = ignition::math::Quaterniond(0, 0.70711, 0.70711, 0);
+static const auto q_ENU_to_NED = ignition::math::Quaterniond(0, 0.70711, 0.70711, 0);
 
 /**
  * @brief Quaternion for rotation between body FLU and body FRD frames
  *
  * +PI rotation around X (Forward) axis rotates from Forward, Right, Down (aircraft)
  * to Forward, Left, Up (base_link) frames and vice-versa.
+ * This rotation is symmetric, so q_FLU_to_FRD == q_FRD_to_FLU.
  */
-static const auto q_br = ignition::math::Quaterniond(0, 1, 0, 0);
+static const auto q_FLU_to_FRD = ignition::math::Quaterniond(0, 1, 0, 0);
 
 // sensor X-axis unit vector in `base_link` frame
 static const ignition::math::Vector3d kDownwardRotation = ignition::math::Vector3d(0, 0, -1);

--- a/src/gazebo_opticalflow_mockup_plugin.cpp
+++ b/src/gazebo_opticalflow_mockup_plugin.cpp
@@ -100,8 +100,8 @@ void OpticalFlowMockupPlugin::OnUpdate(const common::UpdateInfo&)
     ignition::math::Vector3d angular_velocity_model = ignitionFromGazeboMath(model_->GetRelativeAngularVel());
 #endif
     // Compute velocities in body FRD frame
-    ignition::math::Vector3d angular_velocity = q_br.Inverse().RotateVector(angular_velocity_model);
-    ignition::math::Vector3d linear_velocity = q_br.Inverse().RotateVector(
+    ignition::math::Vector3d angular_velocity = q_FLU_to_FRD.RotateVector(angular_velocity_model);
+    ignition::math::Vector3d linear_velocity = q_FLU_to_FRD.RotateVector(
                                          pose_model_world.Rot().Inverse().RotateVector(velocity_model_world));
 
   // Compute flow


### PR DESCRIPTION
The previous naming with q_ng and q_br is not very comprehensible. Therefore in some places, there was a not needed inverse call. Actually since both rotations are symmetric, this does not matter.
But it helps to make the code much more readable.