### PR TITLE
Increase vision noise

### DIFF
--- a/models/iris_vision/iris_vision.sdf
+++ b/models/iris_vision/iris_vision.sdf
@@ -4,7 +4,7 @@
         <robotNamespace></robotNamespace>
         <pubRate>30</pubRate>
         <randomWalk>0.1</randomWalk>
-        <noiseDensity>5e-04</noiseDensity>
+        <noiseDensity>0.01</noiseDensity>
         <corellationTime>60.0</corellationTime>
     </plugin>
 


### PR DESCRIPTION
In order for the mavlink_interface to send vision velocity as well we need to set the `send_odometry` option to true.
Additionally the previous vision noise was really small. I suggest to increase it to 1cm. This seems more realistic. With the previous choice of 5e-4 the variance was 2.5e-7, which could cause numerical issues in the ekf.