### PR TITLE
Fix gazebo motor model plugin calculations

### DIFF
--- a/src/gazebo_motor_model.cpp
+++ b/src/gazebo_motor_model.cpp
@@ -200,9 +200,9 @@ void GazeboMotorModel::UpdateForcesAndMoments() {
   // XXX this has to be modelled better
   //
 #if GAZEBO_MAJOR_VERSION >= 9
-  ignition::math::Vector3d body_velocity = link_->WorldLinearVel() - wind_vel_;
+  ignition::math::Vector3d body_velocity = link_->WorldLinearVel();
 #else
-  ignition::math::Vector3d body_velocity = ignitionFromGazeboMath(link_->GetWorldLinearVel())  - wind_vel_;
+  ignition::math::Vector3d body_velocity = ignitionFromGazeboMath(link_->GetWorldLinearVel());
 #endif
   double vel = body_velocity.Length();
   double scalar = 1 - vel / 25.0; // at 50 m/s the rotor will not produce any force anymore
@@ -220,7 +220,8 @@ void GazeboMotorModel::UpdateForcesAndMoments() {
   ignition::math::Vector3d joint_axis = ignitionFromGazeboMath(joint_->GetGlobalAxis(0));
 #endif
   //ignition::math::Vector3d body_velocity = link_->WorldLinearVel();
-  ignition::math::Vector3d body_velocity_perpendicular = body_velocity - (body_velocity * joint_axis) * joint_axis;
+  ignition::math::Vector3d relative_wind_velocity = body_velocity - wind_vel_;
+  ignition::math::Vector3d body_velocity_perpendicular = relative_wind_velocity - (relative_wind_velocity.Dot(joint_axis)) * joint_axis;
   ignition::math::Vector3d air_drag = -std::abs(real_motor_velocity) * rotor_drag_coefficient_ * body_velocity_perpendicular;
   // Apply air_drag to link.
   link_->AddForce(air_drag);

--- a/src/gazebo_motor_model.cpp
+++ b/src/gazebo_motor_model.cpp
@@ -219,7 +219,6 @@ void GazeboMotorModel::UpdateForcesAndMoments() {
 #else
   ignition::math::Vector3d joint_axis = ignitionFromGazeboMath(joint_->GetGlobalAxis(0));
 #endif
-  //ignition::math::Vector3d body_velocity = link_->WorldLinearVel();
   ignition::math::Vector3d relative_wind_velocity = body_velocity - wind_vel_;
   ignition::math::Vector3d body_velocity_perpendicular = relative_wind_velocity - (relative_wind_velocity.Dot(joint_axis)) * joint_axis;
   ignition::math::Vector3d air_drag = -std::abs(real_motor_velocity) * rotor_drag_coefficient_ * body_velocity_perpendicular;


### PR DESCRIPTION
This PR fixes the motor model calculation error reported by https://github.com/PX4/sitl_gazebo/issues/312, where the body velocity was calculated with a product multiplied element wise while it should have been a dot product. 

This is also more consistent with rotors_simulator https://github.com/ethz-asl/rotors_simulator/blob/master/rotors_gazebo_plugins/src/gazebo_motor_model.cpp#L445

**Test / Validation**
Testing was done with wind blowing at 4m/s at a single direction
Log: https://review.px4.io/plot_app?log=3347a6b3-f280-4cb6-84a5-ae183e3e1d64