### PR TITLE
Handle continuous zoom

### DIFF
--- a/include/gazebo_geotagged_images_plugin.h
+++ b/include/gazebo_geotagged_images_plugin.h
@@ -85,6 +85,7 @@ private:
     int         _captureCount;
     double      _captureInterval;
     int         _fd;
+    int         _zoom_cmd;
 
     enum {
         CAPTURE_DISABLED,


### PR DESCRIPTION
This commits adds a iterator for zoom so that it can handle continuous zoom controls for MAV_CMD_SET_CAMERA_ZOOM message

This is useful for testing groundstation software implementations that use continuous zoom messages. 