### PR TITLE
magnetometer_plugin: fix slowdown over time

### DIFF
--- a/src/gazebo_magnetometer_plugin.cpp
+++ b/src/gazebo_magnetometer_plugin.cpp
@@ -195,6 +195,7 @@ void MagnetometerPlugin::OnUpdate(const common::UpdateInfo&)
     magnetic_field->set_z(magnetic_field_I[2]);
     mag_message_.set_allocated_magnetic_field(magnetic_field);
 
+    mag_message_.clear_magnetic_field_covariance();
     for (auto i = 0; i < 9; ++i) {
       switch (i){
         // principal diagonal = the variance of the random variables


### PR DESCRIPTION
We need to clear the covariance before filling it again, otherwise it grows forever and slows the simulation down.

Alternative to https://github.com/PX4/sitl_gazebo/pull/465.
Fixes https://github.com/PX4/Firmware/issues/14189, fixes: https://github.com/PX4/Firmware/issues/12975

Found by @tnkkk.