### PR TITLE
Fix gimbal pointing backwards

### DIFF
--- a/include/gazebo_gimbal_controller_plugin.hh
+++ b/include/gazebo_gimbal_controller_plugin.hh
@@ -34,6 +34,7 @@
 #include <ignition/math.hh>
 
 #include "Imu.pb.h"
+#include "Groundtruth.pb.h"
 
 namespace gazebo
 {
@@ -68,6 +69,7 @@ namespace gazebo
   static double kYawDir = 1.0;
 
   typedef const boost::shared_ptr<const sensor_msgs::msgs::Imu> ImuPtr;
+  typedef const boost::shared_ptr<const sensor_msgs::msgs::Groundtruth> GtPtr;
 
   class GAZEBO_VISIBLE GimbalControllerPlugin : public ModelPlugin
   {
@@ -80,7 +82,7 @@ namespace gazebo
 
     private: void OnUpdate();
 
-    private: void ImuCallback(ImuPtr& imu_message);
+    private: void GroundTruthCallback(GtPtr& imu_message);
 
 #if GAZEBO_MAJOR_VERSION > 7 || (GAZEBO_MAJOR_VERSION == 7 && GAZEBO_MINOR_VERSION >= 4)
     /// only gazebo 7.4 and above support Any
@@ -119,7 +121,7 @@ namespace gazebo
     private: physics::JointPtr pitchJoint;
 
     private: sensors::ImuSensorPtr cameraImuSensor;
-    private: double lastImuYaw;
+    private: double vehicleYaw;
 
     private: std::string status;
 

--- a/include/gazebo_gimbal_controller_plugin.hh
+++ b/include/gazebo_gimbal_controller_plugin.hh
@@ -33,7 +33,6 @@
 #include <gazebo/sensors/sensors.hh>
 #include <ignition/math.hh>
 
-#include "Imu.pb.h"
 #include "Groundtruth.pb.h"
 
 namespace gazebo
@@ -68,7 +67,6 @@ namespace gazebo
   static double kPitchDir = -1.0;
   static double kYawDir = 1.0;
 
-  typedef const boost::shared_ptr<const sensor_msgs::msgs::Imu> ImuPtr;
   typedef const boost::shared_ptr<const sensor_msgs::msgs::Groundtruth> GtPtr;
 
   class GAZEBO_VISIBLE GimbalControllerPlugin : public ModelPlugin

--- a/src/gazebo_gps_plugin.cpp
+++ b/src/gazebo_gps_plugin.cpp
@@ -152,7 +152,7 @@ void GpsPlugin::OnUpdate(const common::UpdateInfo&){
   ignition::math::Pose3d T_W_I = ignitionFromGazeboMath(model_->GetWorldPose());    // TODO(burrimi): Check tf
 #endif
   ignition::math::Vector3d& pos_W_I = T_W_I.Pos();           // Use the models' world position for GPS and groundtruth
-
+  ignition::math::Quaterniond& att_W_I = T_W_I.Rot();
   // reproject position without noise into geographic coordinates
   auto latlon_gt = reproject(pos_W_I);
 
@@ -252,6 +252,10 @@ void GpsPlugin::OnUpdate(const common::UpdateInfo&){
   groundtruth_msg.set_velocity_east(velocity_current_W.X());
   groundtruth_msg.set_velocity_north(velocity_current_W.Y());
   groundtruth_msg.set_velocity_up(velocity_current_W.Z());
+  groundtruth_msg.set_attitude_q_w(att_W_I.W());
+  groundtruth_msg.set_attitude_q_x(att_W_I.X());
+  groundtruth_msg.set_attitude_q_y(att_W_I.Y());
+  groundtruth_msg.set_attitude_q_z(att_W_I.Z());
 
   // publish Groundtruth msg at full rate
   gt_pub_->Publish(groundtruth_msg);


### PR DESCRIPTION
This PR fixes https://github.com/PX4/Firmware/issues/14902, where the gimbal was pointing backwards. 

@julianoes @TSC21 It seems like the problem is that we transform the yaw command, and not the actual gimbal orientation to the correct frame. While this is not a "fix", nevertheless I would like to have this fix in so that the end user does not suffer from the issue.

I will try to fix it properly in the meantime