### PR TITLE
Travis CI: add pipelines to build and test with Gazebo 11 over Ubuntu 20.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
           cache:
             ccache: true
           env:
-            - PX4_DOCKER_REPO=px4io/px4-dev-simulation-xenial:2020-03-29
+            - PX4_DOCKER_REPO=px4io/px4-dev-simulation-xenial:2020-05-25
             - BUILD=${CMAKE_BUILD}
         - name: CMake unit tests build and run (Gazebo 7)
           os: linux
@@ -34,7 +34,7 @@ matrix:
           cache:
             ccache: true
           env:
-            - PX4_DOCKER_REPO=px4io/px4-dev-simulation-xenial:2020-03-29
+            - PX4_DOCKER_REPO=px4io/px4-dev-simulation-xenial:2020-05-25
             - BUILD=${CMAKE_UNIT_TEST_BUILD}
         - name: CMake build (Gazebo 9)
           os: linux
@@ -44,7 +44,7 @@ matrix:
           cache:
             ccache: true
           env:
-            - PX4_DOCKER_REPO=px4io/px4-dev-simulation-bionic:2020-03-29
+            - PX4_DOCKER_REPO=px4io/px4-dev-simulation-bionic:2020-05-25
             - BUILD=${CMAKE_BUILD}
         - name: CMake unit tests build and run (Gazebo 9)
           os: linux
@@ -54,7 +54,27 @@ matrix:
           cache:
             ccache: true
           env:
-            - PX4_DOCKER_REPO=px4io/px4-dev-simulation-bionic:2020-03-29
+            - PX4_DOCKER_REPO=px4io/px4-dev-simulation-bionic:2020-05-25
+            - BUILD=${CMAKE_UNIT_TEST_BUILD}
+        - name: CMake build (Gazebo 11)
+          os: linux
+          language: cpp
+          services:
+            - docker
+          cache:
+            ccache: true
+          env:
+            - PX4_DOCKER_REPO=px4io/px4-dev-simulation-focal:2020-05-25
+            - BUILD=${CMAKE_BUILD}
+        - name: CMake unit tests build and run (Gazebo 11)
+          os: linux
+          language: cpp
+          services:
+            - docker
+          cache:
+            ccache: true
+          env:
+            - PX4_DOCKER_REPO=px4io/px4-dev-simulation-focal:2020-05-25
             - BUILD=${CMAKE_UNIT_TEST_BUILD}
         - name: Catkin build on Ubuntu 16.04 with ROS Kinetic (Gazebo 7)
           os: linux
@@ -74,7 +94,7 @@ matrix:
           cache:
             ccache: true
           env:
-            - PX4_DOCKER_REPO=px4io/px4-dev-ros-melodic:2020-03-29
+            - PX4_DOCKER_REPO=px4io/px4-dev-ros-melodic:2020-05-25
             - BUILD=${MELODIC}
         - name: Validate SDF schemas
           os: linux
@@ -84,7 +104,7 @@ matrix:
           cache:
             ccache: true
           env:
-            - PX4_DOCKER_REPO=px4io/px4-dev-simulation-bionic:2020-03-29
+            - PX4_DOCKER_REPO=px4io/px4-dev-simulation-bionic:2020-05-25
             - BUILD="source ./scripts/validate_sdf.bash"
         - name: macOS Mojave (Xcode 11.3)
           os: osx


### PR DESCRIPTION
This adds Ubuntu 20.04 and Gazebo 11 as supported to `sitl_gazebo`.