### PR TITLE
models: fix iris propellors with Gazebo 11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -228,7 +228,7 @@ add_custom_command(OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/models/iris/iris.sdf
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   COMMAND rm -f ${CMAKE_CURRENT_SOURCE_DIR}/models/iris/iris.sdf
   COMMAND ${PYTHON_EXECUTABLE} ${scripts_dir}/xacro.py -o  ${rotors_description_dir}/urdf/iris_base.urdf  ${rotors_description_dir}/urdf/iris_base.xacro enable_mavlink_interface:=${enable_mavlink_interface} enable_ground_truth:=${enable_ground_truth} enable_wind:=${enable_wind} enable_logging:=${enable_logging} rotors_description_dir:=${rotors_description_dir} send_vision_estimation:=${send_vision_estimation} send_odometry:=${send_odometry}
-  COMMAND gz sdf -p  ${rotors_description_dir}/urdf/iris_base.urdf >> ${CMAKE_CURRENT_SOURCE_DIR}/models/iris/iris.sdf
+  COMMAND gz sdf -v 1.7 -p  ${rotors_description_dir}/urdf/iris_base.urdf >> ${CMAKE_CURRENT_SOURCE_DIR}/models/iris/iris.sdf
   COMMAND rm -f ${rotors_description_dir}/urdf/iris_base.urdf
   DEPENDS ${rotors_description_dir}/urdf/iris.xacro
   DEPENDS ${rotors_description_dir}/urdf/iris_base.xacro

--- a/models/iris/model.config
+++ b/models/iris/model.config
@@ -2,7 +2,7 @@
 <model>
   <name>3DR Iris</name>
   <version>1.0</version>
-  <sdf version='1.4'>iris.sdf</sdf>
+  <sdf version='1.7'>iris.sdf</sdf>
 
   <author>
    <name>Lorenz Meier and Thomas Gubler</name>

--- a/models/iris_opt_flow/iris_opt_flow.sdf
+++ b/models/iris_opt_flow/iris_opt_flow.sdf
@@ -1,4 +1,4 @@
-<sdf version='1.5'>
+<sdf version='1.7'>
   <model name='iris_opt_flow'>
     <include>
       <uri>model://iris</uri>

--- a/models/iris_opt_flow/model.config
+++ b/models/iris_opt_flow/model.config
@@ -2,7 +2,7 @@
 <model>
   <name>3DR Iris with lidar and optical flow</name>
   <version>1.0</version>
-  <sdf version='1.4'>iris_opt_flow.sdf</sdf>
+  <sdf version='1.7'>iris_opt_flow.sdf</sdf>
 
   <author>
    <name>Christoph Tobler</name>

--- a/models/iris_opt_flow_mockup/iris_opt_flow_mockup.sdf
+++ b/models/iris_opt_flow_mockup/iris_opt_flow_mockup.sdf
@@ -1,4 +1,4 @@
-<sdf version='1.5'>
+<sdf version='1.7'>
   <model name='iris_opt_flow_mockup'>
     <include>
       <uri>model://iris</uri>

--- a/models/iris_opt_flow_mockup/model.config
+++ b/models/iris_opt_flow_mockup/model.config
@@ -2,7 +2,7 @@
 <model>
   <name>3DR Iris with lidar and optical flow mockup</name>
   <version>1.0</version>
-  <sdf version='1.4'>iris_opt_flow_mockup.sdf</sdf>
+  <sdf version='1.7'>iris_opt_flow_mockup.sdf</sdf>
 
   <author>
    <name>Kamil Ritz</name>


### PR DESCRIPTION
Without this change the optical flow models have the propellors in a completely wrong location and don't fly.

This fixes the flip seen in https://github.com/PX4/Firmware/issues/14300#issuecomment-633578551.