### PR TITLE
CI: bump container tags to 2020-05-28; temporarly remove Gazebo 11 and Kinetic builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
           cache:
             ccache: true
           env:
-            - PX4_DOCKER_REPO=px4io/px4-dev-simulation-xenial:2020-05-25
+            - PX4_DOCKER_REPO=px4io/px4-dev-simulation-xenial:2020-05-28
             - BUILD=${CMAKE_BUILD}
         - name: CMake unit tests build and run (Gazebo 7)
           os: linux
@@ -34,7 +34,7 @@ matrix:
           cache:
             ccache: true
           env:
-            - PX4_DOCKER_REPO=px4io/px4-dev-simulation-xenial:2020-05-25
+            - PX4_DOCKER_REPO=px4io/px4-dev-simulation-xenial:2020-05-28
             - BUILD=${CMAKE_UNIT_TEST_BUILD}
         - name: CMake build (Gazebo 9)
           os: linux
@@ -44,7 +44,7 @@ matrix:
           cache:
             ccache: true
           env:
-            - PX4_DOCKER_REPO=px4io/px4-dev-simulation-bionic:2020-05-25
+            - PX4_DOCKER_REPO=px4io/px4-dev-simulation-bionic:2020-05-28
             - BUILD=${CMAKE_BUILD}
         - name: CMake unit tests build and run (Gazebo 9)
           os: linux
@@ -54,38 +54,40 @@ matrix:
           cache:
             ccache: true
           env:
-            - PX4_DOCKER_REPO=px4io/px4-dev-simulation-bionic:2020-05-25
+            - PX4_DOCKER_REPO=px4io/px4-dev-simulation-bionic:2020-05-28
             - BUILD=${CMAKE_UNIT_TEST_BUILD}
-        - name: CMake build (Gazebo 11)
-          os: linux
-          language: cpp
-          services:
-            - docker
-          cache:
-            ccache: true
-          env:
-            - PX4_DOCKER_REPO=px4io/px4-dev-simulation-focal:2020-05-25
-            - BUILD=${CMAKE_BUILD}
-        - name: CMake unit tests build and run (Gazebo 11)
-          os: linux
-          language: cpp
-          services:
-            - docker
-          cache:
-            ccache: true
-          env:
-            - PX4_DOCKER_REPO=px4io/px4-dev-simulation-focal:2020-05-25
-            - BUILD=${CMAKE_UNIT_TEST_BUILD}
-        - name: Catkin build on Ubuntu 16.04 with ROS Kinetic (Gazebo 7)
-          os: linux
-          language: cpp
-          services:
-            - docker
-          cache:
-            ccache: true
-          env:
-            - PX4_DOCKER_REPO=px4io/px4-dev-ros-kinetic:2020-03-29
-            - BUILD=${KINETIC}
+        # FIXME: Currently failing when creating QT moc files
+        # - name: CMake build (Gazebo 11)
+        #   os: linux
+        #   language: cpp
+        #   services:
+        #     - docker
+        #   cache:
+        #     ccache: true
+        #   env:
+        #     - PX4_DOCKER_REPO=px4io/px4-dev-simulation-focal:2020-05-28
+        #     - BUILD=${CMAKE_BUILD}
+        # - name: CMake unit tests build and run (Gazebo 11)
+        #   os: linux
+        #   language: cpp
+        #   services:
+        #     - docker
+        #   cache:
+        #     ccache: true
+        #   env:
+        #     - PX4_DOCKER_REPO=px4io/px4-dev-simulation-focal:2020-05-28
+        #     - BUILD=${CMAKE_UNIT_TEST_BUILD}
+        # FIXME: px4-dev-ros-kinetic is failing due to some pip install problems
+        # - name: Catkin build on Ubuntu 16.04 with ROS Kinetic (Gazebo 7)
+        #   os: linux
+        #   language: cpp
+        #   services:
+        #     - docker
+        #   cache:
+        #     ccache: true
+        #   env:
+        #     - PX4_DOCKER_REPO=px4io/px4-dev-ros-kinetic:2020-05-28
+        #     - BUILD=${KINETIC}
         - name: Catkin build on Ubuntu 18.04 with ROS Melodic (Gazebo 9)
           os: linux
           language: cpp
@@ -94,7 +96,7 @@ matrix:
           cache:
             ccache: true
           env:
-            - PX4_DOCKER_REPO=px4io/px4-dev-ros-melodic:2020-05-25
+            - PX4_DOCKER_REPO=px4io/px4-dev-ros-melodic:2020-05-28
             - BUILD=${MELODIC}
         - name: Validate SDF schemas
           os: linux
@@ -104,7 +106,7 @@ matrix:
           cache:
             ccache: true
           env:
-            - PX4_DOCKER_REPO=px4io/px4-dev-simulation-bionic:2020-05-25
+            - PX4_DOCKER_REPO=px4io/px4-dev-simulation-bionic:2020-05-28
             - BUILD="source ./scripts/validate_sdf.bash"
         - name: macOS Mojave (Xcode 11.3)
           os: osx


### PR DESCRIPTION
`CAMERA_CAPTURE_STATUS` update required also a MAVlink header update on the containers.

At the same time, this removes temporary the Kinetic and Gazebo 11 stages.