### PR TITLE
Fix function arguments mismatch with its header

### DIFF
--- a/src/gazebo_geotagged_images_plugin.cpp
+++ b/src/gazebo_geotagged_images_plugin.cpp
@@ -735,8 +735,7 @@ void GeotaggedImagesPlugin::_send_capture_status(struct sockaddr* srcaddr)
         0,                                      // video status (Idle)
         interval,                               // image interval
         0,                                      // recording time in ms
-        available_mib,                          // available storage capacity
-        _imageCounter);                         // total number of images
+        available_mib)                          // available storage capacity
     _send_mavlink_message(&msg, srcaddr);
 }
 


### PR DESCRIPTION
the "mavlink_msg_camera_capture_status_pack_chan" function utilized on line 728 has one more arguemnt "_imageCounter" compared with its mavlink2.0 header, located at 
"catkin_ws/devel/include/mavlink/v2.0/common/./mavlink_msg_camera_capture_status.h" line 110
``
static inline uint16_t mavlink_msg_camera_capture_status_pack_chan(uint8_t system_id, uint8_t component_id, uint8_t chan, mavlink_message_t* msg, uint32_t time_boot_ms,uint8_t image_status,uint8_t video_status,float image_interval,uint32_t recording_time_ms,float available_capacity)
``
The error can be replayed under this environment:
Ros melodic
Gazebo 9
Mavlink 2.0
and I build this repository under the master branch.
