### PR TITLE
Fix typhoon h480 internals

### DIFF
--- a/models/typhoon_h480/typhoon_h480.sdf
+++ b/models/typhoon_h480/typhoon_h480.sdf
@@ -1,7 +1,7 @@
 <sdf version='1.5'>
   <model name='typhoon_h480'>
     <!-- Typhoon H body -->
-    <pose>0 0 0.26 0 0 3.1415927</pose>
+    <pose>0 0 0.26 0 0 0.0</pose>
     <link name='base_link'>
       <pose>0 0 0 0 0 0</pose>
       <inertial>
@@ -38,7 +38,7 @@
         </surface>
       </collision>
       <visual name='base_link_visual'>
-        <pose>0 0 0 0 0 0</pose>
+        <pose>0 0 0 0 0 3.141592</pose>
         <geometry>
           <mesh>
             <scale>0.001 0.001 0.001</scale>
@@ -218,7 +218,7 @@
         </inertia>
       </inertial>
       <visual name='cgo3_vertical_arm_visual'>
-        <pose>0 0 0 0 0 0</pose>
+        <pose>-0.051 0 0 0 0 3.141592</pose>
         <geometry>
           <mesh>
             <scale>0.001 0.001 0.001</scale>
@@ -280,7 +280,7 @@
         </inertia>
       </inertial>
       <visual name='cgo3_horizontal_arm_visual'>
-        <pose>0 0 0 0 0 0</pose>
+        <pose>-0.05 0 0 0 0 3.141592</pose>
         <geometry>
           <mesh>
             <scale>0.001 0.001 0.001</scale>
@@ -298,7 +298,7 @@
     <joint name='cgo3_horizontal_arm_joint' type='revolute'>
       <child>cgo3_horizontal_arm_link</child>
       <parent>cgo3_vertical_arm_link</parent>
-      <pose>0.026 0 -0.162 0 0 0</pose>
+      <pose>-0.07 0 -0.162 0 0 0</pose>
       <!--
       <controlIndex>7</controlIndex>
       -->
@@ -366,7 +366,7 @@
         </surface>
       </collision>
       <visual name='cgo3_camera_visual'>
-        <pose>0 0 0 0 0 0</pose>
+        <pose>-0.05 0 0 0 0 3.141592</pose>
         <geometry>
           <mesh>
             <scale>0.001 0.001 0.001</scale>
@@ -384,7 +384,7 @@
         <always_on>1</always_on>
       </sensor>
       <sensor name="camera" type="camera">
-        <pose>-0.051 0 -0.162 0 0 3.14159</pose>
+        <pose>0.0 0 -0.162 0 0 0</pose>
         <camera>
           <horizontal_fov>2.0</horizontal_fov>
           <image>
@@ -400,24 +400,6 @@
         <always_on>1</always_on>
         <update_rate>10</update_rate>
         <visualize>true</visualize>
-        <!-- how to make this work without using urdf?
-        <plugin name="cgo3_camera_controller" filename="libgazebo_ros_camera.so">
-          <alwaysOn>true</alwaysOn>
-          <updateRate>0.0</updateRate>
-          <cameraName>cgo3_camera</cameraName>
-          <imageTopicName>image_raw</imageTopicName>
-          <cameraInfoTopicName>camera_info</cameraInfoTopicName>
-          <frameName>cgo3_camera_optical_frame</frameName>
-          <hackBaseline>0.0</hackBaseline>
-          <distortionK1>0.0</distortionK1>
-          <distortionK2>0.0</distortionK2>
-          <distortionK3>0.0</distortionK3>
-          <distortionT1>0.0</distortionT1>
-          <distortionT2>0.0</distortionT2>
-        </plugin>
-        -->
-        <!-- GStreamer camera plugin (needs a lot of CPU! Consider lowering the
-             camera image size) -->
         <plugin name="GstCameraPlugin" filename="libgazebo_gst_camera_plugin.so">
             <robotNamespace></robotNamespace>
             <udpHost>127.0.0.1</udpHost>
@@ -435,7 +417,7 @@
     <joint name='cgo3_camera_joint' type='revolute'>
       <child>cgo3_camera_link</child>
       <parent>cgo3_horizontal_arm_link</parent>
-      <pose>-0.041 0.03 -0.162 0 0 0</pose>
+      <pose>-0.01 0.03 -0.162 0 0 0</pose>
       <axis>
         <xyz>0 -1 0</xyz>
         <limit>
@@ -675,7 +657,7 @@
     </joint>
 
     <link name='typhoon_h480/imu_link'>
-      <pose>0 0 0 0 0 3.1415927</pose>
+      <pose>0 0 0 0 0 0</pose>
       <inertial>
         <pose>0 0 0 0 0 0</pose>
         <mass>0.015</mass>
@@ -1143,7 +1125,7 @@
 
     <include>
       <uri>model://sonar</uri>
-      <pose>-0.1 0 0 0 0 0</pose>
+      <pose>0.08 0 -0.03 0 0 3.141592</pose>
     </include>
     <joint name="sonar_joint" type="revolute">
       <child>sonar::link</child>
@@ -1167,34 +1149,6 @@
       <robotNamespace></robotNamespace>
       <jointName>rotor_0_joint</jointName>
       <linkName>rotor_0</linkName>
-      <turningDirection>ccw</turningDirection>
-      <timeConstantUp>0.0125</timeConstantUp>
-      <timeConstantDown>0.025</timeConstantDown>
-      <maxRotVelocity>1500</maxRotVelocity>
-      <motorConstant>8.54858e-06</motorConstant>
-      <momentConstant>0.06</momentConstant>
-      <commandSubTopic>/gazebo/command/motor_speed</commandSubTopic>
-      <motorNumber>4</motorNumber>
-      <rotorDragCoefficient>0.000806428</rotorDragCoefficient>
-      <rollingMomentCoefficient>1e-06</rollingMomentCoefficient>
-      <motorSpeedPubTopic>/motor_speed/4</motorSpeedPubTopic>
-      <rotorVelocitySlowdownSim>10</rotorVelocitySlowdownSim>
-      <!--
-      <joint_control_pid>
-        <p>0.1</p>
-        <i>0</i>
-        <d>0</d>
-        <iMax>0</iMax>
-        <iMin>0</iMin>
-        <cmdMax>3</cmdMax>
-        <cmdMin>-3</cmdMin>
-      </joint_control_pid>
-      -->
-    </plugin>
-    <plugin name='back_left_motor_model' filename='libgazebo_motor_model.so'>
-      <robotNamespace></robotNamespace>
-      <jointName>rotor_1_joint</jointName>
-      <linkName>rotor_1</linkName>
       <turningDirection>cw</turningDirection>
       <timeConstantUp>0.0125</timeConstantUp>
       <timeConstantDown>0.025</timeConstantDown>
@@ -1207,50 +1161,28 @@
       <rollingMomentCoefficient>1e-06</rollingMomentCoefficient>
       <motorSpeedPubTopic>/motor_speed/5</motorSpeedPubTopic>
       <rotorVelocitySlowdownSim>10</rotorVelocitySlowdownSim>
-      <!--
-      <joint_control_pid>
-        <p>0.1</p>
-        <i>0</i>
-        <d>0</d>
-        <iMax>0</iMax>
-        <iMin>0</iMin>
-        <cmdMax>3</cmdMax>
-        <cmdMin>-3</cmdMin>
-      </joint_control_pid>
-      -->
     </plugin>
-    <plugin name='front_left_motor_model' filename='libgazebo_motor_model.so'>
+    <plugin name='back_left_motor_model' filename='libgazebo_motor_model.so'>
       <robotNamespace></robotNamespace>
-      <jointName>rotor_2_joint</jointName>
-      <linkName>rotor_2</linkName>
-      <turningDirection>cw</turningDirection>
+      <jointName>rotor_1_joint</jointName>
+      <linkName>rotor_1</linkName>
+      <turningDirection>ccw</turningDirection>
       <timeConstantUp>0.0125</timeConstantUp>
       <timeConstantDown>0.025</timeConstantDown>
       <maxRotVelocity>1500</maxRotVelocity>
       <motorConstant>8.54858e-06</motorConstant>
       <momentConstant>0.06</momentConstant>
       <commandSubTopic>/gazebo/command/motor_speed</commandSubTopic>
-      <motorNumber>2</motorNumber>
+      <motorNumber>4</motorNumber>
       <rotorDragCoefficient>0.000806428</rotorDragCoefficient>
       <rollingMomentCoefficient>1e-06</rollingMomentCoefficient>
-      <motorSpeedPubTopic>/motor_speed/2</motorSpeedPubTopic>
+      <motorSpeedPubTopic>/motor_speed/4</motorSpeedPubTopic>
       <rotorVelocitySlowdownSim>10</rotorVelocitySlowdownSim>
-      <!--
-      <joint_control_pid>
-        <p>0.1</p>
-        <i>0</i>
-        <d>0</d>
-        <iMax>0</iMax>
-        <iMin>0</iMin>
-        <cmdMax>3</cmdMax>
-        <cmdMin>-3</cmdMin>
-      </joint_control_pid>
-      -->
     </plugin>
-    <plugin name='back_right_motor_model' filename='libgazebo_motor_model.so'>
+    <plugin name='front_left_motor_model' filename='libgazebo_motor_model.so'>
       <robotNamespace></robotNamespace>
-      <jointName>rotor_3_joint</jointName>
-      <linkName>rotor_3</linkName>
+      <jointName>rotor_2_joint</jointName>
+      <linkName>rotor_2</linkName>
       <turningDirection>ccw</turningDirection>
       <timeConstantUp>0.0125</timeConstantUp>
       <timeConstantDown>0.025</timeConstantDown>
@@ -1263,22 +1195,11 @@
       <rollingMomentCoefficient>1e-06</rollingMomentCoefficient>
       <motorSpeedPubTopic>/motor_speed/3</motorSpeedPubTopic>
       <rotorVelocitySlowdownSim>10</rotorVelocitySlowdownSim>
-      <!--
-      <joint_control_pid>
-        <p>0.1</p>
-        <i>0</i>
-        <d>0</d>
-        <iMax>0</iMax>
-        <iMin>0</iMin>
-        <cmdMax>3</cmdMax>
-        <cmdMin>-3</cmdMin>
-      </joint_control_pid>
-      -->
     </plugin>
-    <plugin name='back_left_motor_model' filename='libgazebo_motor_model.so'>
+    <plugin name='back_right_motor_model' filename='libgazebo_motor_model.so'>
       <robotNamespace></robotNamespace>
-      <jointName>rotor_4_joint</jointName>
-      <linkName>rotor_4</linkName>
+      <jointName>rotor_3_joint</jointName>
+      <linkName>rotor_3</linkName>
       <turningDirection>cw</turningDirection>
       <timeConstantUp>0.0125</timeConstantUp>
       <timeConstantDown>0.025</timeConstantDown>
@@ -1286,27 +1207,16 @@
       <motorConstant>8.54858e-06</motorConstant>
       <momentConstant>0.06</momentConstant>
       <commandSubTopic>/gazebo/command/motor_speed</commandSubTopic>
-      <motorNumber>0</motorNumber>
+      <motorNumber>2</motorNumber>
       <rotorDragCoefficient>0.000806428</rotorDragCoefficient>
       <rollingMomentCoefficient>1e-06</rollingMomentCoefficient>
-      <motorSpeedPubTopic>/motor_speed/0</motorSpeedPubTopic>
+      <motorSpeedPubTopic>/motor_speed/2</motorSpeedPubTopic>
       <rotorVelocitySlowdownSim>10</rotorVelocitySlowdownSim>
-      <!--
-      <joint_control_pid>
-        <p>0.1</p>
-        <i>0</i>
-        <d>0</d>
-        <iMax>0</iMax>
-        <iMin>0</iMin>
-        <cmdMax>3</cmdMax>
-        <cmdMin>-3</cmdMin>
-      </joint_control_pid>
-      -->
     </plugin>
-    <plugin name='front_left_motor_model' filename='libgazebo_motor_model.so'>
+    <plugin name='back_left_motor_model' filename='libgazebo_motor_model.so'>
       <robotNamespace></robotNamespace>
-      <jointName>rotor_5_joint</jointName>
-      <linkName>rotor_5</linkName>
+      <jointName>rotor_4_joint</jointName>
+      <linkName>rotor_4</linkName>
       <turningDirection>ccw</turningDirection>
       <timeConstantUp>0.0125</timeConstantUp>
       <timeConstantDown>0.025</timeConstantDown>
@@ -1319,17 +1229,23 @@
       <rollingMomentCoefficient>1e-06</rollingMomentCoefficient>
       <motorSpeedPubTopic>/motor_speed/1</motorSpeedPubTopic>
       <rotorVelocitySlowdownSim>10</rotorVelocitySlowdownSim>
-      <!--
-      <joint_control_pid>
-        <p>0.1</p>
-        <i>0</i>
-        <d>0</d>
-        <iMax>0</iMax>
-        <iMin>0</iMin>
-        <cmdMax>3</cmdMax>
-        <cmdMin>-3</cmdMin>
-      </joint_control_pid>
-      -->
+    </plugin>
+    <plugin name='front_left_motor_model' filename='libgazebo_motor_model.so'>
+      <robotNamespace></robotNamespace>
+      <jointName>rotor_5_joint</jointName>
+      <linkName>rotor_5</linkName>
+      <turningDirection>cw</turningDirection>
+      <timeConstantUp>0.0125</timeConstantUp>
+      <timeConstantDown>0.025</timeConstantDown>
+      <maxRotVelocity>1500</maxRotVelocity>
+      <motorConstant>8.54858e-06</motorConstant>
+      <momentConstant>0.06</momentConstant>
+      <commandSubTopic>/gazebo/command/motor_speed</commandSubTopic>
+      <motorNumber>0</motorNumber>
+      <rotorDragCoefficient>0.000806428</rotorDragCoefficient>
+      <rollingMomentCoefficient>1e-06</rollingMomentCoefficient>
+      <motorSpeedPubTopic>/motor_speed/0</motorSpeedPubTopic>
+      <rotorVelocitySlowdownSim>10</rotorVelocitySlowdownSim>
     </plugin>
     <plugin name="gps_plugin" filename="libgazebo_gps_plugin.so">
         <robotNamespace></robotNamespace>
@@ -1376,18 +1292,6 @@
           <zero_position_disarmed>0</zero_position_disarmed>
           <zero_position_armed>100</zero_position_armed>
           <joint_control_type>velocity</joint_control_type>
-          <!-- gazebo_motor_model has the joint_control_pid active in this model
-          <joint_control_pid>
-            <p>0.1</p>
-            <i>0</i>
-            <d>0</d>
-            <iMax>0</iMax>
-            <iMin>0</iMin>
-            <cmdMax>3</cmdMax>
-            <cmdMin>-3</cmdMin>
-          </joint_control_pid>
-          -->
-          <joint_name>rotor_4_joint</joint_name>
         </channel>
         <channel name="rotor1">
           <input_index>1</input_index>
@@ -1396,18 +1300,6 @@
           <zero_position_disarmed>0</zero_position_disarmed>
           <zero_position_armed>100</zero_position_armed>
           <joint_control_type>velocity</joint_control_type>
-          <!-- gazebo_motor_model has the joint_control_pid active in this model
-          <joint_control_pid>
-            <p>0.1</p>
-            <i>0</i>
-            <d>0</d>
-            <iMax>0</iMax>
-            <iMin>0</iMin>
-            <cmdMax>3</cmdMax>
-            <cmdMin>-3</cmdMin>
-          </joint_control_pid>
-          -->
-          <joint_name>rotor_5_joint</joint_name>
         </channel>
         <channel name="rotor2">
           <input_index>2</input_index>
@@ -1416,18 +1308,6 @@
           <zero_position_disarmed>0</zero_position_disarmed>
           <zero_position_armed>100</zero_position_armed>
           <joint_control_type>velocity</joint_control_type>
-          <!-- gazebo_motor_model has the joint_control_pid active in this model
-          <joint_control_pid>
-            <p>0.1</p>
-            <i>0</i>
-            <d>0</d>
-            <iMax>0</iMax>
-            <iMin>0</iMin>
-            <cmdMax>3</cmdMax>
-            <cmdMin>-3</cmdMin>
-          </joint_control_pid>
-          -->
-          <joint_name>rotor_2_joint</joint_name>
         </channel>
         <channel name="rotor3">
           <input_index>3</input_index>
@@ -1436,18 +1316,6 @@
           <zero_position_disarmed>0</zero_position_disarmed>
           <zero_position_armed>100</zero_position_armed>
           <joint_control_type>velocity</joint_control_type>
-          <!-- gazebo_motor_model has the joint_control_pid active in this model
-          <joint_control_pid>
-            <p>0.1</p>
-            <i>0</i>
-            <d>0</d>
-            <iMax>0</iMax>
-            <iMin>0</iMin>
-            <cmdMax>3</cmdMax>
-            <cmdMin>-3</cmdMin>
-          </joint_control_pid>
-          -->
-          <joint_name>rotor_3_joint</joint_name>
         </channel>
         <channel name="rotor4">
           <input_index>4</input_index>
@@ -1456,38 +1324,14 @@
           <zero_position_disarmed>0</zero_position_disarmed>
           <zero_position_armed>100</zero_position_armed>
           <joint_control_type>velocity</joint_control_type>
-          <!-- gazebo_motor_model has the joint_control_pid active in this model
-          <joint_control_pid>
-            <p>0.1</p>
-            <i>0</i>
-            <d>0</d>
-            <iMax>0</iMax>
-            <iMin>0</iMin>
-            <cmdMax>3</cmdMax>
-            <cmdMin>-3</cmdMin>
-          </joint_control_pid>
-          -->
-          <joint_name>rotor_0_joint</joint_name>
         </channel>
-        <channel name="rotor5">
+       <channel name="rotor5">
           <input_index>5</input_index>
           <input_offset>0</input_offset>
           <input_scaling>1500</input_scaling>
           <zero_position_disarmed>0</zero_position_disarmed>
           <zero_position_armed>100</zero_position_armed>
           <joint_control_type>velocity</joint_control_type>
-          <!-- gazebo_motor_model has the joint_control_pid active in this model
-          <joint_control_pid>
-            <p>0.1</p>
-            <i>0</i>
-            <d>0</d>
-            <iMax>0</iMax>
-            <iMin>0</iMin>
-            <cmdMax>3</cmdMax>
-            <cmdMin>-3</cmdMin>
-          </joint_control_pid>
-          -->
-          <joint_name>rotor_1_joint</joint_name>
         </channel>
         <channel name="gimbal_roll">
           <input_index>6</input_index>
@@ -1502,7 +1346,7 @@
         <channel name="gimbal_pitch">
           <input_index>7</input_index>
           <input_offset>0</input_offset>
-          <input_scaling>3.1415</input_scaling>
+          <input_scaling>-3.1415</input_scaling>
           <zero_position_disarmed>0</zero_position_disarmed>
           <zero_position_armed>0</zero_position_armed>
           <joint_control_type>position_gztopic</joint_control_type>

--- a/models/typhoon_h480/typhoon_h480.sdf
+++ b/models/typhoon_h480/typhoon_h480.sdf
@@ -743,7 +743,7 @@
       <child>rotor_3</child>
       <parent>base_link</parent>
       <axis>
-        <xyz>0.0446 -0.0825 1.8977</xyz>
+        <xyz>0 0 1</xyz>
         <limit>
           <lower>-1e+16</lower>
           <upper>1e+16</upper>
@@ -815,7 +815,7 @@
       <child>rotor_0</child>
       <parent>base_link</parent>
       <axis>
-        <xyz>0.046 0.0827 1.8977</xyz>
+        <xyz>0 0 1</xyz>
         <limit>
           <lower>-1e+16</lower>
           <upper>1e+16</upper>
@@ -887,7 +887,7 @@
       <child>rotor_4</child>
       <parent>base_link</parent>
       <axis>
-        <xyz>-0.09563 -0.0003 1.8976</xyz>
+        <xyz>0 0 1</xyz>
         <limit>
           <lower>-1e+16</lower>
           <upper>1e+16</upper>
@@ -959,7 +959,7 @@
       <child>rotor_1</child>
       <parent>base_link</parent>
       <axis>
-        <xyz>0.0486 0.0811 1.8976</xyz>
+        <xyz>0 0 1</xyz>
         <limit>
           <lower>-1e+16</lower>
           <upper>1e+16</upper>
@@ -1032,7 +1032,7 @@
       <child>rotor_5</child>
       <parent>base_link</parent>
       <axis>
-        <xyz>-0.033996 -0.0006 0.68216</xyz>
+        <xyz>0 0 1</xyz>
         <limit>
           <lower>-1e+16</lower>
           <upper>1e+16</upper>
@@ -1104,7 +1104,7 @@
       <child>rotor_2</child>
       <parent>base_link</parent>
       <axis>
-        <xyz>0.0404 -0.0876 1.8976</xyz>
+        <xyz>0 0 1</xyz>
         <limit>
           <lower>-1e+16</lower>
           <upper>1e+16</upper>


### PR DESCRIPTION
I noticed that everything including camera imu, imu, motor layout was rotated by PI, making the model functionally working, but making it confusing to debug orientations. (Issue: https://github.com/PX4/sitl_gazebo/issues/511)

My suspicion of why this happened is given that visual mesh of the body was rotated by pi, everything was simply made to fit the visual mesh. This problem became only to attention when I was trying to add the gimbal to other models. Only the typhoon h480 was working with the gimbal and the rest of the models had the gimbal rotated by pi when it was fitted by it.

Therefore, I have rewired the internals of the Typhoon H480 so that the orientation of the vehicle is actually aligned with the link orientation. 

**Note**: I noticed that each of the motors were tilted slightly as in the real vehicle, so that it has more yaw authority. However, given the change of orientation change it resulted in a loss of yaw authority therefore I made every rotor align vertically. If anybody has information of how much this should be tilted (or if this is even realistic / important) I will bring the tilts back in. 

**Before PR: (Vehicle yaw = 0)**
![image](https://user-images.githubusercontent.com/5248102/83975484-98f68200-a8f4-11ea-9d5b-7510ff1376e2.png)

**After PR: (Vehicle yaw = 0)**
![image](https://user-images.githubusercontent.com/5248102/83975574-ce02d480-a8f4-11ea-8c8c-99df21a0d0d5.png)

Fixes https://github.com/PX4/sitl_gazebo/issues/511

