### PR TITLE
Factor out airspeed as a plugin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -279,6 +279,7 @@ set(nav_msgs msgs/Odometry.proto)
 set(physics_msgs msgs/Wind.proto)
 set(std_msgs msgs/Int32.proto)
 set(sensor_msgs
+  msgs/Airspeed.proto
   msgs/Imu.proto
   msgs/IRLock.proto
   msgs/Float.proto
@@ -309,6 +310,7 @@ add_library(sensor_msgs SHARED ${SEN_PROTO_SRCS})
 link_libraries(mav_msgs nav_msgs std_msgs sensor_msgs)
 link_libraries(physics_msgs)
 
+add_library(gazebo_airspeed_plugin SHARED src/gazebo_airspeed_plugin.cpp)
 add_library(gazebo_geotagged_images_plugin SHARED src/gazebo_geotagged_images_plugin.cpp)
 add_library(gazebo_gps_plugin SHARED src/gazebo_gps_plugin.cpp)
 add_library(gazebo_irlock_plugin SHARED src/gazebo_irlock_plugin.cpp)
@@ -332,6 +334,7 @@ add_library(gazebo_usv_dynamics_plugin SHARED src/gazebo_usv_dynamics_plugin.cpp
 add_library(gazebo_parachute_plugin SHARED src/gazebo_parachute_plugin.cpp)
 
 set(plugins
+  gazebo_airspeed_plugin
   gazebo_geotagged_images_plugin
   gazebo_gps_plugin
   gazebo_irlock_plugin

--- a/include/gazebo_airspeed_plugin.h
+++ b/include/gazebo_airspeed_plugin.h
@@ -1,0 +1,106 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+/**
+ * @brief Airspeed Plugin
+ *
+ * This plugin publishes Airspeed sensor data
+ *
+ * @author Jaeyoung Lim <jaeyoung@auterion.com>
+ */
+
+#ifndef _GAZEBO_AIRSPEED_PLUGIN_HH_
+#define _GAZEBO_AIRSPEED_PLUGIN_HH_
+
+#include <math.h>
+#include <cstdio>
+#include <cstdlib>
+#include <queue>
+#include <random>
+
+#include <sdf/sdf.hh>
+#include <common.h>
+#include <random>
+
+#include <gazebo/common/Plugin.hh>
+#include <gazebo/gazebo.hh>
+#include <gazebo/util/system.hh>
+#include <gazebo/transport/transport.hh>
+#include <gazebo/msgs/msgs.hh>
+#include <gazebo/physics/physics.hh>
+#include <ignition/math.hh>
+
+#include <Airspeed.pb.h>
+#include <Wind.pb.h>
+
+namespace gazebo
+{
+
+typedef const boost::shared_ptr<const physics_msgs::msgs::Wind> WindPtr;
+
+class GAZEBO_VISIBLE AirspeedPlugin : public ModelPlugin
+{
+public:
+  AirspeedPlugin();
+  virtual ~AirspeedPlugin();
+
+protected:
+  virtual void Load(physics::ModelPtr _model, sdf::ElementPtr _sdf);
+  virtual void OnUpdate(const common::UpdateInfo&);
+
+private:
+  void WindVelocityCallback(WindPtr& msg);
+
+  physics::ModelPtr model_;
+  physics::WorldPtr world_;
+  physics::LinkPtr link_;
+
+  transport::NodePtr node_handle_;
+  transport::SubscriberPtr wind_sub_;
+  transport::PublisherPtr airspeed_pub_;
+  event::ConnectionPtr updateConnection_;
+
+  common::Time last_time_;
+  std::string namespace_;
+  std::string link_name_;
+
+  ignition::math::Vector3d wind_vel_;
+
+  std::default_random_engine random_generator_;
+  std::normal_distribution<float> standard_normal_distribution_;
+
+  float diff_pressure_stddev_;
+  float temperature_;
+
+};     // class GAZEBO_VISIBLE AirspeedPlugin
+}      // namespace gazebo
+#endif // _GAZEBO_AIRSPEED_PLUGIN_HH_

--- a/include/gazebo_mavlink_interface.h
+++ b/include/gazebo_mavlink_interface.h
@@ -56,6 +56,7 @@
 #include <ignition/math.hh>
 #include <sdf/sdf.hh>
 #include <common.h>
+#include <Airspeed.pb.h>
 #include <CommandMotorSpeed.pb.h>
 #include <MotorSpeed.pb.h>
 #include <Imu.pb.h>
@@ -93,6 +94,7 @@ namespace gazebo {
 
 typedef const boost::shared_ptr<const mav_msgs::msgs::CommandMotorSpeed> CommandMotorSpeedPtr;
 typedef const boost::shared_ptr<const nav_msgs::msgs::Odometry> OdomPtr;
+typedef const boost::shared_ptr<const sensor_msgs::msgs::Airspeed> AirspeedPtr;
 typedef const boost::shared_ptr<const sensor_msgs::msgs::Groundtruth> GtPtr;
 typedef const boost::shared_ptr<const sensor_msgs::msgs::Imu> ImuPtr;
 typedef const boost::shared_ptr<const sensor_msgs::msgs::IRLock> IRLockPtr;
@@ -120,6 +122,7 @@ static const std::string kDefaultIRLockTopic = "/camera/link/irlock";
 static const std::string kDefaultGPSTopic = "/gps";
 static const std::string kDefaultVisionTopic = "/vision_odom";
 static const std::string kDefaultMagTopic = "/mag";
+static const std::string kDefaultAirspeedTopic = "/airspeed";
 static const std::string kDefaultBarometerTopic = "/baro";
 static const std::string kDefaultWindTopic = "/wind";
 
@@ -167,7 +170,6 @@ public:
     use_elevator_pid_(false),
     use_left_elevon_pid_(false),
     use_right_elevon_pid_(false),
-    vehicle_is_tailsitter_(false),
     send_vision_estimation_(false),
     send_odometry_(false),
     imu_sub_topic_(kDefaultImuTopic),
@@ -176,6 +178,7 @@ public:
     gps_sub_topic_(kDefaultGPSTopic),
     vision_sub_topic_(kDefaultVisionTopic),
     mag_sub_topic_(kDefaultMagTopic),
+    airspeed_sub_topic_(kDefaultAirspeedTopic),
     baro_sub_topic_(kDefaultBarometerTopic),
     sensor_map_ {},
     wind_sub_topic_(kDefaultWindTopic),
@@ -266,8 +269,6 @@ private:
   bool use_left_elevon_pid_;
   bool use_right_elevon_pid_;
 
-  bool vehicle_is_tailsitter_;
-
   bool send_vision_estimation_;
   bool send_odometry_;
 
@@ -290,6 +291,7 @@ private:
   void IRLockCallback(IRLockPtr& irlock_msg);
   void VisionCallback(OdomPtr& odom_msg);
   void MagnetometerCallback(MagnetometerPtr& mag_msg);
+  void AirspeedCallback(AirspeedPtr& airspeed_msg);
   void BarometerCallback(BarometerPtr& baro_msg);
   void WindVelocityCallback(WindPtr& msg);
   void send_mavlink_message(const mavlink_message_t *message);
@@ -354,6 +356,7 @@ private:
   transport::SubscriberPtr groundtruth_sub_;
   transport::SubscriberPtr vision_sub_;
   transport::SubscriberPtr mag_sub_;
+  transport::SubscriberPtr airspeed_sub_;
   transport::SubscriberPtr baro_sub_;
   transport::SubscriberPtr wind_sub_;
 
@@ -366,6 +369,7 @@ private:
   std::string groundtruth_sub_topic_;
   std::string vision_sub_topic_;
   std::string mag_sub_topic_;
+  std::string airspeed_sub_topic_;
   std::string baro_sub_topic_;
   std::string wind_sub_topic_;
 
@@ -427,6 +431,7 @@ private:
 
   double optflow_distance;
   double sonar_distance;
+  double diff_pressure_;
 
   in_addr_t mavlink_addr_;
   int mavlink_udp_port_; // MAVLink refers to the PX4 simulator interface here

--- a/models/plane/plane.sdf
+++ b/models/plane/plane.sdf
@@ -87,6 +87,39 @@
         <use_parent_model_frame>1</use_parent_model_frame>
       </axis>
     </joint>
+    <link name='plane/airspeed_link'>
+      <pose>0 0 0 0 0 0</pose>
+      <inertial>
+        <pose>0 0 0 0 0 0</pose>
+        <mass>0.015</mass>
+        <inertia>
+          <ixx>1e-05</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>1e-05</iyy>
+          <iyz>0</iyz>
+          <izz>1e-05</izz>
+        </inertia>
+      </inertial>
+    </link>
+    <joint name='plane/airspeed_joint' type='revolute'>
+      <child>plane/airspeed_link</child>
+      <parent>base_link</parent>
+      <axis>
+        <xyz>1 0 0</xyz>
+        <limit>
+          <lower>0</lower>
+          <upper>0</upper>
+          <effort>0</effort>
+          <velocity>0</velocity>
+        </limit>
+        <dynamics>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+        </dynamics>
+        <use_parent_model_frame>1</use_parent_model_frame>
+      </axis>
+    </joint>
     <link name='rotor_puller'>
       <pose>0.3 0 0.0 0 1.57 0</pose>
       <inertial>
@@ -643,6 +676,10 @@
       <robotNamespace/>
       <pubRate>50</pubRate>
       <baroTopic>/baro</baroTopic>
+    </plugin>
+    <plugin name='airspeed_plugin' filename='libgazebo_airspeed_plugin.so'>
+      <robotNamespace/>
+      <linkName>plane/airspeed_link</linkName>
     </plugin>
     <plugin name='mavlink_interface' filename='libgazebo_mavlink_interface.so'>
       <robotNamespace></robotNamespace>

--- a/models/standard_vtol/standard_vtol.sdf
+++ b/models/standard_vtol/standard_vtol.sdf
@@ -177,6 +177,39 @@
         <use_parent_model_frame>1</use_parent_model_frame>
       </axis>
     </joint>
+    <link name='standard_vtol/airspeed_link'>
+      <pose>0 0 0 0 0 0</pose>
+      <inertial>
+        <pose>0 0 0 0 0 0</pose>
+        <mass>0.015</mass>
+        <inertia>
+          <ixx>1e-05</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>1e-05</iyy>
+          <iyz>0</iyz>
+          <izz>1e-05</izz>
+        </inertia>
+      </inertial>
+    </link>
+    <joint name='standard_vtol/airspeed_joint' type='revolute'>
+      <child>standard_vtol/airspeed_link</child>
+      <parent>base_link</parent>
+      <axis>
+        <xyz>1 0 0</xyz>
+        <limit>
+          <lower>0</lower>
+          <upper>0</upper>
+          <effort>0</effort>
+          <velocity>0</velocity>
+        </limit>
+        <dynamics>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+        </dynamics>
+        <use_parent_model_frame>1</use_parent_model_frame>
+      </axis>
+    </joint>
     <link name='rotor_0'>
       <pose>0.35 -0.35 0.07 0 0 0</pose>
       <inertial>
@@ -698,6 +731,8 @@
         left_elevon_joint
       </control_joint_name>
       <control_joint_rad_to_cl>-1.0</control_joint_rad_to_cl>
+      <robotNamespace></robotNamespace>
+      <windSubTopic>/wind</windSubTopic>
     </plugin>
     <plugin name="right_wing" filename="libLiftDragPlugin.so">
       <a0>0.05984281113</a0>
@@ -718,6 +753,8 @@
         right_elevon_joint
       </control_joint_name>
       <control_joint_rad_to_cl>-1.0</control_joint_rad_to_cl>
+      <robotNamespace></robotNamespace>
+      <windSubTopic>/wind</windSubTopic>
     </plugin>
     <plugin name="elevator" filename="libLiftDragPlugin.so">
       <a0>-0.2</a0>
@@ -738,6 +775,8 @@
         elevator_joint
       </control_joint_name>
       <control_joint_rad_to_cl>-12.0</control_joint_rad_to_cl>
+      <robotNamespace></robotNamespace>
+      <windSubTopic>/wind</windSubTopic>
     </plugin>
     <plugin name="rudder" filename="libLiftDragPlugin.so">
       <a0>0.0</a0>
@@ -754,6 +793,8 @@
       <forward>1 0 0</forward>
       <upward>0 1 0</upward>
       <link_name>base_link</link_name>
+      <robotNamespace></robotNamespace>
+      <windSubTopic>/wind</windSubTopic>
     </plugin>
     <plugin name='front_right_motor_model' filename='libgazebo_motor_model.so'>
       <robotNamespace></robotNamespace>
@@ -869,6 +910,10 @@
       <robotNamespace/>
       <pubRate>50</pubRate>
       <baroTopic>/baro</baroTopic>
+    </plugin>
+    <plugin name='airspeed_plugin' filename='libgazebo_airspeed_plugin.so'>
+      <robotNamespace/>
+      <linkName>standard_vtol/airspeed_link</linkName>
     </plugin>
     <plugin name='mavlink_interface' filename='libgazebo_mavlink_interface.so'>
       <robotNamespace></robotNamespace>

--- a/models/tailsitter/tailsitter.sdf
+++ b/models/tailsitter/tailsitter.sdf
@@ -85,6 +85,39 @@
         <use_parent_model_frame>1</use_parent_model_frame>
       </axis>
     </joint>
+    <link name='tailsitter/airspeed_link'>
+      <pose>0 0 0 0 -1.57 0</pose>
+      <inertial>
+        <pose>0 0 0 0 0 0</pose>
+        <mass>0.015</mass>
+        <inertia>
+          <ixx>1e-05</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>1e-05</iyy>
+          <iyz>0</iyz>
+          <izz>1e-05</izz>
+        </inertia>
+      </inertial>
+    </link>
+    <joint name='tailsitter/airspeed_joint' type='revolute'>
+      <child>tailsitter/airspeed_link</child>
+      <parent>base_link</parent>
+      <axis>
+        <xyz>1 0 0</xyz>
+        <limit>
+          <lower>0</lower>
+          <upper>0</upper>
+          <effort>0</effort>
+          <velocity>0</velocity>
+        </limit>
+        <dynamics>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+        </dynamics>
+        <use_parent_model_frame>1</use_parent_model_frame>
+      </axis>
+    </joint>
     <link name='rotor_0'>
       <pose>0.3 -0.3 0.4 0 0 0</pose>
       <inertial>
@@ -508,6 +541,8 @@
         left_elevon_joint
       </control_joint_name>
       <control_joint_rad_to_cl>-0.5</control_joint_rad_to_cl>
+      <robotNamespace></robotNamespace>
+      <windSubTopic>/wind</windSubTopic>
     </plugin>
     <plugin name="right_wing" filename="libLiftDragPlugin.so">
       <a0>0.05984281113</a0>
@@ -528,6 +563,8 @@
         right_elevon_joint
       </control_joint_name>
       <control_joint_rad_to_cl>-0.5</control_joint_rad_to_cl>
+      <robotNamespace></robotNamespace>
+      <windSubTopic>/wind</windSubTopic>
     </plugin>
     <plugin name="elevator" filename="libLiftDragPlugin.so">
       <a0>0.05984281113</a0>
@@ -547,6 +584,8 @@
       <control_joint_name>
         elevator_joint
       </control_joint_name>
+      <robotNamespace></robotNamespace>
+      <windSubTopic>/wind</windSubTopic>
     </plugin>
     <plugin name="rudder" filename="libLiftDragPlugin.so">
       <a0>0.0</a0>
@@ -563,6 +602,8 @@
       <forward>0 0 1</forward>
       <upward>0 1 0</upward>
       <link_name>base_link</link_name>
+      <robotNamespace></robotNamespace>
+      <windSubTopic>/wind</windSubTopic>
     </plugin>
     <plugin name='rosbag' filename='libgazebo_multirotor_base_plugin.so'>
       <robotNamespace></robotNamespace>
@@ -667,6 +708,10 @@
       <pubRate>50</pubRate>
       <baroTopic>/baro</baroTopic>
     </plugin>
+    <plugin name='airspeed_plugin' filename='libgazebo_airspeed_plugin.so'>
+      <robotNamespace/>
+      <linkName>tailsitter/airspeed_link</linkName>
+    </plugin>
     <plugin name='mavlink_interface' filename='libgazebo_mavlink_interface.so'>
       <robotNamespace></robotNamespace>
       <imuSubTopic>/imu</imuSubTopic>
@@ -686,7 +731,6 @@
       <hil_state_level>false</hil_state_level>
       <enable_lockstep>true</enable_lockstep>
       <use_tcp>true</use_tcp>
-      <vehicle_is_tailsitter>true</vehicle_is_tailsitter>
       <motorSpeedCommandPubTopic>/gazebo/command/motor_speed</motorSpeedCommandPubTopic>
       <control_channels>
         <channel name="rotor0">

--- a/msgs/Airspeed.proto
+++ b/msgs/Airspeed.proto
@@ -1,0 +1,8 @@
+syntax = "proto2";
+package sensor_msgs.msgs;
+
+message Airspeed
+{
+  required int64  time_usec             = 1;
+  required double diff_pressure         = 2;
+}

--- a/src/gazebo_airspeed_plugin.cpp
+++ b/src/gazebo_airspeed_plugin.cpp
@@ -1,0 +1,131 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+/**
+ * @brief Airspeed Plugin
+ *
+ * This plugin publishes Airspeed
+ *
+ * @author Jaeyoung Lim <jaeyoung@auterion.com>
+ */
+
+#include <gazebo_airspeed_plugin.h>
+
+namespace gazebo {
+GZ_REGISTER_MODEL_PLUGIN(AirspeedPlugin)
+
+AirspeedPlugin::AirspeedPlugin() : ModelPlugin(),
+  diff_pressure_stddev_(0.01f),
+  temperature_(20.0f)
+{ }
+
+AirspeedPlugin::~AirspeedPlugin()
+{
+    if (updateConnection_)
+      updateConnection_->~Connection();
+}
+
+void AirspeedPlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf)
+{
+  // Store the pointer to the model.
+  model_ = _model;
+  world_ = model_->GetWorld();
+
+  if (_sdf->HasElement("robotNamespace")) {
+    namespace_ = _sdf->GetElement("robotNamespace")->Get<std::string>();
+  } else {
+    gzerr << "[gazebo_wind_plugin] Please specify a robotNamespace.\n";
+  }
+
+  node_handle_ = transport::NodePtr(new transport::Node());
+  node_handle_->Init(namespace_);
+
+  if (_sdf->HasElement("linkName"))
+    link_name_ = _sdf->GetElement("linkName")->Get<std::string>();
+  else
+    gzerr << "[gazebo_airspeed_plugin] Please specify a linkName.\n";
+  // Get the pointer to the link
+  link_ = model_->GetLink(link_name_);
+  if (link_ == NULL)
+    gzthrow("[gazebo_airspeed_plugin] Couldn't find specified link \"" << link_name_ << "\".");
+
+  // Listen to the update event. This event is broadcast every
+  // simulation iteration.
+  updateConnection_ = event::Events::ConnectWorldUpdateBegin(
+      boost::bind(&AirspeedPlugin::OnUpdate, this, _1));
+
+  airspeed_pub_ = node_handle_->Advertise<sensor_msgs::msgs::Airspeed>("~/" + model_->GetName() + "/airspeed", 10);
+  wind_sub_ = node_handle_->Subscribe("~/" + model_->GetName() + "/wind", &AirspeedPlugin::WindVelocityCallback, this);
+
+  getSdfParam<float>(_sdf, "DiffPressureStdev", diff_pressure_stddev_, diff_pressure_stddev_);
+  getSdfParam<float>(_sdf, "Temperature", temperature_, temperature_);
+
+}
+
+void AirspeedPlugin::OnUpdate(const common::UpdateInfo&){
+#if GAZEBO_MAJOR_VERSION >= 9
+  common::Time current_time = world_->SimTime();
+#else
+  common::Time current_time = world_->GetSimTime();
+#endif
+  const float temperature_msl = 288.0f; // temperature at MSL (Kelvin)
+  float temperature_local = temperature_ + 273.0f;
+  const float density_ratio = powf((temperature_msl/temperature_local) , 4.256f);
+  float rho = 1.225f / density_ratio;
+
+  const float diff_pressure_noise = standard_normal_distribution_(random_generator_) * diff_pressure_stddev_;
+
+#if GAZEBO_MAJOR_VERSION >= 9
+  ignition::math::Pose3d T_W_I = link_->WorldPose();
+#else
+  ignition::math::Pose3d T_W_I = ignitionFromGazeboMath(link_->GetWorldPose());
+#endif
+  ignition::math::Quaterniond C_W_I = T_W_I.Rot();
+
+  ignition::math::Vector3d vel_a = link_->RelativeLinearVel() - C_W_I.RotateVector(wind_vel_);
+  double diff_pressure = 0.005f * rho * vel_a.X() * vel_a.X() + diff_pressure_noise;
+
+  // calculate differential pressure in hPa
+  sensor_msgs::msgs::Airspeed airspeed_msg;
+  airspeed_msg.set_time_usec(current_time.Double() * 1e6);
+  airspeed_msg.set_diff_pressure(diff_pressure);
+  airspeed_pub_->Publish(airspeed_msg);
+
+  last_time_ = current_time;
+}
+
+void AirspeedPlugin::WindVelocityCallback(WindPtr& msg) {
+  wind_vel_ = ignition::math::Vector3d(msg->velocity().x(),
+            msg->velocity().y(),
+            msg->velocity().z());
+}
+} // namespace gazebo


### PR DESCRIPTION
Previously, the airspeed model was included as part of the `gazebo_mavlink_interface`. However, this does not make much sense and prevents you from mounting airspeed sensors in arbitrary orientations on the vehicle. For this reason, there was a sdf element `vehicle_is_tailsitter` to enable measuring airspeed for the tailsitter, which airspeed is measured on the z axis. 

This PR separates the airspeed measurement into a separate plugin, so the airspeed sensor can be mounted in arbitrary orientations. Also, parameters such as temperature, noise are exposed through sdf, so it can be changed easily. 

Airspeed plugin on plane, tailsitter, standard_vtols model has been updated and tested. On the tailsitter the airspeed sensor is mounted vertically. 

**Testing**
Flight test on a plane
Flight Log: https://review.px4.io/plot_app?log=c4950de7-59e8-4397-87fa-f24aba3458fb

Moving forward, this is needed to be able to mount multiple airspeed sensors, but this needs extension of the HIL SENSOR message. 
