### PR TITLE
feature: make GPS its own model, gazebo_gps_plugin a sensor plugin and groundtruth its own model plugin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -311,6 +311,7 @@ link_libraries(physics_msgs)
 
 add_library(gazebo_geotagged_images_plugin SHARED src/gazebo_geotagged_images_plugin.cpp)
 add_library(gazebo_gps_plugin SHARED src/gazebo_gps_plugin.cpp)
+add_library(gazebo_groundtruth_plugin SHARED src/gazebo_groundtruth_plugin.cpp)
 add_library(gazebo_irlock_plugin SHARED src/gazebo_irlock_plugin.cpp)
 add_library(gazebo_lidar_plugin SHARED src/gazebo_lidar_plugin.cpp)
 add_library(gazebo_opticalflow_mockup_plugin SHARED src/gazebo_opticalflow_mockup_plugin.cpp)
@@ -334,6 +335,7 @@ add_library(gazebo_parachute_plugin SHARED src/gazebo_parachute_plugin.cpp)
 set(plugins
   gazebo_geotagged_images_plugin
   gazebo_gps_plugin
+  gazebo_groundtruth_plugin
   gazebo_irlock_plugin
   gazebo_lidar_plugin
   gazebo_opticalflow_mockup_plugin

--- a/include/gazebo_gps_plugin.h
+++ b/include/gazebo_gps_plugin.h
@@ -44,22 +44,24 @@
 #include <gazebo/physics/physics.hh>
 #include <ignition/math.hh>
 
+#include <gazebo/sensors/SensorTypes.hh>
+#include <gazebo/sensors/GpsSensor.hh>
+
 #include <SITLGps.pb.h>
 #include <Groundtruth.pb.h>
 
 namespace gazebo
 {
-class GAZEBO_VISIBLE GpsPlugin : public ModelPlugin
+class GAZEBO_VISIBLE GpsPlugin : public SensorPlugin
 {
 public:
   GpsPlugin();
   virtual ~GpsPlugin();
 
 protected:
-  virtual void Load(physics::ModelPtr _model, sdf::ElementPtr _sdf);
+  virtual void Load(sensors::SensorPtr _parent, sdf::ElementPtr _sdf);
   virtual void OnUpdate(const common::UpdateInfo&);
 
-protected:
   /* Keep this protected so that it's possible to unit test it. */
   std::pair<double, double> reproject(ignition::math::Vector3d& pos);
 
@@ -72,11 +74,13 @@ private:
   bool checkWorldHomePosition(physics::WorldPtr world);
 
   std::string namespace_;
+  std::string gps_id_;
   std::default_random_engine random_generator_;
   std::normal_distribution<float> standard_normal_distribution_;
 
   bool gps_noise_;
 
+  sensors::GpsSensorPtr parentSensor_;
   physics::ModelPtr model_;
   physics::WorldPtr world_;
   event::ConnectionPtr updateConnection_;
@@ -84,6 +88,8 @@ private:
   transport::NodePtr node_handle_;
   transport::PublisherPtr gt_pub_;
   transport::PublisherPtr gps_pub_;
+
+  std::string gps_topic_;
 
   sensor_msgs::msgs::SITLGps gps_msg;
   sensor_msgs::msgs::Groundtruth groundtruth_msg;

--- a/include/gazebo_gps_plugin.h
+++ b/include/gazebo_gps_plugin.h
@@ -73,6 +73,8 @@ private:
    **/
   bool checkWorldHomePosition(physics::WorldPtr world);
 
+  void addEntityEventCallback(const std::string &name);
+
   std::string namespace_;
   std::string gps_id_;
   std::default_random_engine random_generator_;
@@ -80,10 +82,13 @@ private:
 
   bool gps_noise_;
 
+  std::string model_name_;
+
   sensors::GpsSensorPtr parentSensor_;
   physics::ModelPtr model_;
   physics::WorldPtr world_;
   event::ConnectionPtr updateConnection_;
+  event::ConnectionPtr addEntityConnection_;
 
   transport::NodePtr node_handle_;
   transport::PublisherPtr gt_pub_;

--- a/include/gazebo_gps_plugin.h
+++ b/include/gazebo_gps_plugin.h
@@ -68,6 +68,7 @@ public:
 protected:
   virtual void Load(sensors::SensorPtr _parent, sdf::ElementPtr _sdf);
   virtual void OnSensorUpdate();
+  virtual void OnWorldUpdate(const common::UpdateInfo& /*_info*/);
 
 private:
   std::string namespace_;
@@ -82,6 +83,7 @@ private:
   sensors::GpsSensorPtr parentSensor_;
   physics::ModelPtr model_;
   physics::WorldPtr world_;
+  event::ConnectionPtr updateWorldConnection_;
   event::ConnectionPtr updateSensorConnection_;
 
   transport::NodePtr node_handle_;
@@ -92,6 +94,7 @@ private:
 
   common::Time last_gps_time_;
   common::Time last_time_;
+  common::Time current_time_;
 
   // Home defaults to Zurich Irchel Park
   // @note The home position can be specified using the environment variables:
@@ -104,7 +107,6 @@ private:
   double world_altitude_ = 0.0;
 
   // gps delay related
-  static constexpr double gps_update_interval_ = 0.2; // 5hz
   static constexpr double gps_delay = 0.12;           // 120 ms
   static constexpr int gps_buffer_size_max = 1000;
   std::queue<sensor_msgs::msgs::SITLGps> gps_delay_buffer;

--- a/include/gazebo_gps_plugin.h
+++ b/include/gazebo_gps_plugin.h
@@ -52,6 +52,13 @@
 
 namespace gazebo
 {
+static constexpr double kDefaultGpsXYRandomWalk = 2.0;          // (m/s) / sqrt(hz)
+static constexpr double kDefaultGpsZRandomWalk = 4.0;           // (m/s) / sqrt(hz)
+static constexpr double kDefaultGpsXYNoiseDensity = 2.0e-4;     // (m) / sqrt(hz)
+static constexpr double kDefaultGpsZNoiseDensity = 4.0e-4;      // (m) / sqrt(hz)
+static constexpr double kDefaultGpsVXYNoiseDensity = 0.2;       // (m/s) / sqrt(hz)
+static constexpr double kDefaultGpsVZNoiseDensity = 0.4;        // (m/s) / sqrt(hz)
+
 class GAZEBO_VISIBLE GpsPlugin : public SensorPlugin
 {
 public:
@@ -142,13 +149,13 @@ private:
   double std_z;     // meters
   std::default_random_engine rand_;
   std::normal_distribution<float> randn_;
-  static constexpr double gps_corellation_time = 60.0;    // s
-  static constexpr double gps_xy_random_walk = 2.0;       // (m/s) / sqrt(hz)
-  static constexpr double gps_z_random_walk = 4.0;        // (m/s) / sqrt(hz)
-  static constexpr double gps_xy_noise_density = 2e-4;    // (m) / sqrt(hz)
-  static constexpr double gps_z_noise_density = 4e-4;     // (m) / sqrt(hz)
-  static constexpr double gps_vxy_noise_density = 2e-1;   // (m/s) / sqrt(hz)
-  static constexpr double gps_vz_noise_density = 4e-1;    // (m/s) / sqrt(hz)
+  static constexpr const double gps_corellation_time_ = 60.0;    // s
+  double gps_xy_random_walk_;
+  double gps_z_random_walk_;
+  double gps_xy_noise_density_;
+  double gps_z_noise_density_;
+  double gps_vxy_noise_density_;
+  double gps_vz_noise_density_;
 };     // class GAZEBO_VISIBLE GpsPlugin
 }      // namespace gazebo
 #endif // _GAZEBO_GPS_PLUGIN_HH_

--- a/include/gazebo_groundtruth_plugin.h
+++ b/include/gazebo_groundtruth_plugin.h
@@ -71,7 +71,7 @@ public:
 
 protected:
   virtual void Load(physics::ModelPtr _model, sdf::ElementPtr _sdf);
-  virtual void OnUpdate(const common::UpdateInfo&  /*_info*/);
+  virtual void OnUpdate(const common::UpdateInfo& /*_info*/);
 
 private:
   std::string namespace_;

--- a/include/gazebo_groundtruth_plugin.h
+++ b/include/gazebo_groundtruth_plugin.h
@@ -1,0 +1,97 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+/**
+ * @brief Groundtruth Plugin
+ *
+ * This plugin gets and publishes ground-truth data
+ *
+ * @author Nuno Marques <nuno.marques@dronesolutions.io>
+ */
+
+#ifndef _GAZEBO_GROUNDTRUTH_PLUGIN_HH_
+#define _GAZEBO_GROUNDTRUTH_PLUGIN_HH_
+
+#include <math.h>
+#include <cstdio>
+#include <cstdlib>
+#include <queue>
+#include <random>
+
+#include <sdf/sdf.hh>
+#include <common.h>
+
+#include <gazebo/common/Plugin.hh>
+#include <gazebo/gazebo.hh>
+#include <gazebo/util/system.hh>
+#include <gazebo/transport/transport.hh>
+#include <gazebo/msgs/msgs.hh>
+#include <gazebo/physics/physics.hh>
+#include <ignition/math.hh>
+
+#include <Groundtruth.pb.h>
+
+namespace gazebo
+{
+
+class GAZEBO_VISIBLE GroundtruthPlugin : public ModelPlugin
+{
+public:
+  GroundtruthPlugin();
+  virtual ~GroundtruthPlugin();
+
+protected:
+  virtual void Load(physics::ModelPtr _model, sdf::ElementPtr _sdf);
+  virtual void OnUpdate(const common::UpdateInfo&  /*_info*/);
+
+private:
+  std::string namespace_;
+  physics::ModelPtr model_;
+  physics::WorldPtr world_;
+  event::ConnectionPtr updateConnection_;
+
+  transport::NodePtr node_handle_;
+  transport::PublisherPtr gt_pub_;
+
+  // Home defaults to Zurich Irchel Park
+  // @note The home position can be specified using the environment variables:
+  // PX4_HOME_LAT, PX4_HOME_LON, and PX4_HOME_ALT
+  double lat_home_ = kDefaultHomeLatitude;
+  double lon_home_ = kDefaultHomeLongitude;
+  double alt_home_ = kDefaultHomeAltitude;
+  double world_latitude_ = 0.0;
+  double world_longitude_ = 0.0;
+  double world_altitude_ = 0.0;
+
+};     // class GAZEBO_VISIBLE GroundtruthPlugin
+}      // namespace gazebo
+#endif // _GAZEBO_GROUNDTRUTH_PLUGIN_HH_

--- a/include/gazebo_mavlink_interface.h
+++ b/include/gazebo_mavlink_interface.h
@@ -88,7 +88,7 @@ static constexpr size_t MAX_TXQ_SIZE = 1000;
 //! Default distance sensor model joint naming
 static const std::regex kDefaultLidarModelJointNaming(".*(lidar|sf10a)(.*_joint)");
 static const std::regex kDefaultSonarModelJointNaming(".*(sonar|mb1240-xl-ez4)(.*_joint)");
-static const std::regex kDefaultGPSModelJointNaming(".*(gps)(.*_joint)");
+static const std::regex kDefaultGPSModelJointNaming(".*(gps|ublox-neo-7M)(.*_joint)");
 
 namespace gazebo {
 

--- a/include/gazebo_mavlink_interface.h
+++ b/include/gazebo_mavlink_interface.h
@@ -86,9 +86,9 @@ static constexpr ssize_t MAX_SIZE = MAVLINK_MAX_PACKET_LEN + 16;
 static constexpr size_t MAX_TXQ_SIZE = 1000;
 
 //! Default distance sensor model joint naming
-static const std::regex kDefaultLidarModelLinkNaming("(lidar|sf10a)(.*::link)");
-static const std::regex kDefaultSonarModelLinkNaming("(sonar|mb1240-xl-ez4)(.*::link)");
-static const std::regex kDefaultGPSModelLinkNaming("(gps)(.*::link)");
+static const std::regex kDefaultLidarModelJointNaming("(lidar|sf10a)(.*_joint)");
+static const std::regex kDefaultSonarModelJointNaming("(sonar|mb1240-xl-ez4)(.*_joint)");
+static const std::regex kDefaultGPSModelJointNaming("(gps)(.*_joint)");
 
 namespace gazebo {
 
@@ -323,7 +323,7 @@ private:
   template <typename GazeboMsgT>
   void CreateSensorSubscription(
       void (GazeboMavlinkInterface::*fp)(const boost::shared_ptr<GazeboMsgT const>&, const int&),
-      GazeboMavlinkInterface* ptr, const physics::Link_V& links, const std::regex& model);
+      GazeboMavlinkInterface* ptr, const physics::Joint_V& joints, const std::regex& model);
 
   // Serial interface
   void open();

--- a/include/gazebo_mavlink_interface.h
+++ b/include/gazebo_mavlink_interface.h
@@ -88,6 +88,7 @@ static constexpr size_t MAX_TXQ_SIZE = 1000;
 //! Default distance sensor model joint naming
 static const std::regex kDefaultLidarModelLinkNaming("(lidar|sf10a)(.*::link)");
 static const std::regex kDefaultSonarModelLinkNaming("(sonar|mb1240-xl-ez4)(.*::link)");
+static const std::regex kDefaultGPSModelLinkNaming("(gps)(.*::link)");
 
 namespace gazebo {
 
@@ -117,7 +118,6 @@ static const std::string kDefaultMotorVelocityReferencePubTopic = "/gazebo/comma
 static const std::string kDefaultImuTopic = "/imu";
 static const std::string kDefaultOpticalFlowTopic = "/px4flow/link/opticalFlow";
 static const std::string kDefaultIRLockTopic = "/camera/link/irlock";
-static const std::string kDefaultGPSTopic = "/gps";
 static const std::string kDefaultVisionTopic = "/vision_odom";
 static const std::string kDefaultMagTopic = "/mag";
 static const std::string kDefaultBarometerTopic = "/baro";
@@ -173,7 +173,6 @@ public:
     imu_sub_topic_(kDefaultImuTopic),
     opticalFlow_sub_topic_(kDefaultOpticalFlowTopic),
     irlock_sub_topic_(kDefaultIRLockTopic),
-    gps_sub_topic_(kDefaultGPSTopic),
     vision_sub_topic_(kDefaultVisionTopic),
     mag_sub_topic_(kDefaultMagTopic),
     baro_sub_topic_(kDefaultBarometerTopic),
@@ -282,7 +281,7 @@ private:
   boost::thread callback_queue_thread_;
   void QueueThread();
   void ImuCallback(ImuPtr& imu_msg);
-  void GpsCallback(GpsPtr& gps_msg);
+  void GpsCallback(GpsPtr& gps_msg, const int& id);
   void GroundtruthCallback(GtPtr& groundtruth_msg);
   void LidarCallback(LidarPtr& lidar_msg, const int& id);
   void SonarCallback(SonarPtr& sonar_msg, const int& id);
@@ -324,7 +323,7 @@ private:
   template <typename GazeboMsgT>
   void CreateSensorSubscription(
       void (GazeboMavlinkInterface::*fp)(const boost::shared_ptr<GazeboMsgT const>&, const int&),
-      GazeboMavlinkInterface* ptr, const physics::Link_V& links);
+      GazeboMavlinkInterface* ptr, const physics::Link_V& links, const std::regex& model);
 
   // Serial interface
   void open();
@@ -350,7 +349,6 @@ private:
   transport::SubscriberPtr imu_sub_;
   transport::SubscriberPtr opticalFlow_sub_;
   transport::SubscriberPtr irlock_sub_;
-  transport::SubscriberPtr gps_sub_;
   transport::SubscriberPtr groundtruth_sub_;
   transport::SubscriberPtr vision_sub_;
   transport::SubscriberPtr mag_sub_;
@@ -362,7 +360,6 @@ private:
   std::string imu_sub_topic_;
   std::string opticalFlow_sub_topic_;
   std::string irlock_sub_topic_;
-  std::string gps_sub_topic_;
   std::string groundtruth_sub_topic_;
   std::string vision_sub_topic_;
   std::string mag_sub_topic_;

--- a/include/gazebo_mavlink_interface.h
+++ b/include/gazebo_mavlink_interface.h
@@ -86,9 +86,9 @@ static constexpr ssize_t MAX_SIZE = MAVLINK_MAX_PACKET_LEN + 16;
 static constexpr size_t MAX_TXQ_SIZE = 1000;
 
 //! Default distance sensor model joint naming
-static const std::regex kDefaultLidarModelJointNaming("(lidar|sf10a)(.*_joint)");
-static const std::regex kDefaultSonarModelJointNaming("(sonar|mb1240-xl-ez4)(.*_joint)");
-static const std::regex kDefaultGPSModelJointNaming("(gps)(.*_joint)");
+static const std::regex kDefaultLidarModelJointNaming(".*(lidar|sf10a)(.*_joint)");
+static const std::regex kDefaultSonarModelJointNaming(".*(sonar|mb1240-xl-ez4)(.*_joint)");
+static const std::regex kDefaultGPSModelJointNaming(".*(gps)(.*_joint)");
 
 namespace gazebo {
 

--- a/models/3DR_gps_mag/3DR_gps_mag.sdf.jinja
+++ b/models/3DR_gps_mag/3DR_gps_mag.sdf.jinja
@@ -46,7 +46,7 @@
         {{ box(l, w, h)|indent(8) }}
       </collision>
 
-      <sensor name="ublox-neo-7" type="gps">
+      <sensor name="ublox-neo-7M" type="gps">
         <pose>0 0 0 0 0 0</pose>
         <update_rate>10.0</update_rate>
         <always_on>true</always_on>
@@ -92,6 +92,16 @@
             </vertical>
           </velocity_sensing>
         </gps>
+        <plugin name="gps_plugin" filename="libgazebo_gps_plugin.so">
+          <robotNamespace></robotNamespace>
+          <gpsNoise>true</gpsNoise>
+          <gpsXYRandomWalk>2.0</gpsXYRandomWalk>
+          <gpsZRandomWalk>4.0</gpsZRandomWalk>
+          <gpsXYNoiseDensity>2.0e-4</gpsXYNoiseDensity>
+          <gpsZNoiseDensity>4.0e-4</gpsZNoiseDensity>
+          <gpsVXYNoiseDensity>0.2</gpsVXYNoiseDensity>
+          <gpsVZNoiseDensity>0.4</gpsVZNoiseDensity>
+        </plugin>
       </sensor>
 
       <sensor name="HMC5883L" type="magnetometer">

--- a/models/delta_wing/delta_wing.sdf
+++ b/models/delta_wing/delta_wing.sdf
@@ -259,6 +259,9 @@
       <accelerometerBiasCorrelationTime>300.0</accelerometerBiasCorrelationTime>
       <accelerometerTurnOnBiasSigma>0.196</accelerometerTurnOnBiasSigma>
     </plugin>
+    <plugin name='groundtruth_plugin' filename='libgazebo_groundtruth_plugin.so'>
+      <robotNamespace/>
+    </plugin>
     <plugin name='magnetometer_plugin' filename='libgazebo_magnetometer_plugin.so'>
       <robotNamespace/>
       <pubRate>100</pubRate>

--- a/models/delta_wing/delta_wing.sdf
+++ b/models/delta_wing/delta_wing.sdf
@@ -237,11 +237,19 @@
       </gazebo_joint_control_pid>
     </plugin>
     -->
+    <include>
+      <uri>model://gps</uri>
+      <pose>0 0 0 0 0 0</pose>
+      <name>gps</name>
+    </include>
+    <joint name='gps_joint' type='fixed'>
+      <child>gps::link</child>
+      <parent>base_link</parent>
+    </joint>
     <plugin name='gazebo_imu_plugin' filename='libgazebo_imu_plugin.so'>
       <robotNamespace>delta_wing</robotNamespace>
       <linkName>delta_wing/imu_link</linkName>
       <imuTopic>/imu</imuTopic>
-      <gpsSubTopic>/gps</gpsSubTopic>
       <gyroscopeNoiseDensity>0.0003394</gyroscopeNoiseDensity>
       <gyroscopeRandomWalk>3.8785e-05</gyroscopeRandomWalk>
       <gyroscopeBiasCorrelationTime>1000.0</gyroscopeBiasCorrelationTime>
@@ -250,10 +258,6 @@
       <accelerometerRandomWalk>0.006</accelerometerRandomWalk>
       <accelerometerBiasCorrelationTime>300.0</accelerometerBiasCorrelationTime>
       <accelerometerTurnOnBiasSigma>0.196</accelerometerTurnOnBiasSigma>
-    </plugin>
-    <plugin name="gps_plugin" filename="libgazebo_gps_plugin.so">
-        <robotNamespace></robotNamespace>
-        <gpsNoise>true</gpsNoise>
     </plugin>
     <plugin name='magnetometer_plugin' filename='libgazebo_magnetometer_plugin.so'>
       <robotNamespace/>

--- a/models/gps/gps.sdf
+++ b/models/gps/gps.sdf
@@ -5,14 +5,14 @@
       <pose>0 0 0 0 0 0</pose>
       <inertial>
         <pose>0 0 0 0 0 0</pose>
-        <mass>0.01</mass>
+        <mass>0.015</mass>
         <inertia>
-          <ixx>2.1733e-6</ixx>
+          <ixx>1e-05</ixx>
           <ixy>0</ixy>
           <ixz>0</ixz>
-          <iyy>2.1733e-6</iyy>
+          <iyy>1e-05</iyy>
           <iyz>0</iyz>
-          <izz>1.8e-7</izz>
+          <izz>1e-05</izz>
         </inertia>
       </inertial>
       <visual name="visual">
@@ -30,6 +30,52 @@
       </visual>
       <sensor name="gps" type="gps">
         <pose>0 0 0 0 0 0</pose>
+        <update_rate>5.0</update_rate>
+        <always_on>true</always_on>
+        <visualize>false</visualize>
+        <!-- GpsSensor noise currently not used -->
+        <!-- <gps>
+          <position_sensing>
+            <horizontal>
+              <noise type="gaussian_quantized">
+                <mean>0</mean>
+                <stddev>1</stddev>
+                <bias_mean>3</bias_mean>
+                <bias_stddev>1</bias_stddev>
+                <precision>0.5</precision>
+              </noise>
+            </horizontal>
+            <vertical>
+              <noise type="gaussian_quantized">
+                <mean>0</mean>
+                <stddev>1</stddev>
+                <bias_mean>3</bias_mean>
+                <bias_stddev>1</bias_stddev>
+                <precision>1.0</precision>
+              </noise>
+            </vertical>
+          </position_sensing>
+          <velocity_sensing>
+            <horizontal>
+              <noise type="gaussian_quantized">
+                <mean>0</mean>
+                <stddev>0.1</stddev>
+                <bias_mean>0.1</bias_mean>
+                <bias_stddev>0.1</bias_stddev>
+                <precision>0.1</precision>
+              </noise>
+            </horizontal>
+            <vertical>
+              <noise type="gaussian_quantized">
+                <mean>0</mean>
+                <stddev>0.2</stddev>
+                <bias_mean>0.2</bias_mean>
+                <bias_stddev>0.2</bias_stddev>
+                <precision>0.2</precision>
+              </noise>
+            </vertical>
+          </velocity_sensing>
+        </gps> -->
         <plugin name="gps_plugin" filename="libgazebo_gps_plugin.so">
           <robotNamespace></robotNamespace>
           <gpsNoise>true</gpsNoise>

--- a/models/gps/gps.sdf
+++ b/models/gps/gps.sdf
@@ -33,6 +33,12 @@
         <plugin name="gps_plugin" filename="libgazebo_gps_plugin.so">
           <robotNamespace></robotNamespace>
           <gpsNoise>true</gpsNoise>
+          <gpsXYRandomWalk>2.0</gpsXYRandomWalk>
+          <gpsZRandomWalk>4.0</gpsZRandomWalk>
+          <gpsXYNoiseDensity>2.0e-4</gpsXYNoiseDensity>
+          <gpsZNoiseDensity>4.0e-4</gpsZNoiseDensity>
+          <gpsVXYNoiseDensity>0.2</gpsVXYNoiseDensity>
+          <gpsVZNoiseDensity>0.4</gpsVZNoiseDensity>
         </plugin>
       </sensor>
     </link>

--- a/models/gps/gps.sdf
+++ b/models/gps/gps.sdf
@@ -1,0 +1,40 @@
+<?xml version="1.0" ?>
+<sdf version="1.6">
+  <model name="gps">
+    <link name="link">
+      <pose>0 0 0 0 0 0</pose>
+      <inertial>
+        <pose>0 0 0 0 0 0</pose>
+        <mass>0.01</mass>
+        <inertia>
+          <ixx>2.1733e-6</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>2.1733e-6</iyy>
+          <iyz>0</iyz>
+          <izz>1.8e-7</izz>
+        </inertia>
+      </inertial>
+      <visual name="visual">
+        <geometry>
+          <cylinder>
+            <radius>0.01</radius>
+            <length>0.002</length>
+          </cylinder>
+        </geometry>
+        <material>
+          <script>
+            <name>Gazebo/Black</name>
+          </script>
+        </material>
+      </visual>
+      <sensor name="gps" type="gps">
+        <pose>0 0 0 0 0 0</pose>
+        <plugin name="gps_plugin" filename="libgazebo_gps_plugin.so">
+          <robotNamespace></robotNamespace>
+          <gpsNoise>true</gpsNoise>
+        </plugin>
+      </sensor>
+    </link>
+  </model>
+</sdf>

--- a/models/gps/model.config
+++ b/models/gps/model.config
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<model>
+  <name>GPS</name>
+  <version>1.0</version>
+  <sdf version='1.6'>gps.sdf</sdf>
+
+  <author>
+   <name>Nuno Marques</name>
+   <email>nuno.marques@dronesolutions.io</email>
+  </author>
+
+  <description>
+    Common GPS model.
+  </description>
+</model>

--- a/models/if750a/if750a.sdf
+++ b/models/if750a/if750a.sdf
@@ -354,6 +354,24 @@
       <linkName>base_link</linkName>
       <rotorVelocitySlowdownSim>10</rotorVelocitySlowdownSim>
     </plugin>
+    <include>
+      <uri>model://gps</uri>
+      <pose>-0.01 0.173 0.47 0 0 0</pose>
+      <name>gps0</name>
+    </include>
+    <joint name='gps0_joint' type='fixed'>
+      <child>gps0::link</child>
+      <parent>base_link</parent>
+    </joint>
+    <include>
+      <uri>model://gps</uri>
+      <pose>0.001 -0.173 0.47 0 0 0</pose>
+      <name>gps1</name>
+    </include>
+    <joint name='gps1_joint' type='fixed'>
+      <child>gps1::link</child>
+      <parent>base_link</parent>
+    </joint>
     <plugin name='front_right_motor_model' filename='libgazebo_motor_model.so'>
       <robotNamespace/>
       <jointName>rotor_0_joint</jointName>
@@ -422,10 +440,6 @@
       <motorSpeedPubTopic>/motor_speed/3</motorSpeedPubTopic>
       <rotorVelocitySlowdownSim>10</rotorVelocitySlowdownSim>
     </plugin>
-    <plugin name='gps_plugin' filename='libgazebo_gps_plugin.so'>
-      <robotNamespace/>
-      <gpsNoise>true</gpsNoise>
-    </plugin>
     <plugin name='magnetometer_plugin' filename='libgazebo_magnetometer_plugin.so'>
       <robotNamespace/>
       <pubRate>100</pubRate>
@@ -447,7 +461,6 @@
     <plugin name='mavlink_interface' filename='libgazebo_mavlink_interface.so'>
       <robotNamespace/>
       <imuSubTopic>/imu</imuSubTopic>
-      <gpsSubTopic>/gps</gpsSubTopic>
       <magSubTopic>/mag</magSubTopic>
       <baroSubTopic>/baro</baroSubTopic>
       <mavlink_addr>INADDR_ANY</mavlink_addr>

--- a/models/if750a/if750a.sdf
+++ b/models/if750a/if750a.sdf
@@ -440,6 +440,9 @@
       <motorSpeedPubTopic>/motor_speed/3</motorSpeedPubTopic>
       <rotorVelocitySlowdownSim>10</rotorVelocitySlowdownSim>
     </plugin>
+    <plugin name='groundtruth_plugin' filename='libgazebo_groundtruth_plugin.so'>
+      <robotNamespace/>
+    </plugin>
     <plugin name='magnetometer_plugin' filename='libgazebo_magnetometer_plugin.so'>
       <robotNamespace/>
       <pubRate>100</pubRate>

--- a/models/iris_dual_gps/iris_dual_gps.sdf
+++ b/models/iris_dual_gps/iris_dual_gps.sdf
@@ -1,0 +1,19 @@
+<sdf version='1.6'>
+  <model name='iris_dual_gps'>
+    <include>
+      <uri>model://iris</uri>
+    </include>
+    <!--second GPS-->
+    <include>
+      <uri>model://gps</uri>
+      <pose>-0.1 0 0 0 0 0</pose>
+      <name>gps1</name>
+    </include>
+    <joint name='gps1_joint' type='fixed'>
+      <child>gps1::link</child>
+      <parent>iris::base_link</parent>
+    </joint>
+  </model>
+</sdf>
+
+<!-- vim: set et ft=xml fenc=utf-8 ff=unix sts=0 sw=2 ts=2 : -->

--- a/models/iris_dual_gps/model.config
+++ b/models/iris_dual_gps/model.config
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<model>
+  <name>3DR Iris two GPS modules</name>
+  <version>1.0</version>
+  <sdf version='1.6'>iris_dual_gps.sdf</sdf>
+
+  <author>
+   <name>Nuno Marques</name>
+   <email>nuno.marques@dronesolutions.io</email>
+  </author>
+
+  <description>
+    This is a model of the 3DR Iris Quadrotor with two GPS modules. The original
+    model has been created by Thomas Gubler and is maintained by Lorenz Meier.
+  </description>
+</model>

--- a/models/matrice_100/matrice_100.sdf.jinja
+++ b/models/matrice_100/matrice_100.sdf.jinja
@@ -273,9 +273,8 @@
       <!--<sonar_topic>fuselage/mb1240-xl-ez4/link/sonar</sonar_topic>-->
     <!--</plugin>-->
 
-    <plugin name="gps_plugin" filename="libgazebo_gps_plugin.so">
-        <robotNamespace></robotNamespace>
-        <gpsNoise>true</gpsNoise>
+    <plugin name='groundtruth_plugin' filename='libgazebo_groundtruth_plugin.so'>
+      <robotNamespace/>
     </plugin>
 
     <plugin name='magnetometer_plugin' filename='libgazebo_magnetometer_plugin.so'>

--- a/models/plane/plane.sdf
+++ b/models/plane/plane.sdf
@@ -454,6 +454,15 @@
         </ode>
       </physics>
     </joint>
+    <include>
+      <uri>model://gps</uri>
+      <pose>0 0 0 0 0 0</pose>
+      <name>gps</name>
+    </include>
+    <joint name='gps_joint' type='fixed'>
+      <child>gps::link</child>
+      <parent>base_link</parent>
+    </joint>
     <plugin name="left_wing" filename="libLiftDragPlugin.so">
       <a0>0.05984281113</a0>
       <cla>4.752798721</cla>
@@ -627,10 +636,6 @@
       <windGustVelocityMean>0</windGustVelocityMean>
       <windPubTopic>/wind</windPubTopic>
     </plugin>
-    <plugin name="gps_plugin" filename="libgazebo_gps_plugin.so">
-        <robotNamespace></robotNamespace>
-        <gpsNoise>true</gpsNoise>
-    </plugin>
     <plugin name='magnetometer_plugin' filename='libgazebo_magnetometer_plugin.so'>
       <robotNamespace/>
       <pubRate>100</pubRate>
@@ -647,7 +652,6 @@
     <plugin name='mavlink_interface' filename='libgazebo_mavlink_interface.so'>
       <robotNamespace></robotNamespace>
       <imuSubTopic>/imu</imuSubTopic>
-      <gpsSubTopic>/gps</gpsSubTopic>
       <magSubTopic>/mag</magSubTopic>
       <baroSubTopic>/baro</baroSubTopic>
       <mavlink_addr>INADDR_ANY</mavlink_addr>

--- a/models/plane/plane.sdf
+++ b/models/plane/plane.sdf
@@ -636,6 +636,9 @@
       <windGustVelocityMean>0</windGustVelocityMean>
       <windPubTopic>/wind</windPubTopic>
     </plugin>
+    <plugin name='groundtruth_plugin' filename='libgazebo_groundtruth_plugin.so'>
+      <robotNamespace/>
+    </plugin>
     <plugin name='magnetometer_plugin' filename='libgazebo_magnetometer_plugin.so'>
       <robotNamespace/>
       <pubRate>100</pubRate>

--- a/models/px4vision/px4vision.sdf
+++ b/models/px4vision/px4vision.sdf
@@ -344,6 +344,15 @@
         <use_parent_model_frame>1</use_parent_model_frame>
       </axis>
     </joint>
+    <include>
+      <uri>model://gps</uri>
+      <pose>0 0 0.12 0 0 0</pose>
+      <name>gps</name>
+    </include>
+    <joint name='gps_joint' type='fixed'>
+      <child>gps::link</child>
+      <parent>base_link</parent>
+    </joint>
     <plugin name='rosbag' filename='libgazebo_multirotor_base_plugin.so'>
       <robotNamespace/>
       <linkName>base_link</linkName>
@@ -417,9 +426,8 @@
       <motorSpeedPubTopic>/motor_speed/3</motorSpeedPubTopic>
       <rotorVelocitySlowdownSim>10</rotorVelocitySlowdownSim>
     </plugin>
-    <plugin name='gps_plugin' filename='libgazebo_gps_plugin.so'>
+    <plugin name='groundtruth_plugin' filename='libgazebo_groundtruth_plugin.so'>
       <robotNamespace/>
-      <gpsNoise>1</gpsNoise>
     </plugin>
     <plugin name='magnetometer_plugin' filename='libgazebo_magnetometer_plugin.so'>
       <robotNamespace/>

--- a/models/r1_rover/r1_rover.sdf
+++ b/models/r1_rover/r1_rover.sdf
@@ -458,6 +458,15 @@
         <use_parent_model_frame>1</use_parent_model_frame>
       </axis>
     </joint>
+    <include>
+      <uri>model://gps</uri>
+      <pose>0 0 0.12 0 0 0</pose>
+      <name>gps</name>
+    </include>
+    <joint name='gps_joint' type='fixed'>
+      <child>gps::link</child>
+      <parent>base_link</parent>
+    </joint>
     <plugin name='gazebo_imu_plugin' filename='libgazebo_imu_plugin.so'>
       <robotNamespace></robotNamespace>
       <linkName>rover/imu_link</linkName>
@@ -470,10 +479,6 @@
       <accelerometerRandomWalk>0.006</accelerometerRandomWalk>
       <accelerometerBiasCorrelationTime>300.0</accelerometerBiasCorrelationTime>
       <accelerometerTurnOnBiasSigma>0.196</accelerometerTurnOnBiasSigma>
-    </plugin>
-    <plugin name="gps_plugin" filename="libgazebo_gps_plugin.so">
-        <robotNamespace></robotNamespace>
-        <gpsNoise>true</gpsNoise>
     </plugin>
     <plugin name='magnetometer_plugin' filename='libgazebo_magnetometer_plugin.so'>
       <robotNamespace/>
@@ -491,7 +496,6 @@
     <plugin name='mavlink_interface' filename='libgazebo_mavlink_interface.so'>
       <robotNamespace></robotNamespace>
       <imuSubTopic>/imu</imuSubTopic>
-      <gpsSubTopic>/gps</gpsSubTopic>
       <magSubTopic>/mag</magSubTopic>
       <baroSubTopic>/baro</baroSubTopic>
       <mavlink_addr>INADDR_ANY</mavlink_addr>
@@ -581,7 +585,7 @@
             <cmdMin>-1200</cmdMin>
           </joint_control_pid>
         </channel>
-      </control_channels> 
+      </control_channels>
     </plugin>
     <!-- <plugin name='skid_steer_drive_controller' filename='libgazebo_ros_skid_steer_drive.so'>
       <updateRate>50.0</updateRate>

--- a/models/r1_rover/r1_rover.sdf
+++ b/models/r1_rover/r1_rover.sdf
@@ -480,6 +480,9 @@
       <accelerometerBiasCorrelationTime>300.0</accelerometerBiasCorrelationTime>
       <accelerometerTurnOnBiasSigma>0.196</accelerometerTurnOnBiasSigma>
     </plugin>
+    <plugin name='groundtruth_plugin' filename='libgazebo_groundtruth_plugin.so'>
+      <robotNamespace/>
+    </plugin>
     <plugin name='magnetometer_plugin' filename='libgazebo_magnetometer_plugin.so'>
       <robotNamespace/>
       <pubRate>20</pubRate>

--- a/models/rotors_description/urdf/component_snippets.xacro
+++ b/models/rotors_description/urdf/component_snippets.xacro
@@ -62,9 +62,9 @@
           </sensor>
         </link>
       </model>
-      <joint name="gps_joint" type="fixed">
+      <joint name="${gps_name}_joint" type="fixed">
         <parent>${parent_link}</parent>
-        <child>gps::link</child>
+        <child>${gps_name}::link</child>
       </joint>
     </gazebo>
   </xacro:macro>

--- a/models/rotors_description/urdf/component_snippets.xacro
+++ b/models/rotors_description/urdf/component_snippets.xacro
@@ -5,6 +5,7 @@
   Copyright 2015 Mina Kamel, ASL, ETH Zurich, Switzerland
   Copyright 2015 Janosch Nikolic, ASL, ETH Zurich, Switzerland
   Copyright 2015 Markus Achtelik, ASL, ETH Zurich, Switzerland
+  Copyright 2015-2020 PX4 Development Team. All rights reserved.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -20,6 +21,54 @@
 -->
 
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
+  <!-- Macro to a add a GPS sensor. -->
+  <xacro:macro name="gps_macro"
+    params="gps_name pos_x pos_y pos_z gps_noise namespace parent_link">
+    <gazebo>
+      <model name="${gps_name}">
+        <link name="link">
+          <pose>${pos_x} ${pos_y} ${pos_z} 0 0 0</pose>
+          <inertial>
+            <pose>0 0 0 0 0 0</pose>
+            <mass>0.01</mass>
+            <inertia>
+              <ixx>2.1733e-6</ixx>
+              <ixy>0</ixy>
+              <ixz>0</ixz>
+              <iyy>2.1733e-6</iyy>
+              <iyz>0</iyz>
+              <izz>1.8e-7</izz>
+            </inertia>
+          </inertial>
+          <visual name="visual">
+            <geometry>
+              <cylinder>
+                <radius>0.01</radius>
+                <length>0.002</length>
+              </cylinder>
+            </geometry>
+            <material>
+              <script>
+                <name>Gazebo/Black</name>
+              </script>
+            </material>
+          </visual>
+          <sensor name="gps" type="gps">
+            <pose>0 0 0 0 0 0</pose>
+            <plugin name="gps_plugin" filename="libgazebo_gps_plugin.so">
+              <robotNamespace>${namespace}</robotNamespace>
+              <gpsNoise>${gps_noise}</gpsNoise>
+            </plugin>
+          </sensor>
+        </link>
+      </model>
+      <joint name="gps_joint" type="fixed">
+        <parent>${parent_link}</parent>
+        <child>gps::link</child>
+      </joint>
+    </gazebo>
+  </xacro:macro>
+
   <!-- Macro to add logging to a bag file. -->
   <xacro:macro name="bag_plugin_macro"
     params="namespace bag_file rotor_velocity_slowdown_sim">
@@ -124,16 +173,6 @@
     </gazebo>
   </xacro:macro>
 
-  <!-- Macro to add the gps_plugin. -->
-  <xacro:macro name="gps_plugin_macro" params="namespace gps_noise">
-    <gazebo>
-      <plugin name="gps_plugin" filename="libgazebo_gps_plugin.so">
-        <robotNamespace>${namespace}</robotNamespace>
-        <gpsNoise>${gps_noise}</gpsNoise>
-      </plugin>
-    </gazebo>
-  </xacro:macro>
-
   <!-- Macro to add the magnetometer_plugin. -->
   <xacro:macro name="magnetometer_plugin_macro" params="namespace pub_rate noise_density random_walk bias_correlation_time mag_topic">
     <gazebo>
@@ -160,12 +199,11 @@
   </xacro:macro>
 
   <!-- Macro to add the mavlink interface. -->
-  <xacro:macro name="mavlink_interface_macro" params="namespace imu_sub_topic gps_sub_topic mag_sub_topic baro_sub_topic mavlink_addr mavlink_udp_port mavlink_tcp_port serial_enabled serial_device baudrate qgc_addr qgc_udp_port sdk_addr sdk_udp_port hil_mode hil_state_level vehicle_is_tailsitter send_vision_estimation send_odometry enable_lockstep use_tcp">
+  <xacro:macro name="mavlink_interface_macro" params="namespace imu_sub_topic mag_sub_topic baro_sub_topic mavlink_addr mavlink_udp_port mavlink_tcp_port serial_enabled serial_device baudrate qgc_addr qgc_udp_port sdk_addr sdk_udp_port hil_mode hil_state_level vehicle_is_tailsitter send_vision_estimation send_odometry enable_lockstep use_tcp">
     <gazebo>
       <plugin name="mavlink_interface" filename="libgazebo_mavlink_interface.so">
         <robotNamespace>${namespace}</robotNamespace>
         <imuSubTopic>${imu_sub_topic}</imuSubTopic>
-        <gpsSubTopic>${gps_sub_topic}</gpsSubTopic>
         <magSubTopic>${mag_sub_topic}</magSubTopic>
         <baroSubTopic>${baro_sub_topic}</baroSubTopic>
         <mavlink_addr>$(arg mavlink_addr)</mavlink_addr>
@@ -289,12 +327,11 @@
   </xacro:macro>
 
   <!-- Macro to add the mavlink interface for a fixed-wing model. -->
-  <xacro:macro name="mavlink_interface_macro_fw" params="namespace imu_sub_topic gps_sub_topic mag_sub_topic baro_sub_topic mavlink_addr mavlink_udp_port mavlink_tcp_port serial_enabled serial_device baudrate qgc_addr qgc_udp_port sdk_addr sdk_udp_port hil_mode hil_state_level vehicle_is_tailsitter send_vision_estimation send_odometry enable_lockstep use_tcp">
+  <xacro:macro name="mavlink_interface_macro_fw" params="namespace imu_sub_topic mag_sub_topic baro_sub_topic mavlink_addr mavlink_udp_port mavlink_tcp_port serial_enabled serial_device baudrate qgc_addr qgc_udp_port sdk_addr sdk_udp_port hil_mode hil_state_level vehicle_is_tailsitter send_vision_estimation send_odometry enable_lockstep use_tcp">
     <gazebo>
       <plugin name="mavlink_interface" filename="libgazebo_mavlink_interface.so">
         <robotNamespace>${namespace}</robotNamespace>
         <imuSubTopic>${imu_sub_topic}</imuSubTopic>
-        <gpsSubTopic>${gps_sub_topic}</gpsSubTopic>
         <magSubTopic>${mag_sub_topic}</magSubTopic>
         <baroSubTopic>${baro_sub_topic}</baroSubTopic>
         <mavlink_addr>$(arg mavlink_addr)</mavlink_addr>
@@ -367,12 +404,11 @@
   </xacro:macro>
 
   <!-- Macro to add the mavlink interface for a fixed-wing model. -->
-  <xacro:macro name="mavlink_interface_macro_vtol" params="namespace imu_sub_topic gps_sub_topic mag_sub_topic baro_sub_topic mavlink_addr mavlink_udp_port mavlink_tcp_port serial_enabled serial_device baudrate qgc_addr qgc_udp_port sdk_addr sdk_udp_port hil_mode hil_state_level vehicle_is_tailsitter send_vision_estimation send_odometry enable_lockstep use_tcp">
+  <xacro:macro name="mavlink_interface_macro_vtol" params="namespace imu_sub_topic mag_sub_topic baro_sub_topic mavlink_addr mavlink_udp_port mavlink_tcp_port serial_enabled serial_device baudrate qgc_addr qgc_udp_port sdk_addr sdk_udp_port hil_mode hil_state_level vehicle_is_tailsitter send_vision_estimation send_odometry enable_lockstep use_tcp">
     <gazebo>
       <plugin name='mavlink_interface' filename='libgazebo_mavlink_interface.so'>
         <robotNamespace>${namespace}</robotNamespace>
         <imuSubTopic>${imu_sub_topic}</imuSubTopic>
-        <gpsSubTopic>${gps_sub_topic}</gpsSubTopic>
         <magSubTopic>${mag_sub_topic}</magSubTopic>
         <baroSubTopic>${baro_sub_topic}</baroSubTopic>
         <mavlink_addr>$(arg mavlink_addr)</mavlink_addr>

--- a/models/rotors_description/urdf/component_snippets.xacro
+++ b/models/rotors_description/urdf/component_snippets.xacro
@@ -23,7 +23,9 @@
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
   <!-- Macro to a add a GPS sensor. -->
   <xacro:macro name="gps_macro"
-    params="gps_name pos_x pos_y pos_z gps_noise namespace parent_link">
+    params="gps_name pos_x pos_y pos_z namespace gps_noise gps_xy_random_walk
+            gps_z_random_walk gps_xy_noise_density gps_z_noise_density
+            gps_vxy_noise_density gps_vz_noise_density parent_link">
     <gazebo>
       <model name="${gps_name}">
         <link name="link">
@@ -58,6 +60,12 @@
             <plugin name="gps_plugin" filename="libgazebo_gps_plugin.so">
               <robotNamespace>${namespace}</robotNamespace>
               <gpsNoise>${gps_noise}</gpsNoise>
+              <gpsXYRandomWalk>${gps_xy_random_walk}</gpsXYRandomWalk>
+              <gpsZRandomWalk>${gps_z_random_walk}</gpsZRandomWalk>
+              <gpsXYNoiseDensity>${gps_xy_noise_density}</gpsXYNoiseDensity>
+              <gpsZNoiseDensity>${gps_z_noise_density}</gpsZNoiseDensity>
+              <gpsVXYNoiseDensity>${gps_vxy_noise_density}</gpsVXYNoiseDensity>
+              <gpsVZNoiseDensity>${gps_vz_noise_density}</gpsVZNoiseDensity>
             </plugin>
           </sensor>
         </link>

--- a/models/rotors_description/urdf/component_snippets.xacro
+++ b/models/rotors_description/urdf/component_snippets.xacro
@@ -181,6 +181,15 @@
     </gazebo>
   </xacro:macro>
 
+  <!-- Macro to add the groundtruth_plugin. -->
+  <xacro:macro name="groundtruth_plugin_macro" params="namespace">
+    <gazebo>
+      <plugin name='groundtruth_plugin' filename='libgazebo_groundtruth_plugin.so'>
+        <robotNamespace>${namespace}</robotNamespace>
+      </plugin>
+    </gazebo>
+  </xacro:macro>
+
   <!-- Macro to add the magnetometer_plugin. -->
   <xacro:macro name="magnetometer_plugin_macro" params="namespace pub_rate noise_density random_walk bias_correlation_time mag_topic">
     <gazebo>

--- a/models/rotors_description/urdf/fixedwing_base.xacro
+++ b/models/rotors_description/urdf/fixedwing_base.xacro
@@ -5,6 +5,7 @@
   Copyright 2015 Mina Kamel, ASL, ETH Zurich, Switzerland
   Copyright 2015 Janosch Nikolic, ASL, ETH Zurich, Switzerland
   Copyright 2015 Markus Achtelik, ASL, ETH Zurich, Switzerland
+  Copyright 2020 PX4 Development Team. All rights reserved.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -26,7 +27,7 @@
     <link name="base_link"></link>
     <joint name="base_joint" type="fixed">
       <parent link="base_link" />
-      <child link="base_link_inertial" />      
+      <child link="base_link_inertial" />
     </joint>
     <link name="base_link_inertial">
       <inertial>

--- a/models/rotors_description/urdf/iris.xacro
+++ b/models/rotors_description/urdf/iris.xacro
@@ -1,4 +1,35 @@
 <?xml version="1.0"?>
+<!--
+  -   Copyright (c) 2015-2020 PX4 Development Team. All rights reserved.
+  -
+  - Redistribution and use in source and binary forms, with or without
+  - modification, are permitted provided that the following conditions
+  - are met:
+  -
+  - 1. Redistributions of source code must retain the above copyright
+  -    notice, this list of conditions and the following disclaimer.
+  - 2. Redistributions in binary form must reproduce the above copyright
+  -    notice, this list of conditions and the following disclaimer in
+  -    the documentation and/or other materials provided with the
+  -    distribution.
+  - 3. Neither the name PX4 nor the names of its contributors may be
+  -    used to endorse or promote products derived from this software
+  -    without specific prior written permission.
+  -
+  - THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  - "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  - LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+  - FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+  - COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+  - INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+  - BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+  - OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+  - AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+  - LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+  - ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  - POSSIBILITY OF SUCH DAMAGE.
+  -
+  -->
 
 <robot name="iris" xmlns:xacro="http://ros.org/wiki/xacro">
   <!-- Properties -->
@@ -31,10 +62,10 @@
 
   <!-- Property Blocks -->
   <xacro:property name="body_inertia">
-    <inertia 
+    <inertia
     ixx="${1/12 * mass * (body_height * body_height + body_width * body_width)}"
     iyy="${1/12 * mass * (body_height * body_height + body_width * body_width)}"
-    izz="${1/12 * mass * (body_width * body_width + body_width * body_width)}"    
+    izz="${1/12 * mass * (body_width * body_width + body_width * body_width)}"
     ixy="0.0" ixz="0.0" iyz="0.0" /> <!-- [kg.m^2] [kg.m^2] [kg.m^2] [kg.m^2] [kg.m^2] [kg.m^2] -->
   </xacro:property>
 

--- a/models/rotors_description/urdf/iris_base.xacro
+++ b/models/rotors_description/urdf/iris_base.xacro
@@ -1,4 +1,35 @@
 <?xml version="1.0"?>
+<!--
+  -   Copyright (c) 2015-2020 PX4 Development Team. All rights reserved.
+  -
+  - Redistribution and use in source and binary forms, with or without
+  - modification, are permitted provided that the following conditions
+  - are met:
+  -
+  - 1. Redistributions of source code must retain the above copyright
+  -    notice, this list of conditions and the following disclaimer.
+  - 2. Redistributions in binary form must reproduce the above copyright
+  -    notice, this list of conditions and the following disclaimer in
+  -    the documentation and/or other materials provided with the
+  -    distribution.
+  - 3. Neither the name PX4 nor the names of its contributors may be
+  -    used to endorse or promote products derived from this software
+  -    without specific prior written permission.
+  -
+  - THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  - "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  - LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+  - FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+  - COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+  - INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+  - BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+  - OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+  - AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+  - LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+  - ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  - POSSIBILITY OF SUCH DAMAGE.
+  -
+  -->
 
 <robot name="iris" xmlns:xacro="http://ros.org/wiki/xacro">
   <!-- Properties that can be assigned at build time as arguments.
@@ -49,13 +80,16 @@
         />
   </xacro:if>
 
-
-  <!-- Instantiate gps plugin. -->
-  <xacro:gps_plugin_macro
-    namespace="${namespace}"
+  <!-- Mount a GPS module. -->
+  <xacro:gps_macro
+    gps_name="gps"
+    pos_x="0.015"
+    pos_y="0.0"
+    pos_z="0.0"
     gps_noise="true"
-    >
-  </xacro:gps_plugin_macro>
+    namespace=""
+    parent_link="base_link">
+  </xacro:gps_macro>
 
   <!-- Instantiate magnetometer plugin. -->
   <xacro:magnetometer_plugin_macro
@@ -81,7 +115,6 @@
   <xacro:mavlink_interface_macro
     namespace="${namespace}"
     imu_sub_topic="/imu"
-    gps_sub_topic="/gps"
     mag_sub_topic="/mag"
     baro_sub_topic="/baro"
     mavlink_addr="$(arg mavlink_addr)"

--- a/models/rotors_description/urdf/iris_base.xacro
+++ b/models/rotors_description/urdf/iris_base.xacro
@@ -97,6 +97,12 @@
     parent_link="base_link">
   </xacro:gps_macro>
 
+  <!-- Instantiate groundtruth plugin. -->
+  <xacro:groundtruth_plugin_macro
+    namespace="${namespace}"
+    >
+  </xacro:groundtruth_plugin_macro>
+
   <!-- Instantiate magnetometer plugin. -->
   <xacro:magnetometer_plugin_macro
     namespace="${namespace}"

--- a/models/rotors_description/urdf/iris_base.xacro
+++ b/models/rotors_description/urdf/iris_base.xacro
@@ -82,8 +82,8 @@
 
   <!-- Mount a GPS module. -->
   <xacro:gps_macro
-    gps_name="gps"
-    pos_x="0.015"
+    gps_name="gps0"
+    pos_x="0.0"
     pos_y="0.0"
     pos_z="0.0"
     gps_noise="true"

--- a/models/rotors_description/urdf/iris_base.xacro
+++ b/models/rotors_description/urdf/iris_base.xacro
@@ -87,6 +87,12 @@
     pos_y="0.0"
     pos_z="0.0"
     gps_noise="true"
+    gps_xy_random_walk="2.0"
+    gps_z_random_walk="4.0"
+    gps_xy_noise_density="2.0e-4"
+    gps_z_noise_density="4.0e-4"
+    gps_vxy_noise_density="0.2"
+    gps_vz_noise_density="0.4"
     namespace=""
     parent_link="base_link">
   </xacro:gps_macro>

--- a/models/rotors_description/urdf/plane.xacro
+++ b/models/rotors_description/urdf/plane.xacro
@@ -1,4 +1,35 @@
 <?xml version="1.0"?>
+<!--
+  -   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+  -
+  - Redistribution and use in source and binary forms, with or without
+  - modification, are permitted provided that the following conditions
+  - are met:
+  -
+  - 1. Redistributions of source code must retain the above copyright
+  -    notice, this list of conditions and the following disclaimer.
+  - 2. Redistributions in binary form must reproduce the above copyright
+  -    notice, this list of conditions and the following disclaimer in
+  -    the documentation and/or other materials provided with the
+  -    distribution.
+  - 3. Neither the name PX4 nor the names of its contributors may be
+  -    used to endorse or promote products derived from this software
+  -    without specific prior written permission.
+  -
+  - THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  - "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  - LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+  - FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+  - COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+  - INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+  - BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+  - OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+  - AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+  - LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+  - ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  - POSSIBILITY OF SUCH DAMAGE.
+  -
+  -->
 
 <robot name="plane" xmlns:xacro="http://ros.org/wiki/xacro">
   <!-- Properties -->
@@ -25,10 +56,10 @@
 
   <!-- Property Blocks -->
   <xacro:property name="body_inertia">
-    <inertia 
+    <inertia
     ixx="${1/12 * mass * (body_height * body_height + body_width * body_width)}"
     iyy="${1/12 * mass * (body_height * body_height + body_width * body_width)}"
-    izz="${1/12 * mass * (body_width * body_width + body_width * body_width)}"    
+    izz="${1/12 * mass * (body_width * body_width + body_width * body_width)}"
     ixy="0.0" ixz="0.0" iyz="0.0" /> <!-- [kg.m^2] [kg.m^2] [kg.m^2] [kg.m^2] [kg.m^2] [kg.m^2] -->
   </xacro:property>
 
@@ -80,7 +111,7 @@
   <!-- Instantiate multirotor_base_macro once -->
   <xacro:fixedwing_base_macro
     robot_namespace="${namespace}">
-    <origin xyz="0 0 0.0" rpy="0 0 0" />      
+    <origin xyz="0 0 0.0" rpy="0 0 0" />
   </xacro:fixedwing_base_macro>
 
   <!-- Instantiate rotors -->
@@ -128,7 +159,7 @@
     <axis xyz="0 1 0" />
     <xacro:insert_block name="left_aileron_joint_origin" />
     <xacro:insert_block name="left_aileron_mesh_origin" />
-  </xacro:control_surface> 
+  </xacro:control_surface>
 
   <!-- Right Aileron -->
   <xacro:control_surface
@@ -152,7 +183,7 @@
     <axis xyz="0 1 0" />
     <xacro:insert_block name="right_aileron_joint_origin" />
     <xacro:insert_block name="right_aileron_mesh_origin" />
-  </xacro:control_surface> 
+  </xacro:control_surface>
 
   <!-- Elevator -->
   <xacro:control_surface
@@ -176,7 +207,7 @@
     <axis xyz="0 1 0" />
       <xacro:insert_block name="elevator_joint_origin" />
     <xacro:insert_block name="elevator_mesh_origin" />
-  </xacro:control_surface> 
+  </xacro:control_surface>
 
 
   <!-- Rudder -->
@@ -201,6 +232,6 @@
     <axis xyz="0 0 1" />
     <xacro:insert_block name="rudder_joint_origin" />
     <xacro:insert_block name="rudder_mesh_origin" />
-  </xacro:control_surface> 
+  </xacro:control_surface>
 
 </robot>

--- a/models/rotors_description/urdf/plane_base.xacro
+++ b/models/rotors_description/urdf/plane_base.xacro
@@ -1,4 +1,35 @@
 <?xml version="1.0"?>
+<!--
+  -   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+  -
+  - Redistribution and use in source and binary forms, with or without
+  - modification, are permitted provided that the following conditions
+  - are met:
+  -
+  - 1. Redistributions of source code must retain the above copyright
+  -    notice, this list of conditions and the following disclaimer.
+  - 2. Redistributions in binary form must reproduce the above copyright
+  -    notice, this list of conditions and the following disclaimer in
+  -    the documentation and/or other materials provided with the
+  -    distribution.
+  - 3. Neither the name PX4 nor the names of its contributors may be
+  -    used to endorse or promote products derived from this software
+  -    without specific prior written permission.
+  -
+  - THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  - "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  - LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+  - FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+  - COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+  - INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+  - BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+  - OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+  - AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+  - LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+  - ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  - POSSIBILITY OF SUCH DAMAGE.
+  -
+  -->
 
 <robot name="plane" xmlns:xacro="http://ros.org/wiki/xacro">
   <!-- Properties that can be assigned at build time as arguments.
@@ -49,13 +80,9 @@
         />
   </xacro:if>
 
-
-  <!-- Instantiate gps plugin. -->
-  <xacro:gps_plugin_macro
-    namespace="${namespace}"
-    gps_noise="true"
-    >
-  </xacro:gps_plugin_macro>
+  <!-- Mount a GPS module. -->
+  <xacro:gps_macro parent_link="base_link">
+  </xacro:gps_macro>
 
   <!-- Instantiate magnetometer plugin. -->
   <xacro:magnetometer_plugin_macro
@@ -81,7 +108,6 @@
   <xacro:mavlink_interface_macro_fw
     namespace="${namespace}"
     imu_sub_topic="/imu"
-    gps_sub_topic="/gps"
     mag_sub_topic="/mag"
     baro_sub_topic="/baro"
     mavlink_addr="$(arg mavlink_addr)"

--- a/models/rotors_description/urdf/plane_base.xacro
+++ b/models/rotors_description/urdf/plane_base.xacro
@@ -81,7 +81,20 @@
   </xacro:if>
 
   <!-- Mount a GPS module. -->
-  <xacro:gps_macro parent_link="base_link">
+  <xacro:gps_macro
+    gps_name="gps0"
+    pos_x="0.0"
+    pos_y="0.0"
+    pos_z="0.0"
+    gps_noise="true"
+    gps_xy_random_walk="2.0"
+    gps_z_random_walk="4.0"
+    gps_xy_noise_density="2.0e-4"
+    gps_z_noise_density="4.0e-4"
+    gps_vxy_noise_density="0.2"
+    gps_vz_noise_density="0.4"
+    namespace=""
+    parent_link="base_link">
   </xacro:gps_macro>
 
   <!-- Instantiate magnetometer plugin. -->

--- a/models/rotors_description/urdf/plane_base.xacro
+++ b/models/rotors_description/urdf/plane_base.xacro
@@ -97,6 +97,12 @@
     parent_link="base_link">
   </xacro:gps_macro>
 
+  <!-- Instantiate groundtruth plugin. -->
+  <xacro:groundtruth_plugin_macro
+    namespace="${namespace}"
+    >
+  </xacro:groundtruth_plugin_macro>
+
   <!-- Instantiate magnetometer plugin. -->
   <xacro:magnetometer_plugin_macro
     namespace="${namespace}"

--- a/models/rotors_description/urdf/standard_vtol.xacro
+++ b/models/rotors_description/urdf/standard_vtol.xacro
@@ -1,4 +1,35 @@
 <?xml version="1.0"?>
+<!--
+  -   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+  -
+  - Redistribution and use in source and binary forms, with or without
+  - modification, are permitted provided that the following conditions
+  - are met:
+  -
+  - 1. Redistributions of source code must retain the above copyright
+  -    notice, this list of conditions and the following disclaimer.
+  - 2. Redistributions in binary form must reproduce the above copyright
+  -    notice, this list of conditions and the following disclaimer in
+  -    the documentation and/or other materials provided with the
+  -    distribution.
+  - 3. Neither the name PX4 nor the names of its contributors may be
+  -    used to endorse or promote products derived from this software
+  -    without specific prior written permission.
+  -
+  - THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  - "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  - LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+  - FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+  - COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+  - INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+  - BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+  - OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+  - AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+  - LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+  - ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  - POSSIBILITY OF SUCH DAMAGE.
+  -
+  -->
 
 <robot name="standard_vtol" xmlns:xacro="http://ros.org/wiki/xacro">
   <!-- Properties -->

--- a/models/rotors_description/urdf/standard_vtol_base.xacro
+++ b/models/rotors_description/urdf/standard_vtol_base.xacro
@@ -1,4 +1,35 @@
 <?xml version="1.0"?>
+<!--
+  -   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+  -
+  - Redistribution and use in source and binary forms, with or without
+  - modification, are permitted provided that the following conditions
+  - are met:
+  -
+  - 1. Redistributions of source code must retain the above copyright
+  -    notice, this list of conditions and the following disclaimer.
+  - 2. Redistributions in binary form must reproduce the above copyright
+  -    notice, this list of conditions and the following disclaimer in
+  -    the documentation and/or other materials provided with the
+  -    distribution.
+  - 3. Neither the name PX4 nor the names of its contributors may be
+  -    used to endorse or promote products derived from this software
+  -    without specific prior written permission.
+  -
+  - THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  - "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  - LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+  - FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+  - COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+  - INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+  - BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+  - OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+  - AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+  - LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+  - ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  - POSSIBILITY OF SUCH DAMAGE.
+  -
+  -->
 
 <robot name="standard_vtol" xmlns:xacro="http://ros.org/wiki/xacro">
   <!-- Properties that can be assigned at build time as arguments.
@@ -49,13 +80,9 @@
         />
   </xacro:if>
 
-
-  <!-- Instantiate gps plugin. -->
-  <xacro:gps_plugin_macro
-    namespace="${namespace}"
-    gps_noise="true"
-    >
-  </xacro:gps_plugin_macro>
+  <!-- Mount a GPS module. -->
+  <xacro:gps_macro parent_link="base_link">
+  </xacro:gps_macro>
 
   <!-- Instantiate magnetometer plugin. -->
   <xacro:magnetometer_plugin_macro
@@ -81,7 +108,6 @@
   <xacro:mavlink_interface_macro_vtol
     namespace="${namespace}"
     imu_sub_topic="/imu"
-    gps_sub_topic="/gps"
     mag_sub_topic="/mag"
     baro_sub_topic="/baro"
     mavlink_addr="$(arg mavlink_addr)"

--- a/models/rotors_description/urdf/standard_vtol_base.xacro
+++ b/models/rotors_description/urdf/standard_vtol_base.xacro
@@ -81,7 +81,20 @@
   </xacro:if>
 
   <!-- Mount a GPS module. -->
-  <xacro:gps_macro parent_link="base_link">
+  <xacro:gps_macro
+    gps_name="gps0"
+    pos_x="0.0"
+    pos_y="0.0"
+    pos_z="0.0"
+    gps_noise="true"
+    gps_xy_random_walk="2.0"
+    gps_z_random_walk="4.0"
+    gps_xy_noise_density="2.0e-4"
+    gps_z_noise_density="4.0e-4"
+    gps_vxy_noise_density="0.2"
+    gps_vz_noise_density="0.4"
+    namespace=""
+    parent_link="base_link">
   </xacro:gps_macro>
 
   <!-- Instantiate magnetometer plugin. -->

--- a/models/rotors_description/urdf/standard_vtol_base.xacro
+++ b/models/rotors_description/urdf/standard_vtol_base.xacro
@@ -97,6 +97,12 @@
     parent_link="base_link">
   </xacro:gps_macro>
 
+  <!-- Instantiate groundtruth plugin. -->
+  <xacro:groundtruth_plugin_macro
+    namespace="${namespace}"
+    >
+  </xacro:groundtruth_plugin_macro>
+
   <!-- Instantiate magnetometer plugin. -->
   <xacro:magnetometer_plugin_macro
     namespace="${namespace}"

--- a/models/rover/rover.sdf
+++ b/models/rover/rover.sdf
@@ -878,6 +878,9 @@
       <accelerometerBiasCorrelationTime>300.0</accelerometerBiasCorrelationTime>
       <accelerometerTurnOnBiasSigma>0.196</accelerometerTurnOnBiasSigma>
     </plugin>
+    <plugin name='groundtruth_plugin' filename='libgazebo_groundtruth_plugin.so'>
+      <robotNamespace/>
+    </plugin>
     <plugin name='magnetometer_plugin' filename='libgazebo_magnetometer_plugin.so'>
       <robotNamespace/>
       <pubRate>100</pubRate>

--- a/models/rover/rover.sdf
+++ b/models/rover/rover.sdf
@@ -851,6 +851,15 @@
         </ode>
       </physics>
     </joint> -->
+    <include>
+      <uri>model://gps</uri>
+      <pose>0 0 0 0 0 0</pose>
+      <name>gps</name>
+    </include>
+    <joint name='gps_joint' type='fixed'>
+      <child>gps::link</child>
+      <parent>base_link</parent>
+    </joint>
     <plugin name='barometer_plugin' filename='libgazebo_barometer_plugin.so'>
       <robotNamespace/>
       <pubRate>50</pubRate>
@@ -869,10 +878,6 @@
       <accelerometerBiasCorrelationTime>300.0</accelerometerBiasCorrelationTime>
       <accelerometerTurnOnBiasSigma>0.196</accelerometerTurnOnBiasSigma>
     </plugin>
-    <plugin name="gps_plugin" filename="libgazebo_gps_plugin.so">
-	<robotNamespace></robotNamespace>
-	<gpsNoise>true</gpsNoise>
-    </plugin>
     <plugin name='magnetometer_plugin' filename='libgazebo_magnetometer_plugin.so'>
       <robotNamespace/>
       <pubRate>100</pubRate>
@@ -884,7 +889,6 @@
     <plugin name='mavlink_interface' filename='libgazebo_mavlink_interface.so'>
       <robotNamespace></robotNamespace>
       <imuSubTopic>/imu</imuSubTopic>
-      <gpsSubTopic>/gps</gpsSubTopic>
       <magSubTopic>/mag</magSubTopic>
       <baroSubTopic>/baro</baroSubTopic>
       <mavlink_addr>INADDR_ANY</mavlink_addr>

--- a/models/solo/solo.sdf
+++ b/models/solo/solo.sdf
@@ -432,6 +432,9 @@
       <motorSpeedPubTopic>/motor_speed/3</motorSpeedPubTopic>
       <rotorVelocitySlowdownSim>10</rotorVelocitySlowdownSim>
     </plugin>
+    <plugin name='groundtruth_plugin' filename='libgazebo_groundtruth_plugin.so'>
+      <robotNamespace/>
+    </plugin>
     <plugin name='magnetometer_plugin' filename='libgazebo_magnetometer_plugin.so'>
       <robotNamespace/>
       <pubRate>100</pubRate>

--- a/models/solo/solo.sdf
+++ b/models/solo/solo.sdf
@@ -352,10 +352,20 @@
     </joint>
     <include>
       <uri>model://gps</uri>
-      <pose>0.03 0 0 0 0 0</pose>
+      <pose>0.1 0 0.01 0 0 0</pose>
+      <name>gps0</name>
     </include>
-    <joint name='gps_joint' type='fixed'>
-      <child>gps::link</child>
+    <joint name='gps0_joint' type='fixed'>
+      <child>gps0::link</child>
+      <parent>base_link</parent>
+    </joint>
+    <include>
+      <uri>model://gps</uri>
+      <pose>-0.1 0 0.01 0 0 0</pose>
+      <name>gps1</name>
+    </include>
+    <joint name='gps1_joint' type='fixed'>
+      <child>gps1::link</child>
       <parent>base_link</parent>
     </joint>
     <plugin name='rosbag' filename='libgazebo_multirotor_base_plugin.so'>

--- a/models/solo/solo.sdf
+++ b/models/solo/solo.sdf
@@ -352,20 +352,11 @@
     </joint>
     <include>
       <uri>model://gps</uri>
-      <pose>0.1 0 0.01 0 0 0</pose>
-      <name>gps0</name>
+      <pose>0.1 0 0 0 0 0</pose>
+      <name>gps</name>
     </include>
-    <joint name='gps0_joint' type='fixed'>
-      <child>gps0::link</child>
-      <parent>base_link</parent>
-    </joint>
-    <include>
-      <uri>model://gps</uri>
-      <pose>-0.1 0 0.01 0 0 0</pose>
-      <name>gps1</name>
-    </include>
-    <joint name='gps1_joint' type='fixed'>
-      <child>gps1::link</child>
+    <joint name='gps_joint' type='fixed'>
+      <child>gps::link</child>
       <parent>base_link</parent>
     </joint>
     <plugin name='rosbag' filename='libgazebo_multirotor_base_plugin.so'>

--- a/models/solo/solo.sdf
+++ b/models/solo/solo.sdf
@@ -350,6 +350,14 @@
         <use_parent_model_frame>1</use_parent_model_frame>
       </axis>
     </joint>
+    <include>
+      <uri>model://gps</uri>
+      <pose>0.03 0 0 0 0 0</pose>
+    </include>
+    <joint name='gps_joint' type='fixed'>
+      <child>gps::link</child>
+      <parent>base_link</parent>
+    </joint>
     <plugin name='rosbag' filename='libgazebo_multirotor_base_plugin.so'>
       <robotNamespace></robotNamespace>
       <linkName>base_link</linkName>
@@ -422,10 +430,6 @@
       <rollingMomentCoefficient>1e-06</rollingMomentCoefficient>
       <motorSpeedPubTopic>/motor_speed/3</motorSpeedPubTopic>
       <rotorVelocitySlowdownSim>10</rotorVelocitySlowdownSim>
-    </plugin>
-    <plugin name="gps_plugin" filename="libgazebo_gps_plugin.so">
-        <robotNamespace></robotNamespace>
-        <gpsNoise>true</gpsNoise>
     </plugin>
     <plugin name='magnetometer_plugin' filename='libgazebo_magnetometer_plugin.so'>
       <robotNamespace/>

--- a/models/standard_vtol/standard_vtol.sdf
+++ b/models/standard_vtol/standard_vtol.sdf
@@ -679,6 +679,15 @@
         </ode>
       </physics>
     </joint>
+    <include>
+      <uri>model://gps</uri>
+      <pose>0 0 0 0 0 0</pose>
+      <name>gps</name>
+    </include>
+    <joint name='gps_joint' type='fixed'>
+      <child>gps::link</child>
+      <parent>base_link</parent>
+    </joint>
     <plugin name="left_wing" filename="libLiftDragPlugin.so">
       <a0>0.05984281113</a0>
       <cla>4.752798721</cla>
@@ -853,10 +862,6 @@
       <accelerometerBiasCorrelationTime>300.0</accelerometerBiasCorrelationTime>
       <accelerometerTurnOnBiasSigma>0.196</accelerometerTurnOnBiasSigma>
     </plugin>
-    <plugin name="gps_plugin" filename="libgazebo_gps_plugin.so">
-        <robotNamespace></robotNamespace>
-        <gpsNoise>true</gpsNoise>
-    </plugin>
     <plugin name='magnetometer_plugin' filename='libgazebo_magnetometer_plugin.so'>
       <robotNamespace/>
       <pubRate>100</pubRate>
@@ -873,7 +878,6 @@
     <plugin name='mavlink_interface' filename='libgazebo_mavlink_interface.so'>
       <robotNamespace></robotNamespace>
       <imuSubTopic>/imu</imuSubTopic>
-      <gpsSubTopic>/gps</gpsSubTopic>
       <magSubTopic>/mag</magSubTopic>
       <baroSubTopic>/baro</baroSubTopic>
       <mavlink_addr>INADDR_ANY</mavlink_addr>

--- a/models/standard_vtol/standard_vtol.sdf
+++ b/models/standard_vtol/standard_vtol.sdf
@@ -862,6 +862,9 @@
       <accelerometerBiasCorrelationTime>300.0</accelerometerBiasCorrelationTime>
       <accelerometerTurnOnBiasSigma>0.196</accelerometerTurnOnBiasSigma>
     </plugin>
+    <plugin name='groundtruth_plugin' filename='libgazebo_groundtruth_plugin.so'>
+      <robotNamespace/>
+    </plugin>
     <plugin name='magnetometer_plugin' filename='libgazebo_magnetometer_plugin.so'>
       <robotNamespace/>
       <pubRate>100</pubRate>

--- a/models/tailsitter/tailsitter.sdf
+++ b/models/tailsitter/tailsitter.sdf
@@ -659,6 +659,9 @@
       <accelerometerBiasCorrelationTime>300.0</accelerometerBiasCorrelationTime>
       <accelerometerTurnOnBiasSigma>0.196</accelerometerTurnOnBiasSigma>
     </plugin>
+    <plugin name='groundtruth_plugin' filename='libgazebo_groundtruth_plugin.so'>
+      <robotNamespace/>
+    </plugin>
     <plugin name='magnetometer_plugin' filename='libgazebo_magnetometer_plugin.so'>
       <robotNamespace/>
       <pubRate>100</pubRate>

--- a/models/tailsitter/tailsitter.sdf
+++ b/models/tailsitter/tailsitter.sdf
@@ -489,6 +489,15 @@
         </ode>
       </physics>
     </joint>
+    <include>
+      <uri>model://gps</uri>
+      <pose>0 0 0.5 0 -1.57 0</pose>
+      <name>gps</name>
+    </include>
+    <joint name='gps_joint' type='fixed'>
+      <child>gps::link</child>
+      <parent>base_link</parent>
+    </joint>
     <plugin name="left_wing" filename="libLiftDragPlugin.so">
       <a0>0.05984281113</a0>
       <cla>4.752798721</cla>
@@ -650,10 +659,6 @@
       <accelerometerBiasCorrelationTime>300.0</accelerometerBiasCorrelationTime>
       <accelerometerTurnOnBiasSigma>0.196</accelerometerTurnOnBiasSigma>
     </plugin>
-    <plugin name="gps_plugin" filename="libgazebo_gps_plugin.so">
-        <robotNamespace></robotNamespace>
-        <gpsNoise>true</gpsNoise>
-    </plugin>
     <plugin name='magnetometer_plugin' filename='libgazebo_magnetometer_plugin.so'>
       <robotNamespace/>
       <pubRate>100</pubRate>
@@ -670,7 +675,6 @@
     <plugin name='mavlink_interface' filename='libgazebo_mavlink_interface.so'>
       <robotNamespace></robotNamespace>
       <imuSubTopic>/imu</imuSubTopic>
-      <gpsSubTopic>/gps</gpsSubTopic>
       <magSubTopic>/mag</magSubTopic>
       <baroSubTopic>/baro</baroSubTopic>
       <mavlink_addr>INADDR_ANY</mavlink_addr>

--- a/models/tiltrotor/tiltrotor.sdf
+++ b/models/tiltrotor/tiltrotor.sdf
@@ -1004,6 +1004,9 @@
       <accelerometerBiasCorrelationTime>300.0</accelerometerBiasCorrelationTime>
       <accelerometerTurnOnBiasSigma>0.196</accelerometerTurnOnBiasSigma>
     </plugin>
+    <plugin name='groundtruth_plugin' filename='libgazebo_groundtruth_plugin.so'>
+      <robotNamespace/>
+    </plugin>
     <plugin name='magnetometer_plugin' filename='libgazebo_magnetometer_plugin.so'>
       <robotNamespace/>
       <pubRate>100</pubRate>

--- a/models/tiltrotor/tiltrotor.sdf
+++ b/models/tiltrotor/tiltrotor.sdf
@@ -836,6 +836,17 @@
         </ode>
       </physics>
     </joint>
+
+    <include>
+      <uri>model://gps</uri>
+      <pose>0 0 0 0 0 0</pose>
+      <name>gps</name>
+    </include>
+    <joint name='gps_joint' type='fixed'>
+      <child>gps::link</child>
+      <parent>base_link</parent>
+    </joint>
+
     <plugin name="left_wing" filename="libLiftDragPlugin.so">
       <a0>0.05984281113</a0>
       <cla>4.752798721</cla>
@@ -993,10 +1004,6 @@
       <accelerometerBiasCorrelationTime>300.0</accelerometerBiasCorrelationTime>
       <accelerometerTurnOnBiasSigma>0.196</accelerometerTurnOnBiasSigma>
     </plugin>
-    <plugin name="gps_plugin" filename="libgazebo_gps_plugin.so">
-        <robotNamespace></robotNamespace>
-        <gpsNoise>true</gpsNoise>
-    </plugin>
     <plugin name='magnetometer_plugin' filename='libgazebo_magnetometer_plugin.so'>
       <robotNamespace/>
       <pubRate>100</pubRate>
@@ -1013,7 +1020,6 @@
     <plugin name='mavlink_interface' filename='libgazebo_mavlink_interface.so'>
       <robotNamespace></robotNamespace>
       <imuSubTopic>/imu</imuSubTopic>
-      <gpsSubTopic>/gps</gpsSubTopic>
       <magSubTopic>/mag</magSubTopic>
       <baroSubTopic>/baro</baroSubTopic>
       <mavlink_addr>INADDR_ANY</mavlink_addr>

--- a/models/typhoon_h480/typhoon_h480.sdf
+++ b/models/typhoon_h480/typhoon_h480.sdf
@@ -1140,6 +1140,17 @@
     </joint>
 
 
+    <include>
+      <uri>model://gps</uri>
+      <pose>0 0 0 0 0 0</pose>
+      <name>gps</name>
+    </include>
+    <joint name='gps_joint' type='fixed'>
+      <child>gps::link</child>
+      <parent>base_link</parent>
+    </joint>
+
+
     <plugin name='rosbag' filename='libgazebo_multirotor_base_plugin.so'>
       <robotNamespace></robotNamespace>
       <linkName>base_link</linkName>
@@ -1247,10 +1258,6 @@
       <motorSpeedPubTopic>/motor_speed/0</motorSpeedPubTopic>
       <rotorVelocitySlowdownSim>10</rotorVelocitySlowdownSim>
     </plugin>
-    <plugin name="gps_plugin" filename="libgazebo_gps_plugin.so">
-        <robotNamespace></robotNamespace>
-        <gpsNoise>true</gpsNoise>
-    </plugin>
     <plugin name='magnetometer_plugin' filename='libgazebo_magnetometer_plugin.so'>
       <robotNamespace/>
       <pubRate>100</pubRate>
@@ -1267,7 +1274,6 @@
     <plugin name='mavlink_interface' filename='libgazebo_mavlink_interface.so'>
       <robotNamespace></robotNamespace>
       <imuSubTopic>/imu</imuSubTopic>
-      <gpsSubTopic>/gps</gpsSubTopic>
       <magSubTopic>/mag</magSubTopic>
       <baroSubTopic>/baro</baroSubTopic>
       <mavlink_addr>INADDR_ANY</mavlink_addr>

--- a/models/typhoon_h480/typhoon_h480.sdf
+++ b/models/typhoon_h480/typhoon_h480.sdf
@@ -1258,6 +1258,9 @@
       <motorSpeedPubTopic>/motor_speed/0</motorSpeedPubTopic>
       <rotorVelocitySlowdownSim>10</rotorVelocitySlowdownSim>
     </plugin>
+    <plugin name='groundtruth_plugin' filename='libgazebo_groundtruth_plugin.so'>
+      <robotNamespace/>
+    </plugin>
     <plugin name='magnetometer_plugin' filename='libgazebo_magnetometer_plugin.so'>
       <robotNamespace/>
       <pubRate>100</pubRate>

--- a/models/uuv_hippocampus/uuv_hippocampus.sdf
+++ b/models/uuv_hippocampus/uuv_hippocampus.sdf
@@ -472,6 +472,10 @@
       <rotorVelocitySlowdownSim>0.05</rotorVelocitySlowdownSim>
     </plugin>
 
+    <plugin name='groundtruth_plugin' filename='libgazebo_groundtruth_plugin.so'>
+      <robotNamespace/>
+    </plugin>
+
     <!--
       propXlinks receive relative force from uuv_plugin
       baselink receives relative torque

--- a/models/uuv_hippocampus/uuv_hippocampus.sdf
+++ b/models/uuv_hippocampus/uuv_hippocampus.sdf
@@ -452,6 +452,17 @@
       </axis>
     </joint>
 
+<!-- GPS -->
+    <include>
+      <uri>model://gps</uri>
+      <pose>0 0 0 0 0 0</pose>
+      <name>gps</name>
+    </include>
+    <joint name='gps_joint' type='fixed'>
+      <child>gps::link</child>
+      <parent>base_link</parent>
+    </joint>
+
 <!-- Plugins -->
     <static>0</static>
 
@@ -560,11 +571,6 @@
       <rotorVelocitySlowdownSim>0.05</rotorVelocitySlowdownSim>
     </plugin>
 
-    <plugin name="gps_plugin" filename="libgazebo_gps_plugin.so">
-        <robotNamespace/>
-        <gpsNoise>true</gpsNoise>
-    </plugin>
-
     <plugin name='magnetometer_plugin' filename='libgazebo_magnetometer_plugin.so'>
       <robotNamespace/>
       <pubRate>100</pubRate>
@@ -583,7 +589,6 @@
     <plugin name='mavlink_interface' filename='libgazebo_mavlink_interface.so'>
       <robotNamespace/>
       <imuSubTopic>/imu</imuSubTopic>
-      <gpsSubTopic>/gps</gpsSubTopic>
       <magSubTopic>/mag</magSubTopic>
       <baroSubTopic>/baro</baroSubTopic>
       <mavlink_addr>INADDR_ANY</mavlink_addr>

--- a/src/gazebo_gps_plugin.cpp
+++ b/src/gazebo_gps_plugin.cpp
@@ -33,7 +33,7 @@ using namespace std;
 namespace gazebo {
 GZ_REGISTER_SENSOR_PLUGIN(GpsPlugin)
 
-GpsPlugin::GpsPlugin()
+GpsPlugin::GpsPlugin() : SensorPlugin()
 { }
 
 GpsPlugin::~GpsPlugin()
@@ -295,7 +295,6 @@ void GpsPlugin::OnWorldUpdate(const common::UpdateInfo& /*_info*/)
   gps_msg.set_latitude_deg(latlon.first * 180.0 / M_PI);
   gps_msg.set_longitude_deg(latlon.second * 180.0 / M_PI);
   gps_msg.set_altitude(pos_W_I.Z() + alt_home_ - noise_gps_pos.Z() + gps_bias.Z());
-  gps_msg.set_longitude_deg(latlon.second * 180.0 / M_PI);
 
   std_xy = 1.0;
   std_z = 1.0;

--- a/src/gazebo_groundtruth_plugin.cpp
+++ b/src/gazebo_groundtruth_plugin.cpp
@@ -1,0 +1,173 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+/**
+ * @brief Groundtruth Plugin
+ *
+ * This plugin gets and publishes ground-truth data
+ *
+ * @author Nuno Marques <nuno.marques@dronesolutions.io>
+ */
+
+#include <gazebo_groundtruth_plugin.h>
+
+namespace gazebo
+{
+GZ_REGISTER_MODEL_PLUGIN(GroundtruthPlugin)
+
+GroundtruthPlugin::GroundtruthPlugin() : ModelPlugin()
+{ }
+
+GroundtruthPlugin::~GroundtruthPlugin()
+{
+  if (updateConnection_)
+    updateConnection_->~Connection();
+  world_->Reset();
+}
+
+void GroundtruthPlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf)
+{
+  // Store the ptr to the model
+  model_ = _model;
+
+  // Store the ptr to the world
+  world_ = model_->GetWorld();
+
+  // Use environment variables if set for home position.
+  const char *env_lat = std::getenv("PX4_HOME_LAT");
+  const char *env_lon = std::getenv("PX4_HOME_LON");
+  const char *env_alt = std::getenv("PX4_HOME_ALT");
+
+  // Check if the world spherical coordinates are set and use them in that case
+  const bool world_has_origin = checkWorldHomePosition(world_, world_latitude_, world_longitude_, world_altitude_);
+
+  if (env_lat) {
+    lat_home_ = std::stod(env_lat) * M_PI / 180.0;
+    gzmsg << "Home latitude is set to " << std::stod(env_lat) << ".\n";
+  } else if (world_has_origin) {
+    lat_home_ = world_latitude_;
+    gzmsg << "[gazebo_groundtruth_plugin] Home latitude is set to " << lat_home_ << ".\n";
+  } else if(_sdf->HasElement("homeLatitude")) {
+    double latitude;
+    getSdfParam<double>(_sdf, "homeLatitude", latitude, lat_home_);
+    lat_home_ = latitude * M_PI / 180.0;
+  }
+
+  if (env_lon) {
+    lon_home_ = std::stod(env_lon) * M_PI / 180.0;
+    gzmsg << "Home longitude is set to " << std::stod(env_lon) << ".\n";
+  } else if (world_has_origin) {
+    lon_home_ = world_longitude_;
+    gzmsg << "[gazebo_groundtruth_plugin] Home longitude is set to " << lon_home_ << ".\n";
+  } else if(_sdf->HasElement("homeLongitude")) {
+    double longitude;
+    getSdfParam<double>(_sdf, "homeLongitude", longitude, lon_home_);
+    lon_home_ = longitude * M_PI / 180.0;
+  }
+
+  if (env_alt) {
+    alt_home_ = std::stod(env_alt);
+    gzmsg << "Home altitude is set to " << alt_home_ << ".\n";
+  } else if (world_has_origin) {
+    alt_home_ = world_altitude_;
+    gzmsg << "[gazebo_groundtruth_plugin] Home altitude is set to " << alt_home_ << ".\n";
+  } else if(_sdf->HasElement("homeAltitude")) {
+    getSdfParam<double>(_sdf, "homeAltitude", alt_home_, alt_home_);
+  }
+
+  namespace_.clear();
+  if (_sdf->HasElement("robotNamespace")) {
+    namespace_ = _sdf->GetElement("robotNamespace")->Get<std::string>();
+  } else {
+    gzerr << "[gazebo_groundtruth_plugin] Please specify a robotNamespace.\n";
+  }
+
+  node_handle_ = transport::NodePtr(new transport::Node());
+  node_handle_->Init(namespace_);
+
+  // Listen to the update event. This event is broadcast every simulation iteration.
+  updateConnection_ = event::Events::ConnectWorldUpdateBegin(
+      boost::bind(&GroundtruthPlugin::OnUpdate, this, _1));
+
+  gt_pub_ = node_handle_->Advertise<sensor_msgs::msgs::Groundtruth>("~/" + model_->GetName() + "/groundtruth", 10);
+}
+
+void GroundtruthPlugin::OnUpdate(const common::UpdateInfo&)
+{
+#if GAZEBO_MAJOR_VERSION >= 9
+  common::Time current_time = world_->SimTime();
+#else
+  common::Time current_time = world_->GetSimTime();
+#endif
+
+#if GAZEBO_MAJOR_VERSION >= 9
+  ignition::math::Pose3d T_W_I = model_->WorldPose();
+#else
+  ignition::math::Pose3d T_W_I = ignitionFromGazeboMath(model_->GetWorldPose());
+#endif
+  // Use the models world position and attitude for groundtruth
+  ignition::math::Vector3d& pos_W_I = T_W_I.Pos();
+  ignition::math::Quaterniond& att_W_I = T_W_I.Rot();
+
+  // reproject position into geographic coordinates
+  auto latlon_gt = reproject(pos_W_I, lat_home_, lon_home_, alt_home_);
+
+  // Use the models' world position for groundtruth velocity.
+#if GAZEBO_MAJOR_VERSION >= 9
+  ignition::math::Vector3d velocity_current_W = model_->WorldLinearVel();
+#else
+  ignition::math::Vector3d velocity_current_W = ignitionFromGazeboMath(model_->GetWorldLinearVel());
+#endif
+
+  ignition::math::Vector3d velocity_current_W_xy = velocity_current_W;
+  velocity_current_W_xy.Z() = 0;
+
+  // fill Groundtruth msg
+  sensor_msgs::msgs::Groundtruth groundtruth_msg;
+
+  groundtruth_msg.set_time_usec(current_time.Double() * 1e6);
+  groundtruth_msg.set_latitude_rad(latlon_gt.first);
+  groundtruth_msg.set_longitude_rad(latlon_gt.second);
+  groundtruth_msg.set_altitude(pos_W_I.Z() + alt_home_);
+  groundtruth_msg.set_velocity_east(velocity_current_W.X());
+  groundtruth_msg.set_velocity_north(velocity_current_W.Y());
+  groundtruth_msg.set_velocity_up(velocity_current_W.Z());
+  groundtruth_msg.set_attitude_q_w(att_W_I.W());
+  groundtruth_msg.set_attitude_q_x(att_W_I.X());
+  groundtruth_msg.set_attitude_q_y(att_W_I.Y());
+  groundtruth_msg.set_attitude_q_z(att_W_I.Z());
+
+  // publish Groundtruth msg at full sim rate
+  gt_pub_->Publish(groundtruth_msg);
+}
+
+} // namespace gazebo

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -32,8 +32,10 @@ endfunction(add_unit_test)
     target_link_libraries(gazebo_gimbal_controller_plugin_test gazebo_gimbal_controller_plugin)
 
     # GPS plugin
-    add_unit_test(gazebo_gps_plugin_test gazebo_gps_plugin_test.cpp)
-    target_link_libraries(gazebo_gps_plugin_test gazebo_gps_plugin)
+    # TODO: as by 15/06/2020, the reproject function was moved to common.h
+    # which means that this unit test needs to be refactored
+    # add_unit_test(gazebo_gps_plugin_test gazebo_gps_plugin_test.cpp)
+    # target_link_libraries(gazebo_gps_plugin_test gazebo_gps_plugin)
 
 
 endif(ENABLE_UNIT_TESTS OR CATKIN_ENABLE_TESTING)


### PR DESCRIPTION
This PR adds the possibility of sending data of multiple GPS's by:
1. Make the GPS it's own model to be integrated in the aircraft models;
2. Make the `gazebo_gps_plugin` a sensor plugin instead of a model plugin;
3. Identify the sensor ID based on the GPS model naming.

Tested with the solo model, but soon to be extended to the other aircraft models as well.

This will also serve as a template to the other sensors (IMU's, mags, etc) so to add the ability of loading them as individual models and add a subscription per sensor, allowing multi-sensor stream to the SITL side. This PR will also follow an addition of an Iris model with dual GPS, so one can test GPS blending in PX4.

@bresch @RomanBapst @MaEtUgR FYI.