### PR TITLE
Add pitching moment control via control surfaces

### DIFF
--- a/include/liftdrag_plugin/liftdrag_plugin.h
+++ b/include/liftdrag_plugin/liftdrag_plugin.h
@@ -84,6 +84,9 @@ namespace gazebo
     /// \brief Cm-alpha rate after stall
     protected: double cmaStall;
 
+    /// \breif Coefficient of Moment / control surface deflection angle slope
+    protected: double cm_delta;
+
     /// \brief: \TODO: make a stall velocity curve
     protected: double velocityStall;
 

--- a/models/tailsitter/tailsitter.sdf
+++ b/models/tailsitter/tailsitter.sdf
@@ -410,20 +410,6 @@
         <pose>0 -0.3 -0.3 0.00 0 0.0</pose>
       </inertial>
     </link>
-    <link name="elevator">
-      <inertial>
-        <mass>0.00000001</mass>
-        <inertia>
-          <ixx>0.000001</ixx>
-          <ixy>0.0</ixy>
-          <iyy>0.000001</iyy>
-          <ixz>0.0</ixz>
-          <iyz>0.0</iyz>
-          <izz>0.000001</izz>
-        </inertia>
-        <pose>0 0 -0.5 0.00 0 0.0</pose>
-      </inertial>
-    </link>
     <link name="rudder">
       <inertial>
         <mass>0.00000001</mass>
@@ -480,27 +466,6 @@
         </ode>
       </physics>
     </joint>
-    <joint name='elevator_joint' type='revolute'>
-      <parent>base_link</parent>
-      <child>elevator</child>
-      <pose>0 0 -0.5 0.00 0 0.0</pose>
-      <axis>
-        <xyz>0 1 0</xyz>
-        <limit>
-          <!-- -30/+30 deg. -->
-          <lower>-0.53</lower>
-          <upper>0.53</upper>
-        </limit>
-        <dynamics>
-          <damping>1.000</damping>
-        </dynamics>
-      </axis>
-      <physics>
-        <ode>
-          <implicit_spring_damper>1</implicit_spring_damper>
-        </ode>
-      </physics>
-    </joint>
     <joint name='rudder_joint' type='revolute'>
       <parent>base_link</parent>
       <child>rudder</child>
@@ -531,6 +496,7 @@
       <cla_stall>-3.85</cla_stall>
       <cda_stall>-0.9233984055</cda_stall>
       <cma_stall>0</cma_stall>
+      <cm_delta>-0.573</cm_delta>
       <cp>0 0.3 0.0</cp>
       <area>0.15</area>
       <air_density>1.2041</air_density>
@@ -553,6 +519,7 @@
       <cla_stall>-3.85</cla_stall>
       <cda_stall>-0.9233984055</cda_stall>
       <cma_stall>0</cma_stall>
+      <cm_delta>-0.573</cm_delta>
       <cp>0 -0.3 -0.0</cp>
       <area>0.15</area>
       <air_density>1.2041</air_density>
@@ -563,27 +530,6 @@
         right_elevon_joint
       </control_joint_name>
       <control_joint_rad_to_cl>-0.5</control_joint_rad_to_cl>
-      <robotNamespace></robotNamespace>
-      <windSubTopic>/wind</windSubTopic>
-    </plugin>
-    <plugin name="elevator" filename="libLiftDragPlugin.so">
-      <a0>0.05984281113</a0>
-      <cla>4.752798721</cla>
-      <cda>0.6417112299</cda>
-      <cma>0.0</cma>
-      <alpha_stall>0.7391428111</alpha_stall>
-      <cla_stall>-3.85</cla_stall>
-      <cda_stall>-0.9233984055</cda_stall>
-      <cma_stall>0</cma_stall>
-      <cp>0 0 -0.5</cp>
-      <area>0.005</area>
-      <air_density>1.2041</air_density>
-      <forward>0 0 1</forward>
-      <upward>-1 0 0</upward>
-      <link_name>base_link</link_name>
-      <control_joint_name>
-        elevator_joint
-      </control_joint_name>
       <robotNamespace></robotNamespace>
       <windSubTopic>/wind</windSubTopic>
     </plugin>
@@ -787,15 +733,6 @@
           <joint_control_type>position_kinematic</joint_control_type>
           <joint_name>right_elevon_joint</joint_name>
         </channel>
-        <channel name="elevator">
-          <input_index>7</input_index>
-          <input_offset>0</input_offset>
-          <input_scaling>1</input_scaling>
-          <zero_position_disarmed>0</zero_position_disarmed>
-          <zero_position_armed>0</zero_position_armed>
-          <joint_control_type>position_kinematic</joint_control_type>
-          <joint_name>elevator_joint</joint_name>
-        </channel>
       </control_channels>
       <left_elevon_joint>
         left_elevon_joint
@@ -803,9 +740,6 @@
       <right_elevon_joint>
         right_elevon_joint
       </right_elevon_joint>
-      <elevator_joint>
-        elevator_joint
-      </elevator_joint>
     </plugin>
     <static>0</static>
   </model>

--- a/models/tailsitter/tailsitter.sdf
+++ b/models/tailsitter/tailsitter.sdf
@@ -496,7 +496,7 @@
       <cla_stall>-3.85</cla_stall>
       <cda_stall>-0.9233984055</cda_stall>
       <cma_stall>0</cma_stall>
-      <cm_delta>-0.573</cm_delta>
+      <cm_delta>-0.3</cm_delta>
       <cp>0 0.3 0.0</cp>
       <area>0.15</area>
       <air_density>1.2041</air_density>
@@ -519,7 +519,7 @@
       <cla_stall>-3.85</cla_stall>
       <cda_stall>-0.9233984055</cda_stall>
       <cma_stall>0</cma_stall>
-      <cm_delta>-0.573</cm_delta>
+      <cm_delta>-0.3</cm_delta>
       <cp>0 -0.3 -0.0</cp>
       <area>0.15</area>
       <air_density>1.2041</air_density>

--- a/src/liftdrag_plugin/liftdrag_plugin.cpp
+++ b/src/liftdrag_plugin/liftdrag_plugin.cpp
@@ -55,6 +55,9 @@ LiftDragPlugin::LiftDragPlugin() : cla(1.0), cda(0.01), cma(0.0), rho(1.2041)
 
   /// how much to change CL per every radian of the control joint value
   this->controlJointRadToCL = 4.0;
+
+  // How much Cm changes with a change in control surface deflection angle
+  this->cm_delta = 0.0;
 }
 
 /////////////////////////////////////////////////
@@ -109,6 +112,9 @@ void LiftDragPlugin::Load(physics::ModelPtr _model,
 
   if (_sdf->HasElement("cma_stall"))
     this->cmaStall = _sdf->Get<double>("cma_stall");
+
+    if (_sdf->HasElement("cm_delta"))
+        this->cm_delta = _sdf->Get<double>("cm_delta");
 
   if (_sdf->HasElement("cp"))
     this->cp = _sdf->Get<ignition::math::Vector3d>("cp");
@@ -310,15 +316,16 @@ void LiftDragPlugin::OnUpdate()
     cl = this->cla * this->alpha * cosSweepAngle;
 
   // modify cl per control joint value
+  double controlAngle;
   if (this->controlJoint)
   {
 #if GAZEBO_MAJOR_VERSION >= 9
-    double controlAngle = this->controlJoint->Position(0);
+    controlAngle = this->controlJoint->Position(0);
 #else
-    double controlAngle = this->controlJoint->GetAngle(0).Radian();
+    controlAngle = this->controlJoint->GetAngle(0).Radian();
 #endif
     cl = cl + this->controlJointRadToCL * controlAngle;
-    /// \TODO: also change cm and cd
+    /// \TODO: also change cd
   }
 
   // compute lift force at cp
@@ -368,6 +375,9 @@ void LiftDragPlugin::OnUpdate()
   else
     cm = this->cma * this->alpha * cosSweepAngle;
 
+  // Take into account the effect of control surface deflection angle to Cm
+  cm += this->cm_delta * controlAngle;
+
   // compute moment (torque) at cp
   ignition::math::Vector3d moment = cm * q * this->area * momentDirection;
 
@@ -384,11 +394,9 @@ void LiftDragPlugin::OnUpdate()
   // gzerr << this->cp << " : " << this->link->GetInertial()->CoG() << "\n";
 
   // force and torque about cg in inertial frame
-  ignition::math::Vector3d force = lift + drag;
-  // + moment.Cross(momentArm);
+  ignition::math::Vector3d force = lift + drag + moment.Cross(momentArm);
 
-  ignition::math::Vector3d torque = moment;
-  // - lift.Cross(momentArm) - drag.Cross(momentArm);
+  ignition::math::Vector3d torque = moment - lift.Cross(momentArm) - drag.Cross(momentArm);
 
   // debug
   //


### PR DESCRIPTION
This pull request adds the effect of the control surface deflection angle on the pitching moment of a wing. This aerodynamic effect is crucial for pitch control in tailless aircraft like the tailsitter SITL model. Earlier, the model needs a virtual elevator for pitch control since the moment coefficient was negated as pointed out in #516.

With pitching moment control via control surface deflection angle, the tailsitter SITL no longer needs the virtual elevator. However, it still needs a virtual rudder for directional stability.

To make the tailsitter SITL model work, the mixer file needs to be changed as well (add pitch control mixer to the elevons and remove the mixer for the virtual elevator). I'm trying to make another PR in the PX4/Firmware repository.