### PR TITLE
Set GPS utc time to use utc time

### DIFF
--- a/include/gazebo_gps_plugin.h
+++ b/include/gazebo_gps_plugin.h
@@ -95,6 +95,7 @@ private:
   common::Time last_gps_time_;
   common::Time last_time_;
   common::Time current_time_;
+  common::Time start_time_;
 
   // Home defaults to Zurich Irchel Park
   // @note The home position can be specified using the environment variables:

--- a/msgs/SITLGps.proto
+++ b/msgs/SITLGps.proto
@@ -4,13 +4,14 @@ package sensor_msgs.msgs;
 message SITLGps
 {
   required int64  time_usec             = 1;
-  required double latitude_deg          = 2;
-  required double longitude_deg         = 3;
-  required double altitude              = 4;
-  optional double eph                   = 5;
-  optional double epv                   = 6;
-  optional double velocity              = 7;
-  optional double velocity_east         = 8;
-  optional double velocity_north        = 9;
-  optional double velocity_up           = 10;
+  optional int64  time_utc_usec         = 2;
+  required double latitude_deg          = 3;
+  required double longitude_deg         = 4;
+  required double altitude              = 5;
+  optional double eph                   = 6;
+  optional double epv                   = 7;
+  optional double velocity              = 8;
+  optional double velocity_east         = 9;
+  optional double velocity_north        = 10;
+  optional double velocity_up           = 11;
 }

--- a/src/gazebo_gps_plugin.cpp
+++ b/src/gazebo_gps_plugin.cpp
@@ -83,9 +83,11 @@ void GpsPlugin::Load(sensors::SensorPtr _parent, sdf::ElementPtr _sdf)
   #if GAZEBO_MAJOR_VERSION >= 9
     last_time_ = world_->SimTime();
     last_gps_time_ = world_->SimTime();
+    start_time_ = world_->StartTime();
   #else
     last_time_ = world_->GetSimTime();
     last_gps_time_ = world_->GetSimTime();
+    start_time_ = world_->GetStartTime();
   #endif
 
   // Use environment variables if set for home position.
@@ -286,6 +288,7 @@ void GpsPlugin::OnWorldUpdate(const common::UpdateInfo& /*_info*/)
   sensor_msgs::msgs::SITLGps gps_msg;
 
   gps_msg.set_time_usec(current_time_.Double() * 1e6);
+  gps_msg.set_time_utc_usec((current_time_.Double() + start_time_.Double()) * 1e6);
 
   // @note Unfurtonately the Gazebo GpsSensor seems to provide bad readings,
   // starting to drift and leading to global position loss

--- a/src/gazebo_mavlink_interface.cpp
+++ b/src/gazebo_mavlink_interface.cpp
@@ -999,7 +999,7 @@ void GazeboMavlinkInterface::SendGroundTruth()
 void GazeboMavlinkInterface::GpsCallback(GpsPtr& gps_msg, const int& id) {
   // fill HIL GPS Mavlink msg
   mavlink_hil_gps_t hil_gps_msg;
-  hil_gps_msg.time_usec = gps_msg->time_usec();
+  hil_gps_msg.time_usec = gps_msg->time_utc_usec();
   hil_gps_msg.fix_type = 3;
   hil_gps_msg.lat = gps_msg->latitude_deg() * 1e7;
   hil_gps_msg.lon = gps_msg->longitude_deg() * 1e7;


### PR DESCRIPTION
Previously GPS `utc_time_usec` was wrongly passing sim time in [simulator](https://github.com/PX4/Firmware/blob/master/src/modules/simulator/simulator_mavlink.cpp#L297), therefore being marked as being flown in close to epoch.

This PR sets the utc time to the current system time by adding wall time. 