### PR TITLE
Add airspeed plugin to tiltrotor

### DIFF
--- a/models/tiltrotor/tiltrotor.sdf
+++ b/models/tiltrotor/tiltrotor.sdf
@@ -114,8 +114,39 @@
         <use_parent_model_frame>1</use_parent_model_frame>
       </axis>
     </joint>
-
-
+    <link name='tiltrotor/airspeed_link'>
+      <pose>0 0 0 0 0 0</pose>
+      <inertial>
+        <pose>0 0 0 0 0 0</pose>
+        <mass>0.015</mass>
+        <inertia>
+          <ixx>1e-05</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>1e-05</iyy>
+          <iyz>0</iyz>
+          <izz>1e-05</izz>
+        </inertia>
+      </inertial>
+    </link>
+    <joint name='tiltrotor/airspeed_joint' type='revolute'>
+      <child>tiltrotor/airspeed_link</child>
+      <parent>base_link</parent>
+      <axis>
+        <xyz>1 0 0</xyz>
+        <limit>
+          <lower>0</lower>
+          <upper>0</upper>
+          <effort>0</effort>
+          <velocity>0</velocity>
+        </limit>
+        <dynamics>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+        </dynamics>
+        <use_parent_model_frame>1</use_parent_model_frame>
+      </axis>
+    </joint>
     <link name='motor_0'>
       <pose>0.35 -0.35 0.02 0 0 0</pose>
       <inertial>
@@ -1019,6 +1050,10 @@
       <robotNamespace/>
       <pubRate>50</pubRate>
       <baroTopic>/baro</baroTopic>
+    </plugin>
+    <plugin name='airspeed_plugin' filename='libgazebo_airspeed_plugin.so'>
+      <robotNamespace/>
+      <linkName>tiltrotor/airspeed_link</linkName>
     </plugin>
     <plugin name='mavlink_interface' filename='libgazebo_mavlink_interface.so'>
       <robotNamespace></robotNamespace>


### PR DESCRIPTION
When airspeed plugin was being factored out in https://github.com/PX4/sitl_gazebo/pull/515 I forgot to add it also the tiltrotor.

I guess this resulted in @dagar fighting the issue in https://github.com/PX4/Firmware/pull/15145 https://github.com/PX4/Firmware/pull/15142

This adds the airspeed plugin to the tiltrotor vehicle properly. 

