### PR TITLE
Fix multivehicle regressions for plane and standard_vtol model

### DIFF
--- a/models/rotors_description/urdf/component_snippets.xacro
+++ b/models/rotors_description/urdf/component_snippets.xacro
@@ -167,6 +167,31 @@
     </gazebo>
   </xacro:macro>
 
+  <!-- Macro to add the airspeed sensor_plugin. -->
+  <xacro:macro name="airspeed_plugin_macro" params="namespace parent_link">
+    <link name="${namespace}/airspeed_link">
+      <inertial>
+        <inertia ixx="1e-05" ixy="0.0" iyy="1e-05" ixz="0.0" iyz="0.0" izz="1e-05" />
+        <mass value="0.015" />  <!-- [kg] -->
+        <origin xyz="0 0 0" rpy="0 0 0" />
+      </inertial>
+    </link>
+    <!-- IMU joint -->
+    <joint name="${namespace}/airspeed_joint" type="revolute">
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <parent link="${parent_link}" />
+      <child link="${namespace}/airspeed_link" />
+      <limit upper="0" lower="0" effort="0" velocity="0" />
+    </joint>
+
+    <gazebo>
+      <plugin name='airspeed_plugin' filename='libgazebo_airspeed_plugin.so'>
+        <robotNamespace/>
+        <linkName>${namespace}/airspeed_link</linkName>
+      </plugin>
+    </gazebo>
+  </xacro:macro>
+
   <!-- Macro to add the controller interface. -->
   <xacro:macro name="controller_plugin_macro" params="namespace imu_sub_topic">
     <gazebo>

--- a/models/rotors_description/urdf/fixedwing_base.xacro
+++ b/models/rotors_description/urdf/fixedwing_base.xacro
@@ -173,6 +173,8 @@
                ${link_name}_joint
             </control_joint_name>
             <control_joint_rad_to_cl>${control_joint_rad_to_cl}</control_joint_rad_to_cl>
+            <robotNamespace></robotNamespace>
+            <windSubTopic>/wind</windSubTopic>
          </plugin>
     </gazebo>
     <gazebo reference="${link_name}">
@@ -225,6 +227,8 @@
                ${link_name}_joint
             </control_joint_name>
             <control_joint_rad_to_cl>${control_joint_rad_to_cl}</control_joint_rad_to_cl>
+            <robotNamespace></robotNamespace>
+            <windSubTopic>/wind</windSubTopic>
          </plugin>
     </gazebo>
     <gazebo reference="${link_name}">

--- a/models/rotors_description/urdf/plane.xacro
+++ b/models/rotors_description/urdf/plane.xacro
@@ -33,7 +33,7 @@
 
 <robot name="plane" xmlns:xacro="http://ros.org/wiki/xacro">
   <!-- Properties -->
-  <xacro:property name="namespace" value="plane" />
+  <xacro:property name="namespace" value="" />
   <xacro:property name="rotor_velocity_slowdown_sim" value="10" />
   <xacro:property name="mass" value="1.5" /> <!-- [kg] -->
   <xacro:property name="body_width" value="0.47" /> <!-- [m] -->

--- a/models/rotors_description/urdf/plane_base.xacro
+++ b/models/rotors_description/urdf/plane_base.xacro
@@ -114,6 +114,13 @@
     >
   </xacro:magnetometer_plugin_macro>
 
+  <!-- Instantiate magnetometer plugin. -->
+  <xacro:airspeed_plugin_macro
+    namespace="${namespace}"
+    parent_link="base_link"
+    >
+  </xacro:airspeed_plugin_macro>
+
   <!-- Instantiate barometer plugin. -->
   <xacro:barometer_plugin_macro
     namespace="${namespace}"

--- a/models/rotors_description/urdf/standard_vtol.xacro
+++ b/models/rotors_description/urdf/standard_vtol.xacro
@@ -33,7 +33,7 @@
 
 <robot name="standard_vtol" xmlns:xacro="http://ros.org/wiki/xacro">
   <!-- Properties -->
-  <xacro:property name="namespace" value="standard_vtol" />
+  <xacro:property name="namespace" value="" />
   <xacro:property name="rotor_velocity_slowdown_sim" value="20" />
   <xacro:property name="mesh_file" value="iris.stl" />
   <xacro:property name="mesh_scale" value="1 1 1"/>

--- a/models/rotors_description/urdf/standard_vtol_base.xacro
+++ b/models/rotors_description/urdf/standard_vtol_base.xacro
@@ -150,6 +150,12 @@
   </xacro:mavlink_interface_macro_vtol>
   </xacro:if>
 
+  <xacro:airspeed_plugin_macro
+    namespace="${namespace}"
+    parent_link="base_link"
+    >
+  </xacro:airspeed_plugin_macro>
+
   <!-- Mount an ADIS16448 IMU. -->
   <xacro:imu_plugin_macro
     namespace="${namespace}"


### PR DESCRIPTION
xacro based multivehicle simulation has shown some regressions (e.g. no gps fix, liftdrag plugin warning messages as below) 

```
[Wrn] [gazebo_gps_plugin.cpp:76] [gazebo_gps_plugin]: standard_vtol_1::gps0 using gps topic "gps0"
[Wrn] [gazebo_gps_plugin.cpp:201] [gazebo_gps_plugin] Using default update rate of 5hz 
[Err] [liftdrag_plugin.cpp:164] [gazebo_wind_plugin] Please specify a robotNamespace.
[Err] [liftdrag_plugin.cpp:164] [gazebo_wind_plugin] Please specify a robotNamespace.
```

This PR addresses these problems and fixes the multivehicle simulation.

I believe the fact that this has been broken and not been known that it was shows that we need tests