### PR TITLE
range sensors: lidar: add simple signal quality model and propagate it to Mavlink

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
           cache:
             ccache: true
           env:
-            - PX4_DOCKER_REPO=px4io/px4-dev-simulation-xenial:2020-05-28
+            - PX4_DOCKER_REPO=px4io/px4-dev-simulation-xenial:2020-06-20
             - BUILD=${CMAKE_BUILD}
         - name: CMake unit tests build and run (Gazebo 7)
           os: linux
@@ -34,7 +34,7 @@ matrix:
           cache:
             ccache: true
           env:
-            - PX4_DOCKER_REPO=px4io/px4-dev-simulation-xenial:2020-05-28
+            - PX4_DOCKER_REPO=px4io/px4-dev-simulation-xenial:2020-06-20
             - BUILD=${CMAKE_UNIT_TEST_BUILD}
         - name: CMake build (Gazebo 9)
           os: linux
@@ -44,7 +44,7 @@ matrix:
           cache:
             ccache: true
           env:
-            - PX4_DOCKER_REPO=px4io/px4-dev-simulation-bionic:2020-05-28
+            - PX4_DOCKER_REPO=px4io/px4-dev-simulation-bionic:2020-06-20
             - BUILD=${CMAKE_BUILD}
         - name: CMake unit tests build and run (Gazebo 9)
           os: linux
@@ -54,7 +54,7 @@ matrix:
           cache:
             ccache: true
           env:
-            - PX4_DOCKER_REPO=px4io/px4-dev-simulation-bionic:2020-05-28
+            - PX4_DOCKER_REPO=px4io/px4-dev-simulation-bionic:2020-06-20
             - BUILD=${CMAKE_UNIT_TEST_BUILD}
         # FIXME: Currently failing when creating QT moc files
         # - name: CMake build (Gazebo 11)
@@ -65,7 +65,7 @@ matrix:
         #   cache:
         #     ccache: true
         #   env:
-        #     - PX4_DOCKER_REPO=px4io/px4-dev-simulation-focal:2020-05-28
+        #     - PX4_DOCKER_REPO=px4io/px4-dev-simulation-focal:2020-06-20
         #     - BUILD=${CMAKE_BUILD}
         # - name: CMake unit tests build and run (Gazebo 11)
         #   os: linux
@@ -75,7 +75,7 @@ matrix:
         #   cache:
         #     ccache: true
         #   env:
-        #     - PX4_DOCKER_REPO=px4io/px4-dev-simulation-focal:2020-05-28
+        #     - PX4_DOCKER_REPO=px4io/px4-dev-simulation-focal:2020-06-20
         #     - BUILD=${CMAKE_UNIT_TEST_BUILD}
         # FIXME: px4-dev-ros-kinetic is failing due to some pip install problems
         # - name: Catkin build on Ubuntu 16.04 with ROS Kinetic (Gazebo 7)
@@ -86,9 +86,9 @@ matrix:
         #   cache:
         #     ccache: true
         #   env:
-        #     - PX4_DOCKER_REPO=px4io/px4-dev-ros-kinetic:2020-05-28
+        #     - PX4_DOCKER_REPO=px4io/px4-dev-ros-kinetic:2020-06-20
         #     - BUILD=${KINETIC}
-        # FIXME: we need a new MAVLink ROS release (by 2020-05-28)
+        # FIXME: we need a new MAVLink ROS release (by 2020-06-20)
         # - name: Catkin build on Ubuntu 18.04 with ROS Melodic (Gazebo 9)
         #   os: linux
         #   language: cpp
@@ -97,7 +97,7 @@ matrix:
         #   cache:
         #     ccache: true
         #   env:
-        #     - PX4_DOCKER_REPO=px4io/px4-dev-ros-melodic:2020-05-28
+        #     - PX4_DOCKER_REPO=px4io/px4-dev-ros-melodic:2020-06-20
         #     - BUILD=${MELODIC}
         - name: Validate SDF schemas
           os: linux
@@ -107,7 +107,7 @@ matrix:
           cache:
             ccache: true
           env:
-            - PX4_DOCKER_REPO=px4io/px4-dev-simulation-bionic:2020-05-28
+            - PX4_DOCKER_REPO=px4io/px4-dev-simulation-bionic:2020-06-20
             - BUILD="source ./scripts/validate_sdf.bash"
         - name: macOS Mojave (Xcode 11.3)
           os: osx

--- a/include/gazebo_lidar_plugin.h
+++ b/include/gazebo_lidar_plugin.h
@@ -73,6 +73,8 @@ namespace gazebo
       std::string namespace_;
       double min_distance_;
       double max_distance_;
+      double low_signal_strength_;
+      double high_signal_strength_;
 
       gazebo::msgs::Quaternion orientation_;
 

--- a/msgs/Range.proto
+++ b/msgs/Range.proto
@@ -11,4 +11,5 @@ message Range
   optional float h_fov                        = 5;
   optional float v_fov                        = 6;
   optional gazebo.msgs.Quaternion orientation = 7;
+  optional int32 signal_quality               = 8;
 }

--- a/src/gazebo_lidar_plugin.cpp
+++ b/src/gazebo_lidar_plugin.cpp
@@ -90,6 +90,12 @@ void LidarPlugin::Load(sensors::SensorPtr _parent, sdf::ElementPtr _sdf)
     max_distance_ = kDefaultMaxDistance;
   }
 
+  // Set high and low signal strength
+  // The considered relationship of distance to returned signal strength is an
+  // inverse square.
+  low_signal_strength_ = sqrt(min_distance_);
+  high_signal_strength_ = sqrt(max_distance_ + 0.02); // extend the threshold so there is still quality at max distance
+
   node_handle_ = transport::NodePtr(new transport::Node());
   node_handle_->Init(namespace_);
 
@@ -142,6 +148,7 @@ void LidarPlugin::OnNewLaserScans()
   lidar_message_.set_min_distance(min_distance_);
   lidar_message_.set_max_distance(max_distance_);
 
+  // get current distance measured from the sensor
   double current_distance = parentSensor_->Range(0);
 
   // set distance to min/max if actual value is smaller/bigger
@@ -155,6 +162,21 @@ void LidarPlugin::OnNewLaserScans()
   lidar_message_.set_h_fov(kDefaultFOV);
   lidar_message_.set_v_fov(kDefaultFOV);
   lidar_message_.set_allocated_orientation(new gazebo::msgs::Quaternion(orientation_));
+
+  // Compute signal strength
+  // Other effects like target size, shape or reflectivity are not considered
+  const double signal_strength = sqrt(current_distance);
+
+  // Compute and set the signal quality
+  // The signal quality is normalized between 1 and 100 using the absolute
+  // signal strength (DISTANCE_SENSOR signal_quality value of 0 means invalid)
+  uint8_t signal_quality = 1;
+  if (signal_strength > low_signal_strength_) {
+    signal_quality = static_cast<uint8_t>(99 * ((high_signal_strength_ - signal_strength) /
+            (high_signal_strength_ - low_signal_strength_)) + 1);
+  }
+
+  lidar_message_.set_signal_quality(signal_quality);
 
   lidar_pub_->Publish(lidar_message_);
 }

--- a/src/gazebo_mavlink_interface.cpp
+++ b/src/gazebo_mavlink_interface.cpp
@@ -1045,6 +1045,7 @@ void GazeboMavlinkInterface::LidarCallback(LidarPtr& lidar_message, const int& i
   sensor_msg.covariance = 0;
   sensor_msg.horizontal_fov = lidar_message->h_fov();
   sensor_msg.vertical_fov = lidar_message->v_fov();
+  sensor_msg.signal_quality = lidar_message->signal_quality();
 
   ignition::math::Quaterniond q_ls = ignition::math::Quaterniond(
     lidar_message->orientation().w(),
@@ -1116,6 +1117,7 @@ void GazeboMavlinkInterface::SonarCallback(SonarPtr& sonar_message, const int& i
   sensor_msg.min_distance = sonar_message->min_distance() * 100.0;
   sensor_msg.max_distance = sonar_message->max_distance() * 100.0;
   sensor_msg.current_distance = sonar_message->current_distance() * 100.0;
+  sensor_msg.signal_quality = sonar_message->signal_quality();
 
   ignition::math::Quaterniond q_ls;
   for (Sensor_M::iterator it = sensor_map_.begin(); it != sensor_map_.end(); ++it) {

--- a/src/gazebo_sonar_plugin.cpp
+++ b/src/gazebo_sonar_plugin.cpp
@@ -124,5 +124,9 @@ void SonarPlugin::OnNewScans()
   sonar_message_.set_v_fov(2.0f * atan(parentSensor_->Radius() / parentSensor_->RangeMax()));
   sonar_message_.set_allocated_orientation(new gazebo::msgs::Quaternion(orientation_));
 
+  // For now, sending 0 as invalid. Might need a different signal modelling
+  // than the lidar plugin
+  sonar_message_.set_signal_quality(0);
+
   sonar_pub_->Publish(sonar_message_);
 }


### PR DESCRIPTION
Adds a simple signal strength model and consequent signal quality metric to the Lidar plugin.

The quality value is normalised between 1 and 100 to fit the Mavlink definition for the DISTANCE_SENSOR message, while the value of 0 is considered to qualify the quality as unknown or invalid.

Follows a PR in upstream Firmware.