### PR TITLE
Fix plane catapult plugin

### DIFF
--- a/include/gazebo_catapult_plugin.h
+++ b/include/gazebo_catapult_plugin.h
@@ -90,11 +90,11 @@ private:
 
   event::ConnectionPtr _updateConnection;
 
-  LaunchStatus launch_status_;
+  LaunchStatus launch_status_ = VEHICLE_STANDBY;
   common::Time trigger_time_;
   
   double max_rot_velocity_ = 3500;
-  double ref_motor_rot_vel_;
+  double ref_motor_rot_vel_ = 0.0;
   double arm_rot_vel_ = 100;
   double launch_duration_ = 0.01;
   double force_magnitude_ = 1.0;

--- a/src/gazebo_catapult_plugin.cpp
+++ b/src/gazebo_catapult_plugin.cpp
@@ -98,7 +98,6 @@ void CatapultPlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf)
 
 void CatapultPlugin::OnUpdate(const common::UpdateInfo&){
 
-    bool vehicle_launched_ = false;
     //Launch vehicle if the vehilce is armed
     if(ref_motor_rot_vel_ > arm_rot_vel_ && launch_status_ != VEHICLE_LAUNCHED ) {
       if(launch_status_ == VEHICLE_STANDBY) {


### PR DESCRIPTION
The plane catapult plugin wasn't working properly. It seems that it is related to uninitialized variables. 