### PR TITLE
Remove the incorrect force generated by moment

### DIFF
--- a/src/liftdrag_plugin/liftdrag_plugin.cpp
+++ b/src/liftdrag_plugin/liftdrag_plugin.cpp
@@ -394,7 +394,7 @@ void LiftDragPlugin::OnUpdate()
   // gzerr << this->cp << " : " << this->link->GetInertial()->CoG() << "\n";
 
   // force and torque about cg in inertial frame
-  ignition::math::Vector3d force = lift + drag + moment.Cross(momentArm);
+  ignition::math::Vector3d force = lift + drag;
 
   ignition::math::Vector3d torque = moment - lift.Cross(momentArm) - drag.Cross(momentArm);
 


### PR DESCRIPTION
This pull request removes the incorrect force term as discussed in #531.