### PR TITLE
Do not validate r1_rover.sdf as unable to validate

### DIFF
--- a/scripts/validate_sdf.bash
+++ b/scripts/validate_sdf.bash
@@ -53,7 +53,7 @@ if [ -d ${MODELS_DIR} ]; then
 	done <<<"$(find ${MODELS_DIR} -type f -name '*.sdf' \
 		! -name '3DR_gps_mag-gen.sdf' ! -name 'px4flow-gen.sdf' \
 		! -name 'pixhawk-gen.sdf' ! -name 'c920-gen.sdf' \
-		! -name 'iris.sdf' ! -name 'delta_wing.sdf' \
+		! -name 'iris.sdf' ! -name 'delta_wing.sdf' ! -name 'r1_rover.sdf' \
 		! -name 'fpv_cam.sdf' ! -name 'iris_triple_depth_camera.sdf')"
 else
 	echo "${MODELS_DIR} doesn't exist!"


### PR DESCRIPTION
There were torsional friction added in https://github.com/PX4/sitl_gazebo/pull/534

However, <contact><friction><torsional> element was not defined in the sdf schema. Therefore ignoring in the validation