### PR TITLE
Barometer drift

### DIFF
--- a/include/gazebo_barometer_plugin.h
+++ b/include/gazebo_barometer_plugin.h
@@ -99,6 +99,9 @@ namespace gazebo {
     // state variables for baro pressure sensor random noise generator
     double baro_rnd_y2_;
     bool baro_rnd_use_last_;
+
+    double baro_drift_pa_per_sec_;
+    double baro_drift_pa_;
   }; // class BarometerPlugin
 } // namespace gazebo
 #endif // _GAZEBO_BAROMETER_PLUGIN_HH_

--- a/models/rotors_description/urdf/component_snippets.xacro
+++ b/models/rotors_description/urdf/component_snippets.xacro
@@ -230,12 +230,13 @@
   </xacro:macro>
 
   <!-- Macro to add the barometer_plugin. -->
-  <xacro:macro name="barometer_plugin_macro" params="namespace pub_rate baro_topic">
+  <xacro:macro name="barometer_plugin_macro" params="namespace pub_rate baro_topic baro_drift_pa_per_sec">
     <gazebo>
       <plugin name="barometer_plugin" filename="libgazebo_barometer_plugin.so">
         <robotNamespace>${namespace}</robotNamespace>
         <pubRate>${pub_rate}</pubRate>
         <baroTopic>${baro_topic}</baroTopic>
+        <baroDriftPaPerSec>${baro_drift_pa_per_sec}</baroDriftPaPerSec>
       </plugin>
     </gazebo>
   </xacro:macro>

--- a/models/rotors_description/urdf/iris_base.xacro
+++ b/models/rotors_description/urdf/iris_base.xacro
@@ -119,6 +119,7 @@
     namespace="${namespace}"
     pub_rate="50"
     baro_topic="/baro"
+    baro_drift_pa_per_sec="0"
     >
   </xacro:barometer_plugin_macro>
 

--- a/models/rotors_description/urdf/standard_vtol_base.xacro
+++ b/models/rotors_description/urdf/standard_vtol_base.xacro
@@ -115,10 +115,12 @@
   </xacro:magnetometer_plugin_macro>
 
   <!-- Instantiate barometer plugin. -->
+  <!-- 1 Pa/s drift is roughly 10 cm/s -->
   <xacro:barometer_plugin_macro
     namespace="${namespace}"
     pub_rate="10"
     baro_topic="/baro"
+    baro_drift_pa_per_sec="0"
     >
   </xacro:barometer_plugin_macro>
 

--- a/src/gazebo_barometer_plugin.cpp
+++ b/src/gazebo_barometer_plugin.cpp
@@ -119,64 +119,67 @@ void BarometerPlugin::Load(physics::ModelPtr model, sdf::ElementPtr sdf)
 void BarometerPlugin::OnUpdate(const common::UpdateInfo&)
 {
 #if GAZEBO_MAJOR_VERSION >= 9
-  common::Time current_time = world_->SimTime();
+  const common::Time current_time = world_->SimTime();
 #else
-  common::Time current_time = world_->GetSimTime();
+  const common::Time current_time = world_->GetSimTime();
 #endif
-  double dt = (current_time - last_pub_time_).Double();
+  const double dt = (current_time - last_pub_time_).Double();
 
   if (dt > 1.0 / pub_rate_) {
 
     // get pose of the model that the plugin is attached to
 #if GAZEBO_MAJOR_VERSION >= 9
-    ignition::math::Pose3d pose_model_world = model_->WorldPose();
+    const ignition::math::Pose3d pose_model_world = model_->WorldPose();
 #else
-    ignition::math::Pose3d pose_model_world = ignitionFromGazeboMath(model_->GetWorldPose());
+    const ignition::math::Pose3d pose_model_world = ignitionFromGazeboMath(model_->GetWorldPose());
 #endif
     ignition::math::Pose3d pose_model; // Z-component pose in local frame (relative to where it started)
     pose_model.Pos().Z() = pose_model_world.Pos().Z() - pose_model_start_.Pos().Z();
 
-    float pose_n_z = -pose_model.Pos().Z(); // convert Z-component from ENU to NED
+    const float pose_n_z = -pose_model.Pos().Z(); // convert Z-component from ENU to NED
 
     // calculate abs_pressure using an ISA model for the tropsphere (valid up to 11km above MSL)
     const float lapse_rate = 0.0065f; // reduction in temperature with altitude (Kelvin/m)
     const float temperature_msl = 288.0f; // temperature at MSL (Kelvin)
-    float alt_msl = (float)alt_home_ - pose_n_z;
-    float temperature_local = temperature_msl - lapse_rate * alt_msl;
-    float pressure_ratio = powf((temperature_msl/temperature_local), 5.256f);
+    const float alt_msl = (float)alt_home_ - pose_n_z;
+    const float temperature_local = temperature_msl - lapse_rate * alt_msl;
+    const float pressure_ratio = powf(temperature_msl / temperature_local, 5.256f);
     const float pressure_msl = 101325.0f; // pressure at MSL
-    float absolute_pressure = pressure_msl / pressure_ratio;
+    const float absolute_pressure = pressure_msl / pressure_ratio;
 
     // generate Gaussian noise sequence using polar form of Box-Muller transformation
-    double x1, x2, w, y1;
-    if (!baro_rnd_use_last_) {
-      do {
-        x1 = 2.0 * standard_normal_distribution_(random_generator_) - 1.0;
-        x2 = 2.0 * standard_normal_distribution_(random_generator_) - 1.0;
-        w = x1 * x1 + x2 * x2;
-      } while ( w >= 1.0 );
-      w = sqrt( (-2.0 * log( w ) ) / w );
-      // calculate two values - the second value can be used next time because it is uncorrelated
-      y1 = x1 * w;
-      baro_rnd_y2_ = x2 * w;
-      baro_rnd_use_last_ = true;
-    } else {
-      // no need to repeat the calculation - use the second value from last update
-      y1 = baro_rnd_y2_;
-      baro_rnd_use_last_ = false;
+    double y1;
+    {
+      double x1, x2, w;
+      if (!baro_rnd_use_last_) {
+        do {
+          x1 = 2.0 * standard_normal_distribution_(random_generator_) - 1.0;
+          x2 = 2.0 * standard_normal_distribution_(random_generator_) - 1.0;
+          w = x1 * x1 + x2 * x2;
+        } while ( w >= 1.0 );
+        w = sqrt( (-2.0 * log( w ) ) / w );
+        // calculate two values - the second value can be used next time because it is uncorrelated
+        y1 = x1 * w;
+        baro_rnd_y2_ = x2 * w;
+        baro_rnd_use_last_ = true;
+      } else {
+        // no need to repeat the calculation - use the second value from last update
+        y1 = baro_rnd_y2_;
+        baro_rnd_use_last_ = false;
+      }
     }
 
     // Apply 1 Pa RMS noise
-    float abs_pressure_noise = 1.0f * (float)y1;
-    absolute_pressure += abs_pressure_noise;
+    const float abs_pressure_noise = 1.0f * (float)y1;
+    const float absolute_pressure_noisy = absolute_pressure + abs_pressure_noise;
 
     // convert to hPa
-    absolute_pressure *= 0.01f;
-    baro_msg_.set_absolute_pressure(absolute_pressure);
+    const float absolute_pressure_noisy_hpa = absolute_pressure_noisy * 0.01f;
+    baro_msg_.set_absolute_pressure(absolute_pressure_noisy_hpa);
 
     // calculate density using an ISA model for the tropsphere (valid up to 11km above MSL)
-    const float density_ratio = powf((temperature_msl/temperature_local) , 4.256f);
-    float rho = 1.225f / density_ratio;
+    const float density_ratio = powf(temperature_msl / temperature_local, 4.256f);
+    const float rho = 1.225f / density_ratio;
 
     // calculate pressure altitude including effect of pressure noise
     baro_msg_.set_pressure_altitude(alt_msl - abs_pressure_noise / (gravity_W_.Length() * rho));


### PR DESCRIPTION
I wanted to run simulations with constantly increasing drift on the barometer, so I've added this to the barometer plugin.

There's a tiny refactoring of the plugin, just to make it a bit easier to modify.

The drift is added as a new sdf element, and added to the barometer xacro, with drift in Pascals per second as the parameter.

Default is of course no drift.