### PR TITLE
Add firmware build test

### DIFF
--- a/.github/workflows/firmware_build_test.yml
+++ b/.github/workflows/firmware_build_test.yml
@@ -1,0 +1,36 @@
+name: Firmware Build Test
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+  Firmware-build:
+    runs-on: ubuntu-latest
+    container: px4io/px4-dev-base-focal:2020-05-12
+    steps:
+    - name: Checkout Firmware master
+      uses: actions/checkout@v2.3.1
+      with:
+        repository: PX4/Firmware
+        ref: master
+        path: Firmware
+        fetch-depth: 0
+        submodules: recurvise
+    - name: Checkout matching branch on PX4/Firmware if possible
+      run: |
+        git checkout ${{github.head_ref}} || echo "Firmware branch: ${{github.head_ref}} not found, using master instead"
+        git submodule update --init --recursive
+      working-directory: Firmware
+    - name: Configure Firmware to include current ECL version
+      working-directory: Firmware/Tools/sitl_gazebo
+      run: |
+        git fetch origin pull/${{github.event.pull_request.number}}/head:${{github.head_ref}}
+        git checkout ${{github.head_ref}}
+    - name: Build Firmware
+      working-directory: Firmware
+      run: DONT_RUN=1 make px4_sitl_default


### PR DESCRIPTION
There were cases where sitl_gazebo was moving ahead with some mavlink definitions and required fixes on the firmware side to get the submoudles updated.

This ensures that the changes are compatible with the latest firmware that is released as a container, so that we can be sure that the changes are compatible with the firmware

**Additional Context**
The github action was taken from https://github.com/PX4/ecl/blob/master/.github/workflows/firmware_build_test.yml