### PR TITLE
Fix gimbal imu sensors intefering with each other

### DIFF
--- a/src/gazebo_gimbal_controller_plugin.cpp
+++ b/src/gazebo_gimbal_controller_plugin.cpp
@@ -332,7 +332,7 @@ void GimbalControllerPlugin::Load(physics::ModelPtr _model,
   }
 #if GAZEBO_MAJOR_VERSION >= 7
   this->cameraImuSensor = std::static_pointer_cast<sensors::ImuSensor>(
-    sensors::SensorManager::Instance()->GetSensor(cameraImuSensorName));
+    sensors::SensorManager::Instance()->GetSensor(_model->SensorScopedName(cameraImuSensorName)[0]));
 #elif GAZEBO_MAJOR_VERSION >= 6
   this->cameraImuSensor = boost::static_pointer_cast<sensors::ImuSensor>(
     sensors::SensorManager::Instance()->GetSensor(cameraImuSensorName));


### PR DESCRIPTION
The gimbal imu sensors would interfere with each other if there were more than one vehicle with a gimbal. 

This was because the `GetSensor` method was using a unscoped name, therefore was taking one of the gimbal imu sensors from any of the vehicles that exists in the world. 

This PR solves this problem by getting the sensor pointer with a fully scoped name which allows the simulation to have multiple instances of vehicles with a gimbal

**Tests**
Tested in SITL gazebo on the typhoon_h480 and the gimbal was controlled through mavros.

![ezgif com-video-to-gif (4)](https://user-images.githubusercontent.com/5248102/87854734-39888a80-c914-11ea-83fd-bbef1fc9b1ce.gif)

**Additional Context**
Fixes https://github.com/PX4/sitl_gazebo/issues/540