### PR TITLE
Oversight fix from #544

### DIFF
--- a/models/rotors_description/urdf/plane_base.xacro
+++ b/models/rotors_description/urdf/plane_base.xacro
@@ -124,6 +124,7 @@
   <!-- Instantiate barometer plugin. -->
   <xacro:barometer_plugin_macro
     namespace="${namespace}"
+    baro_drift_pa_per_sec="0"
     pub_rate="10"
     baro_topic="/baro"
     >


### PR DESCRIPTION
PR #544 modified `iris_base.xacro` and `standard_vtol_base.xacro` but not `plane_base.xacro`. This results in errors when running `sitl_gazebo/scripts/xacro.py`

### Pre-PR Error
```bash
$ python3 $PWD/sitl_gazebo/scripts/xacro.py $PWD/sitl_gazebo/models/rotors_description/urdf/plane_base.xacro \
                rotors_description_dir:=`pwd`/sitl_gazebo/models/rotors_description mavlink_udp_port:=14540
                                                     
Traceback (most recent call last):    
  File "/vagrant/Firmware/Tools/sitl_gazebo/scripts/xacro.py", line 742, in <module>
    main()                  
  File "/vagrant/Firmware/Tools/sitl_gazebo/scripts/xacro.py", line 727, in main
    eval_self_contained(doc)                                                                              
  File "/vagrant/Firmware/Tools/sitl_gazebo/scripts/xacro.py", line 654, in eval_self_contained
    eval_all(doc.documentElement, macros, symbols)
  File "/vagrant/Firmware/Tools/sitl_gazebo/scripts/xacro.py", line 570, in eval_all     
    node.tagName)))                   
__main__.XacroException: Parameters [baro_drift_pa_per_sec] were not set for macro xacro:barometer_plugin_macro
```
