### PR TITLE
Fix airspeed sensor wind subscription

### DIFF
--- a/src/gazebo_airspeed_plugin.cpp
+++ b/src/gazebo_airspeed_plugin.cpp
@@ -84,7 +84,7 @@ void AirspeedPlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf)
       boost::bind(&AirspeedPlugin::OnUpdate, this, _1));
 
   airspeed_pub_ = node_handle_->Advertise<sensor_msgs::msgs::Airspeed>("~/" + model_->GetName() + "/airspeed", 10);
-  wind_sub_ = node_handle_->Subscribe("~/" + model_->GetName() + "/wind", &AirspeedPlugin::WindVelocityCallback, this);
+  wind_sub_ = node_handle_->Subscribe("~/world_wind", &AirspeedPlugin::WindVelocityCallback, this);
 
   getSdfParam<float>(_sdf, "DiffPressureStdev", diff_pressure_stddev_, diff_pressure_stddev_);
   getSdfParam<float>(_sdf, "Temperature", temperature_, temperature_);


### PR DESCRIPTION
While wind topic names have been fixed in https://github.com/PX4/sitl_gazebo/pull/552, airspeed sensor was still subscribing to the wrong topic name. 

Fixes https://github.com/PX4/sitl_gazebo/issues/556