### PR TITLE
Lower wind topic publish rates to 2Hz to increase realtime factor

### DIFF
--- a/include/gazebo_wind_plugin.h
+++ b/include/gazebo_wind_plugin.h
@@ -70,6 +70,7 @@ class GazeboWindPlugin : public WorldPlugin {
         wind_gust_direction_mean_(kDefaultWindGustDirectionMean),
         wind_gust_direction_variance_(kDefaultWindGustDirectionVariance),
         frame_id_(kDefaultFrameId),
+        pub_interval_(0.5),
         node_handle_(NULL) {}
 
   virtual ~GazeboWindPlugin();
@@ -101,6 +102,7 @@ class GazeboWindPlugin : public WorldPlugin {
   double wind_gust_velocity_mean_;
   double wind_gust_velocity_max_;
   double wind_gust_velocity_variance_;
+  double pub_interval_;
   std::default_random_engine wind_velocity_generator_;
   std::normal_distribution<double> wind_velocity_distribution_;
   std::default_random_engine wind_gust_velocity_generator_;
@@ -122,6 +124,7 @@ class GazeboWindPlugin : public WorldPlugin {
 
   common::Time wind_gust_end_;
   common::Time wind_gust_start_;
+  common::Time last_time_;
 
   transport::NodePtr node_handle_;
   transport::PublisherPtr wind_pub_;

--- a/src/gazebo_mavlink_interface.cpp
+++ b/src/gazebo_mavlink_interface.cpp
@@ -360,7 +360,7 @@ void GazeboMavlinkInterface::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf
   mag_sub_ = node_handle_->Subscribe("~/" + model_->GetName() + mag_sub_topic_, &GazeboMavlinkInterface::MagnetometerCallback, this);
   airspeed_sub_ = node_handle_->Subscribe("~/" + model_->GetName() + airspeed_sub_topic_, &GazeboMavlinkInterface::AirspeedCallback, this);
   baro_sub_ = node_handle_->Subscribe("~/" + model_->GetName() + baro_sub_topic_, &GazeboMavlinkInterface::BarometerCallback, this);
-  wind_sub_ = node_handle_->Subscribe("~/" + model_->GetName() + wind_sub_topic_, &GazeboMavlinkInterface::WindVelocityCallback, this);
+  wind_sub_ = node_handle_->Subscribe("~/" + wind_sub_topic_, &GazeboMavlinkInterface::WindVelocityCallback, this);
 
   // Get the model joints
   auto joints = model_->GetJoints();


### PR DESCRIPTION
Realtime factor on the standard_vtol has been falling down to ~0.3 when run together with the wind plugin.

This is due to the fact that wind is being published at the full update of the simulation and being used in multiple components (e.g. `liftdrag_plugin`, `airspeed_plugin`, `gazebo_mavlink_interface`, `gazebo_motor_model`)

This PR constrains the wind topic publish rate by default to 2Hz, increasing the realtime factor even when wind is being published to ~0.97

