### PR TITLE
Send groundtruth messages at full rate

### DIFF
--- a/src/gazebo_mavlink_interface.cpp
+++ b/src/gazebo_mavlink_interface.cpp
@@ -568,9 +568,6 @@ void GazeboMavlinkInterface::OnUpdate(const common::UpdateInfo&  /*_info*/) {
   // Always send Gyro and Accel data at full rate (= sim update rate)
   SendSensorMessages();
 
-  // Send groudntruth at full rate
-  SendGroundTruth();
-
   if (close_conn_) { // close connection if required
     mavlink_interface_->close();
   }
@@ -835,6 +832,9 @@ void GazeboMavlinkInterface::GroundtruthCallback(GtPtr& groundtruth_msg) {
   groundtruth_altitude = groundtruth_msg->altitude();
   // the rest of the data is obtained directly on this interface and sent to
   // the FCU
+
+  // Send groudntruth at full rate
+  SendGroundTruth();
 }
 
 void GazeboMavlinkInterface::LidarCallback(LidarPtr& lidar_message, const int& id) {


### PR DESCRIPTION
**Description of Issue**
The `gazebo_mavlink_interface` is sending ground truth data
a. Even if there are no ground truth messages coming from the groundtruth plugin
b. At the same rate the actuator controls are being sent
(Fixes #566 )

This seems to be a bug coming from #517, where the `groundtruth_plugin` was stripped out of `gazebo_mavlink_interface` but was assumed to always receive the data.

**Solution**
This commit enables sending ground truth messages 
- Only when a groundtruth plugin is running
- Send the mavlink messages at the rate the message is received from the groundtruth plugin

**Testing**
Tested in SITL

