### PR TITLE
Fix wind transformation for airspeed sensor

### DIFF
--- a/src/gazebo_airspeed_plugin.cpp
+++ b/src/gazebo_airspeed_plugin.cpp
@@ -112,9 +112,9 @@ void AirspeedPlugin::OnUpdate(const common::UpdateInfo&){
   ignition::math::Quaterniond C_W_I = T_W_I.Rot();
 
 #if GAZEBO_MAJOR_VERSION >= 9
-  ignition::math::Vector3d vel_a = link_->RelativeLinearVel() - C_W_I.RotateVector(wind_vel_);
+  ignition::math::Vector3d vel_a = link_->RelativeLinearVel() - C_W_I.RotateVectorReverse(wind_vel_);
 #else
-  ignition::math::Vector3d vel_a = ignitionFromGazeboMath(link_->GetRelativeLinearVel()) - C_W_I.RotateVector(wind_vel_);
+  ignition::math::Vector3d vel_a = ignitionFromGazeboMath(link_->GetRelativeLinearVel()) - C_W_I.RotateVectorReverse(wind_vel_);
 #endif
   double diff_pressure = 0.005f * rho * vel_a.X() * vel_a.X() + diff_pressure_noise;
 


### PR DESCRIPTION
Wind transformations were wrong when implementing the airspeed plugin in https://github.com/PX4/sitl_gazebo/pull/515/files

**Tests**
SITL Tests with plane model
- Before PR: https://review.px4.io/plot_app?log=daac676f-51a2-4adf-a384-4e60afdeba14
- After PR: https://review.px4.io/plot_app?log=c5242547-4303-4d26-9664-d93bc7035422

**Additional Context**
- Fixes issue discussed in https://github.com/PX4/sitl_gazebo/pull/557