### PR TITLE
Move testing to github actions from travis

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -1,0 +1,37 @@
+name: Build Tests
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        container:
+        - 'px4io/px4-dev-simulation-focal:2020-08-14' # Gazebo 11
+        - 'px4io/px4-dev-simulation-bionic:2020-08-14' # Gazebo 9
+        - 'px4io/px4-dev-simulation-xenial:2020-06-20' # Gazebo 7
+    container: ${{ matrix.container }}
+    steps:
+    - uses: actions/checkout@v1
+    - name: submodule update
+      run: git submodule update --init --recursive
+    - name: Cmake Build
+      run: |
+        mkdir build
+        cd build
+        cmake ..
+        make
+    - name: Unit Tests
+      working-directory: build
+      run: |
+        cmake -DENABLE_UNIT_TESTS=On ..
+        make
+        make test

--- a/.github/workflows/firmware_build_test.yml
+++ b/.github/workflows/firmware_build_test.yml
@@ -1,0 +1,36 @@
+name: Firmware Build Test
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+  Firmware-build:
+    runs-on: ubuntu-latest
+    container: px4io/px4-dev-simulation-focal:2020-08-14
+    steps:
+    - name: Checkout Firmware master
+      uses: actions/checkout@v2.3.1
+      with:
+        repository: PX4/Firmware
+        ref: master
+        path: Firmware
+        fetch-depth: 0
+        submodules: recurvise
+    - name: Checkout matching branch on PX4/Firmware if possible
+      run: |
+        git checkout ${{github.head_ref}} || echo "Firmware branch: ${{github.head_ref}} not found, using master instead"
+        git submodule update --init --recursive
+      working-directory: Firmware
+    - name: Configure Firmware to include current sitl_gazebo version
+      working-directory: Firmware/Tools/sitl_gazebo
+      run: |
+        git fetch origin pull/${{github.event.pull_request.number}}/head:${{github.head_ref}}
+        git checkout ${{github.head_ref}}
+    - name: Build Firmware
+      working-directory: Firmware
+      run: DONT_RUN=1 make px4_sitl_default gazebo

--- a/.github/workflows/validate_sdf.yml
+++ b/.github/workflows/validate_sdf.yml
@@ -1,0 +1,21 @@
+name: Validate SDF
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+  validate-sdf:
+    runs-on: ubuntu-latest
+    container: px4io/px4-dev-simulation-bionic:2020-08-14
+    steps:
+    - uses: actions/checkout@v1
+    - name: submodule update
+      run: git submodule update --init --recursive
+    - name: Validate SDF
+      shell: bash
+      run: source scripts/validate_sdf.bash

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,57 +16,7 @@ branches:
 
 matrix:
     include:
-        - name: CMake build (Gazebo 7)
-          os: linux
-          language: cpp
-          services:
-            - docker
-          cache:
-            ccache: true
-          env:
-            - PX4_DOCKER_REPO=px4io/px4-dev-simulation-xenial:2020-06-20
-            - BUILD=${CMAKE_BUILD}
-        - name: CMake unit tests build and run (Gazebo 7)
-          os: linux
-          language: cpp
-          services:
-            - docker
-          cache:
-            ccache: true
-          env:
-            - PX4_DOCKER_REPO=px4io/px4-dev-simulation-xenial:2020-06-20
-            - BUILD=${CMAKE_UNIT_TEST_BUILD}
-        - name: CMake build (Gazebo 9)
-          os: linux
-          language: cpp
-          services:
-            - docker
-          cache:
-            ccache: true
-          env:
-            - PX4_DOCKER_REPO=px4io/px4-dev-simulation-bionic:2020-06-20
-            - BUILD=${CMAKE_BUILD}
-        - name: CMake unit tests build and run (Gazebo 9)
-          os: linux
-          language: cpp
-          services:
-            - docker
-          cache:
-            ccache: true
-          env:
-            - PX4_DOCKER_REPO=px4io/px4-dev-simulation-bionic:2020-06-20
-            - BUILD=${CMAKE_UNIT_TEST_BUILD}
         # FIXME: Currently failing when creating QT moc files
-        # - name: CMake build (Gazebo 11)
-        #   os: linux
-        #   language: cpp
-        #   services:
-        #     - docker
-        #   cache:
-        #     ccache: true
-        #   env:
-        #     - PX4_DOCKER_REPO=px4io/px4-dev-simulation-focal:2020-06-20
-        #     - BUILD=${CMAKE_BUILD}
         # - name: CMake unit tests build and run (Gazebo 11)
         #   os: linux
         #   language: cpp
@@ -99,16 +49,6 @@ matrix:
         #   env:
         #     - PX4_DOCKER_REPO=px4io/px4-dev-ros-melodic:2020-06-20
         #     - BUILD=${MELODIC}
-        - name: Validate SDF schemas
-          os: linux
-          language: cpp
-          services:
-            - docker
-          cache:
-            ccache: true
-          env:
-            - PX4_DOCKER_REPO=px4io/px4-dev-simulation-bionic:2020-06-20
-            - BUILD="source ./scripts/validate_sdf.bash"
         - name: macOS Mojave (Xcode 11.3)
           os: osx
           osx_image: xcode11.3


### PR DESCRIPTION
This is an attempt to move build / unit testing to github actions.

Testing includes the following tests
- cmake build tests for gazebo7 , 9, 11
- PX4/Firmware build test with the latest firmware or branch with the same name (Only done in focal with gazebo11, since Firmware CI runs on focal)
- Validation of SDF files

This also adds gazebo11 / focal into the CI :smile:

macOS is still run from travis, I will do a separate PR for macOS, since it is failing on travis too

Edit: Added macOS in https://github.com/PX4/sitl_gazebo/pull/571
