### PR TITLE
Add macOS build tests to github actions

### DIFF
--- a/.github/workflows/build_test_macos.yml
+++ b/.github/workflows/build_test_macos.yml
@@ -1,0 +1,54 @@
+name: MacOS Build Tests
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: submodule update
+      run: git submodule update --init --recursive
+    - name: Before Install
+      run: |
+        brew update;
+        git clone -b release-1.10.0 https://github.com/google/googletest;
+        git clone --depth 1 https://github.com/mavlink/c_library_v2.git /usr/local/include/mavlink/v2.0;
+        pushd /usr/local/include/mavlink/v2.0
+        git checkout 1eff57ee1e54fbed0b24617b1d4452d26d8b2221
+        popd
+    - name: Install
+      run: |
+        pushd googletest
+        mkdir build
+        pushd build
+        cmake ..
+        make
+        make install
+        popd
+        popd
+        brew install gstreamer gst-plugins-base gst-plugins-good glib python
+        brew cask install xquartz
+        brew tap PX4/px4
+        brew install px4-dev
+        brew install px4-sim
+        pip3 install --user --upgrade setuptools
+        pip3 install --user --upgrade rospkg pyserial empy toml numpy pandas jinja2
+    - name: Cmake Build
+      run: |
+        mkdir build
+        cd build
+        cmake ..
+        make
+    - name: Unit Tests
+      working-directory: build
+      run: |
+        cmake -DENABLE_UNIT_TESTS=On ..
+        make
+        make test

--- a/.github/workflows/build_test_macos.yml
+++ b/.github/workflows/build_test_macos.yml
@@ -19,7 +19,7 @@ jobs:
       run: |
         brew update;
         git clone -b release-1.10.0 https://github.com/google/googletest;
-        git clone --depth 1 https://github.com/mavlink/c_library_v2.git /usr/local/include/mavlink/v2.0;
+        git clone https://github.com/mavlink/c_library_v2.git /usr/local/include/mavlink/v2.0;
         pushd /usr/local/include/mavlink/v2.0
         git checkout 1eff57ee1e54fbed0b24617b1d4452d26d8b2221
         popd


### PR DESCRIPTION
This PR adds macOS build tests to github actions. macOS CI has been running usually more than 40 minutes on travis. Lets see if github actions is any faster

This is a dig on gettting https://github.com/PX4/sitl_gazebo/pull/505 running on github actions, also because github actions do not support macOS mojave

Therefore I have left travis so that it can still work with macOS Mojave

**Additional Context**
- Depends on https://github.com/PX4/sitl_gazebo/pull/570
