### PR TITLE
Add MAVSDK Tests to firmware build tests

### DIFF
--- a/.github/workflows/firmware_build_test.yml
+++ b/.github/workflows/firmware_build_test.yml
@@ -1,4 +1,4 @@
-name: Firmware Build Test
+name: Firmware Build and SITL Tests
 
 on:
   push:
@@ -21,6 +21,10 @@ jobs:
         path: Firmware
         fetch-depth: 0
         submodules: recurvise
+    - name: Download MAVSDK
+      run: wget https://github.com/mavlink/MAVSDK/releases/download/v0.27.0/mavsdk_0.27.0_ubuntu18.04_amd64.deb
+    - name: Install MAVSDK
+      run: dpkg -i mavsdk_0.27.0_ubuntu18.04_amd64.deb
     - name: Checkout matching branch on PX4/Firmware if possible
       run: |
         git checkout ${{github.head_ref}} || echo "Firmware branch: ${{github.head_ref}} not found, using master instead"
@@ -33,4 +37,14 @@ jobs:
         git checkout ${{github.head_ref}}
     - name: Build Firmware
       working-directory: Firmware
-      run: DONT_RUN=1 make px4_sitl_default gazebo
+      env:
+        DONT_RUN: 1
+      run: make px4_sitl_default gazebo
+    - name: Build MAVSDK tests
+      working-directory: Firmware
+      env:
+        DONT_RUN: 1
+      run: make px4_sitl_default gazebo mavsdk_tests
+    - name: Run SITL tests
+      working-directory: Firmware
+      run: test/mavsdk_tests/mavsdk_test_runner.py --speed-factor 20 --abort-early test/mavsdk_tests/configs/sitl.json


### PR DESCRIPTION
This PR adds mavsdk testing to the firmware build tests, so that the models can be flown and checked if there are any regressions.
