### PR TITLE
Decrease motor constants of iris

### DIFF
--- a/models/rotors_description/urdf/iris.xacro
+++ b/models/rotors_description/urdf/iris.xacro
@@ -48,7 +48,7 @@
   <xacro:property name="arm_length_back_y" value="0.2" /> <!-- [m] -->
   <xacro:property name="rotor_offset_top" value="0.023" /> <!-- [m] -->
   <xacro:property name="radius_rotor" value="0.128" /> <!-- [m] -->
-  <xacro:property name="motor_constant" value="8.54858e-06" /> <!-- [kg.m/s^2] -->
+  <xacro:property name="motor_constant" value="4.274e-06" /> <!-- [kg.m/s^2] -->
   <xacro:property name="moment_constant" value="0.06" /> <!-- [m] -->
   <xacro:property name="time_constant_up" value="0.0125" /> <!-- [s] -->
   <xacro:property name="time_constant_down" value="0.025" /> <!-- [s] -->


### PR DESCRIPTION
Decreased motor constants since the hover throttle was too low (20%). 

Discussion from: https://github.com/PX4/Firmware/pull/15569