### PR TITLE
Add derived iris models to SITL testing

### DIFF
--- a/resources/sitl.json
+++ b/resources/sitl.json
@@ -11,6 +11,18 @@
             "timeout_min": 10
         },
         {
+            "model": "iris_dual_gps",
+            "vehicle": "iris_dual_gps",
+            "test_filter": "[multicopter]",
+            "timeout_min": 10
+        },
+        {
+            "model": "iris_opt_flow_mockup",
+            "vehicle": "iris_opt_flow_mockup",
+            "test_filter": "[multicopter]",
+            "timeout_min": 10
+        },
+        {
             "model": "standard_vtol",
             "vehicle": "standard_vtol",
             "test_filter": "[multicopter][vtol]",

--- a/resources/sitl.json
+++ b/resources/sitl.json
@@ -17,12 +17,6 @@
             "timeout_min": 10
         },
         {
-            "model": "iris_opt_flow_mockup",
-            "vehicle": "iris_opt_flow_mockup",
-            "test_filter": "[multicopter]",
-            "timeout_min": 10
-        },
-        {
             "model": "standard_vtol",
             "vehicle": "standard_vtol",
             "test_filter": "[multicopter][vtol]",


### PR DESCRIPTION
This PR adds the following models to SITL testing
- `iris_dual_gps`

Related discussion from #504 

Edit: Removed `iris_opt_flow_mockup` from testing since some mission tests were failing