### PR TITLE
Update boat gps sensor

### DIFF
--- a/models/boat/boat.sdf
+++ b/models/boat/boat.sdf
@@ -445,6 +445,15 @@
         <use_parent_model_frame>1</use_parent_model_frame>
       </axis>
     </joint>
+    <include>
+      <uri>model://gps</uri>
+      <pose>0 0 0.12 0 0 0</pose>
+      <name>gps</name>
+    </include>
+    <joint name='gps_joint' type='fixed'>
+      <child>gps::link</child>
+      <parent>base_link</parent>
+    </joint>
     <plugin name='gazebo_imu_plugin' filename='libgazebo_imu_plugin.so'>
       <robotNamespace></robotNamespace>
       <linkName>boat/imu_link</linkName>
@@ -457,12 +466,6 @@
       <accelerometerRandomWalk>0.006</accelerometerRandomWalk>
       <accelerometerBiasCorrelationTime>300.0</accelerometerBiasCorrelationTime>
       <accelerometerTurnOnBiasSigma>0.196</accelerometerTurnOnBiasSigma>
-    </plugin>
-    <plugin name="gps_plugin" filename="libgazebo_gps_plugin.so">
-        <robotNamespace></robotNamespace>
-        <gpsNoise>true</gpsNoise>
-        <homeLatitude>47.343609</homeLatitude>
-        <homeLongitude>8.541391</homeLongitude>
     </plugin>
     <plugin name='magnetometer_plugin' filename='libgazebo_magnetometer_plugin.so'>
       <robotNamespace/>


### PR DESCRIPTION
Previous update on moving gps to a sensor plugin in https://github.com/PX4/sitl_gazebo/pull/517 caused the boat plugin to not load properly

This PR fixes this problem by updating the gps plugin to load the gps model