### PR TITLE
Handle when gps tag command is unsuccessful

### DIFF
--- a/src/gazebo_geotagged_images_plugin.cpp
+++ b/src/gazebo_geotagged_images_plugin.cpp
@@ -227,7 +227,9 @@ void GeotaggedImagesPlugin::OnNewFrame(const unsigned char * image)
              " -gpsmeasuremode=3-d -gpssatellites=13 -gpsaltitude=%.3lf -overwrite_original %s &>/dev/null",
              north_south, east_west, lat, lon, _lastGpsPosition.Z(), file_name);
 
-    system(gps_tag_command);
+    if (system(gps_tag_command) != 0) {
+        gzwarn << "Unable to tag GPS to image: gps tag command returned 1" << endl;
+    }
 
     gzmsg << "Took picture: " << file_name << endl;
 


### PR DESCRIPTION
**Problem Description**
There was a warning message when building PX4 SITL as the following
```
[49/112] Building CXX object CMakeFile...c/gazebo_geotagged_images_plugin.cpp.o
/home/jaeyoung/src/Firmware/Tools/sitl_gazebo/src/gazebo_geotagged_images_plugin.cpp: In member function 'void gazebo::GeotaggedImagesPlugin::OnNewFrame(const unsigned char*)':
/home/jaeyoung/src/Firmware/Tools/sitl_gazebo/src/gazebo_geotagged_images_plugin.cpp:230:11: warning: ignoring return value of 'int system(const char*)', declared with attribute warn_unused_result [-Wunused-result]
     system(gps_tag_command);
     ~~~~~~^~~~~~~~~~~~~~~~~
```

**Solution**
This reports a `gzwarn` when the `gps_tag_command` is unsuccessful.