### PR TITLE
Update mavsdk version for SITL tests

### DIFF
--- a/.github/workflows/firmware_build_test.yml
+++ b/.github/workflows/firmware_build_test.yml
@@ -22,9 +22,9 @@ jobs:
         fetch-depth: 0
         submodules: recurvise
     - name: Download MAVSDK
-      run: wget https://github.com/mavlink/MAVSDK/releases/download/v0.27.0/mavsdk_0.27.0_ubuntu18.04_amd64.deb
+      run: wget https://github.com/mavlink/MAVSDK/releases/download/v0.30.1/mavsdk_0.30.1_ubuntu20.04_amd64.deb
     - name: Install MAVSDK
-      run: dpkg -i mavsdk_0.27.0_ubuntu18.04_amd64.deb
+      run: dpkg -i mavsdk_0.30.1_ubuntu20.04_amd64.deb
     - name: Checkout matching branch on PX4/Firmware if possible
       run: |
         git checkout ${{github.head_ref}} || echo "Firmware branch: ${{github.head_ref}} not found, using master instead"


### PR DESCRIPTION
**Problem Description**
Wasn't able to build mavsdk  tests due to the incorrect mavsdk version with the following error
```
CMake Error at CMakeLists.txt:13 (add_executable):
  Target "mavsdk_tests" links to target "MAVSDK::mavsdk_failure" but the
  target was not found.  Perhaps a find_package() call is missing for an
  IMPORTED target, or an ALIAS target is missing?


CMake Error at CMakeLists.txt:13 (add_executable):
  Target "mavsdk_tests" links to target "MAVSDK::mavsdk_manual_control" but
  the target was not found.  Perhaps a find_package() call is missing for an
  IMPORTED target, or an ALIAS target is missing?
```

**Solution**
Update mavsdk version to `30.1`