### PR TITLE
Support forwarding jinja template outputs for multivehicles

### DIFF
--- a/scripts/jinja_gen.py
+++ b/scripts/jinja_gen.py
@@ -9,10 +9,11 @@ import numpy as np
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument('filename')
+    parser.add_argument('filename', help="file that the sdf file should be generated from")
     parser.add_argument('env_dir')
-    parser.add_argument('--mavlink_tcp_port', default=4560)
-    parser.add_argument('--mavlink_udp_port', default=14560)
+    parser.add_argument('--mavlink_tcp_port', default=4560, help="TCP port for PX4 SITL")
+    parser.add_argument('--mavlink_udp_port', default=14560, help="Mavlink UDP port for mavlink access")
+    parser.add_argument('--output-file', help="sdf output file")
     args = parser.parse_args()
     env = jinja2.Environment(loader=jinja2.FileSystemLoader(args.env_dir))
     template = env.get_template(os.path.relpath(args.filename, args.env_dir))
@@ -27,7 +28,11 @@ if __name__ == "__main__":
 
     d = {'np': np, 'rospack': rospack, 'mavlink_tcp_port': args.mavlink_tcp_port, 'mavlink_udp_port': args.mavlink_udp_port}
     result = template.render(d)
-    filename_out = args.filename.replace('.sdf.jinja', '-gen.sdf')
+    if args.output_file:
+        filename_out = args.output_file
+    else:
+        filename_out = args.filename.replace('.sdf.jinja', '-gen.sdf')
+
     with open(filename_out, 'w') as f_out:
         print(('{:s} -> {:s}'.format(args.filename, filename_out)))
         f_out.write(result)


### PR DESCRIPTION
**Problem Description**
The jinja template output only always create the file in the same directory where the template exists. Therefore this cannot be used for multi-vehicle scenarios where the resulting files need to be directed to different files.

**Solution**
This commit enables forwarding jinja template outputs to a specific file path.

**Additional Context**
- Commit messages are a bit messy since it is based on https://github.com/PX4/sitl_gazebo/pull/609