### PR TITLE
removed motor forces/moments from uuv_plugin

### DIFF
--- a/include/gazebo_uuv_plugin.h
+++ b/include/gazebo_uuv_plugin.h
@@ -26,28 +26,16 @@
 #include <gazebo/common/common.hh>
 #include <gazebo/common/Plugin.hh>
 #include <rotors_model/motor_model.hpp>
-#include "CommandMotorSpeed.pb.h"
 #include "gazebo/transport/transport.hh"
 #include "gazebo/msgs/msgs.hh"
-#include "MotorSpeed.pb.h"
 #include "Float.pb.h"
 #include "common.h"
 
-
-namespace turning_direction {
-const static int CCW = 1;
-const static int CW = -1;
-}
-
 namespace gazebo {
-typedef const boost::shared_ptr<const mav_msgs::msgs::CommandMotorSpeed> CommandMotorSpeedPtr;
 
-class GazeboUUVPlugin : public MotorModel, public ModelPlugin {
+class GazeboUUVPlugin : public ModelPlugin {
  public:
-  GazeboUUVPlugin()
-      : ModelPlugin(),
-        MotorModel(){
-  }
+  GazeboUUVPlugin() : ModelPlugin(){}
 
   virtual ~GazeboUUVPlugin();
   virtual void InitializeParams();
@@ -59,18 +47,7 @@ class GazeboUUVPlugin : public MotorModel, public ModelPlugin {
 
  private:
   std::string namespace_;
-  std::string command_sub_topic_;
   std::string link_base_;
-  std::string link_prop_0_;
-  std::string link_prop_1_;
-  std::string link_prop_2_;
-  std::string link_prop_3_;
-
-  int turning_directions_[4];
-  double motor_commands_[4];
-  double motor_force_constant_;
-  double motor_torque_constant_;
-  double dead_zone_;
 
   /* Hydro coefficients - FOSSEN 2011 */
   double X_u_;
@@ -88,17 +65,9 @@ class GazeboUUVPlugin : public MotorModel, public ModelPlugin {
   double N_rdot_;
 
   transport::NodePtr node_handle_;
-  transport::SubscriberPtr command_sub_;
   physics::ModelPtr model_;
   physics::LinkPtr baseLink_;
-  physics::LinkPtr prop0Link_;
-  physics::LinkPtr prop1Link_;
-  physics::LinkPtr prop2Link_;
-  physics::LinkPtr prop3Link_;
   event::ConnectionPtr updateConnection_;
-  boost::thread callback_queue_thread_;
-  void QueueThread();
-  void VelocityCallback(CommandMotorSpeedPtr &rot_velocities);
 
 };
 }

--- a/models/uuv_hippocampus/uuv_hippocampus.sdf
+++ b/models/uuv_hippocampus/uuv_hippocampus.sdf
@@ -12,6 +12,7 @@
       The hydrodynamic effects are modelled as forces/moments, see 'UpdateForcesAndMoments'-method in the uuv plugin.
   -->
   <model name='uuv_hippocampus'>
+    <static>0</static>
     <link name='base_link'>
 
       <pose>0 0 0 0 0 0</pose>
@@ -72,54 +73,6 @@
       </visual>
       <gravity>0</gravity>
       <velocity_decay/>
-      <!-- Body Frame Visualization -->
-      <!--
-      <visual name='coordinate_x'>
-        <pose>0.15 0 0 0 1.570796 0</pose>
-        <geometry>
-          <cylinder>
-            <radius>0.0025</radius>
-            <length>0.3</length>
-          </cylinder>
-        </geometry>
-        <material>
-          <script>
-            <name>Gazebo/Red</name>
-            <uri>file://media/materials/scripts/gazebo.material</uri>
-          </script>
-        </material>
-      </visual>
-      <visual name='coordinate_y'>
-        <pose>0 -0.075 0 1.570796 0 0</pose>
-        <geometry>
-          <cylinder>
-            <radius>0.0025</radius>
-            <length>0.15</length>
-          </cylinder>
-        </geometry>
-        <material>
-          <script>
-            <name>Gazebo/Green</name>
-            <uri>file://media/materials/scripts/gazebo.material</uri>
-          </script>
-        </material>
-      </visual>
-      <visual name='coordinate_z'>
-        <pose>0 0 -0.075 0 0 0</pose>
-        <geometry>
-          <cylinder>
-            <radius>0.0025</radius>
-            <length>0.15</length>
-          </cylinder>
-        </geometry>
-        <material>
-          <script>
-            <name>Gazebo/Blue</name>
-            <uri>file://media/materials/scripts/gazebo.material</uri>
-          </script>
-        </material>
-      </visual>
-      -->
     </link>
 
     <!--
@@ -175,7 +128,7 @@
 <!-- CCW 1-->
 <!-- rotor_0 link -->
     <link name='rotor_0'>
-      <pose>-0.05 0.0481 0.0481 0 0 0</pose>
+      <pose>-0.05 0.0481 0.0481 0 1.570796 0</pose>
       <inertial>
         <pose>0 0 0 0 -0 0</pose>
         <mass>0.005</mass>
@@ -206,7 +159,7 @@
         </surface>
       </collision>
       <visual name='rotor_0_visual'>
-        <pose>0 0 0 0 0 0</pose>
+        <pose>0 0 0 0 -1.570796 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -245,7 +198,7 @@
 <!-- CW 2 -->
 <!-- rotor_1 link -->
     <link name='rotor_1'>
-      <pose>-0.05 -0.0481 0.0481 0 0 0</pose>
+      <pose>-0.05 -0.0481 0.0481 0 1.570796 0</pose>
       <inertial>
         <pose>0 0 0 0 -0 0</pose>
         <mass>0.005</mass>
@@ -276,7 +229,7 @@
         </surface>
       </collision>
       <visual name='rotor_1_visual'>
-        <pose>0 0 0 0 0 0</pose>
+        <pose>0 0 0 0 -1.570796 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -315,7 +268,7 @@
 <!-- CCW 3 -->
 <!-- rotor_2 link -->
     <link name='rotor_2'>
-      <pose>-0.05 -0.0481 -0.0481 0 0 0</pose>
+      <pose>-0.05 -0.0481 -0.0481 0 1.570796 0</pose>
       <inertial>
         <pose>0 0 0 0 -0 0</pose>
         <mass>0.005</mass>
@@ -346,7 +299,7 @@
         </surface>
       </collision>
       <visual name='rotor_2_visual'>
-        <pose>0 0 0 0 0 0</pose>
+        <pose>0 0 0 0 -1.570796 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -385,7 +338,7 @@
 <!-- CW 4 -->
 <!-- rotor_3 link -->
     <link name='rotor_3'>
-      <pose>-0.05 0.0481 -0.0481 0 0 0</pose>
+      <pose>-0.05 0.0481 -0.0481 0 1.570796 0</pose>
       <inertial>
         <pose>0 0 0 0 -0 0</pose>
         <mass>0.005</mass>
@@ -416,7 +369,7 @@
         </surface>
       </collision>
       <visual name='rotor_3_visual'>
-        <pose>0 0 0 0 0 0</pose>
+        <pose>0 0 0 0 -1.570796 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -464,36 +417,14 @@
     </joint>
 
 <!-- Plugins -->
-    <static>0</static>
-
-    <plugin name='rosbag' filename='libgazebo_multirotor_base_plugin.so'>
-      <robotNamespace/>
-      <linkName>base_link</linkName>
-      <rotorVelocitySlowdownSim>0.05</rotorVelocitySlowdownSim>
-    </plugin>
 
     <plugin name='groundtruth_plugin' filename='libgazebo_groundtruth_plugin.so'>
       <robotNamespace/>
     </plugin>
 
-    <!--
-      propXlinks receive relative force from uuv_plugin
-      baselink receives relative torque
-    -->
     <plugin name='uuv_forces' filename='libgazebo_uuv_plugin.so'>
       <robotNamespace/>
       <baseLinkName>base_link</baseLinkName>
-      <prop0LinkName>rotor_0</prop0LinkName>
-      <prop1LinkName>rotor_1</prop1LinkName>
-      <prop2LinkName>rotor_2</prop2LinkName>
-      <prop3LinkName>rotor_3</prop3LinkName>
-      <turningDirection0>ccw</turningDirection0>
-      <turningDirection1>cw</turningDirection1>
-      <turningDirection2>ccw</turningDirection2>
-      <turningDirection3>cw</turningDirection3>
-      <motorForceConstant>8.5</motorForceConstant>
-      <motorTorqueConstant>0.0024</motorTorqueConstant>
-      <deadZone>0</deadZone>
       <addedMassLinear>1.11 2.8 2.8</addedMassLinear>
       <addedMassAngular>0.00451 0.0163 0.0163</addedMassAngular>
       <dampingLinear>5.39 17.36 17.36</dampingLinear>
@@ -501,21 +432,17 @@
       <commandSubTopic>/gazebo/command/motor_speed</commandSubTopic>
     </plugin>
 
-    <!--
-        The gazebo_motor_model.cpp is called.
-        Forces and Moments are set to zero since they are already calculated using the gazebo_uuv_plugin (see above).
-        The motor model plugins can be removed if you don't need the rotors to spin.
-    -->
     <plugin name='top_port_motor_model' filename='libgazebo_motor_model.so'>
       <robotNamespace/>
+      <reversible>true</reversible>
       <jointName>rotor_0_joint</jointName>
       <linkName>rotor_0</linkName>
       <turningDirection>ccw</turningDirection>
       <timeConstantUp>0.0125</timeConstantUp>
       <timeConstantDown>0.025</timeConstantDown>
       <maxRotVelocity>1100</maxRotVelocity>
-      <motorConstant>0.0</motorConstant>
-      <momentConstant>0.00</momentConstant>
+      <motorConstant>8.5</motorConstant>
+      <momentConstant>0.0024</momentConstant>
       <rotorDragCoefficient>0.0</rotorDragCoefficient>
       <rollingMomentCoefficient>0.0</rollingMomentCoefficient>
       <commandSubTopic>/gazebo/command/motor_speed</commandSubTopic>
@@ -525,14 +452,15 @@
     </plugin>
     <plugin name='top_starboard_motor_model' filename='libgazebo_motor_model.so'>
       <robotNamespace/>
+      <reversible>true</reversible>
       <jointName>rotor_1_joint</jointName>
       <linkName>rotor_1</linkName>
       <turningDirection>cw</turningDirection>
       <timeConstantUp>0.0125</timeConstantUp>
       <timeConstantDown>0.025</timeConstantDown>
       <maxRotVelocity>1100</maxRotVelocity>
-      <motorConstant>0.0</motorConstant>
-      <momentConstant>0.0</momentConstant>
+      <motorConstant>-8.5</motorConstant>
+      <momentConstant>0.0024</momentConstant>
       <rotorDragCoefficient>0.0</rotorDragCoefficient>
       <rollingMomentCoefficient>0.0</rollingMomentCoefficient>
       <commandSubTopic>/gazebo/command/motor_speed</commandSubTopic>
@@ -542,36 +470,38 @@
     </plugin>
     <plugin name='bottom_starboard_motor_model' filename='libgazebo_motor_model.so'>
       <robotNamespace/>
+      <reversible>true</reversible>
       <jointName>rotor_2_joint</jointName>
       <linkName>rotor_2</linkName>
       <turningDirection>ccw</turningDirection>
       <timeConstantUp>0.0125</timeConstantUp>
       <timeConstantDown>0.025</timeConstantDown>
       <maxRotVelocity>1100</maxRotVelocity>
-      <motorConstant>0.0</motorConstant>
-      <momentConstant>0.0</momentConstant>
+      <motorConstant>8.5</motorConstant>
+      <momentConstant>0.0024</momentConstant>
       <rotorDragCoefficient>0.0</rotorDragCoefficient>
       <rollingMomentCoefficient>0.0</rollingMomentCoefficient>
       <commandSubTopic>/gazebo/command/motor_speed</commandSubTopic>
-      <motorNumber>0</motorNumber>
-      <motorSpeedPubTopic>/motor_speed/0</motorSpeedPubTopic>
+      <motorNumber>2</motorNumber>
+      <motorSpeedPubTopic>/motor_speed/2</motorSpeedPubTopic>
       <rotorVelocitySlowdownSim>0.05</rotorVelocitySlowdownSim>
     </plugin>
     <plugin name='bottom_port_motor_model' filename='libgazebo_motor_model.so'>
       <robotNamespace/>
+      <reversible>true</reversible>
       <jointName>rotor_3_joint</jointName>
       <linkName>rotor_3</linkName>
       <turningDirection>cw</turningDirection>
       <timeConstantUp>0.0125</timeConstantUp>
       <timeConstantDown>0.025</timeConstantDown>
       <maxRotVelocity>1100</maxRotVelocity>
-      <motorConstant>0.0</motorConstant>
-      <momentConstant>0.0</momentConstant>
+      <motorConstant>-8.5</motorConstant>
+      <momentConstant>0.0024</momentConstant>
       <rotorDragCoefficient>0.0</rotorDragCoefficient>
       <rollingMomentCoefficient>0.0</rollingMomentCoefficient>
       <commandSubTopic>/gazebo/command/motor_speed</commandSubTopic>
-      <motorNumber>0</motorNumber>
-      <motorSpeedPubTopic>/motor_speed/0</motorSpeedPubTopic>
+      <motorNumber>3</motorNumber>
+      <motorSpeedPubTopic>/motor_speed/3</motorSpeedPubTopic>
       <rotorVelocitySlowdownSim>0.05</rotorVelocitySlowdownSim>
     </plugin>
 
@@ -655,7 +585,6 @@
       </control_channels>
     </plugin>
 
-    <static>0</static>
     <plugin name='gazebo_imu_plugin' filename='libgazebo_imu_plugin.so'>
       <robotNamespace/>
       <linkName>uuv_hippocampus/imu_link</linkName>


### PR DESCRIPTION
The generic motor_model plugin does exactly the same as the motor code in the uuv_plugin. So i removed the motor forces/moments from the uuv_plugin and modified the uuv_hippocampus.sdf to use the generic motor plugin to avoid redundant code.

The uuv_plugin still computes hydrodynamic forces.
@DanielDuecker 