### PR TITLE
removed none used vars from gazebo_mavlink_interface

### DIFF
--- a/include/gazebo_mavlink_interface.h
+++ b/include/gazebo_mavlink_interface.h
@@ -159,21 +159,6 @@ private:
 
   physics::ModelPtr model_{};
   physics::WorldPtr world_{nullptr};
-  physics::JointPtr left_elevon_joint_{nullptr};
-  physics::JointPtr right_elevon_joint_{nullptr};
-  physics::JointPtr elevator_joint_{nullptr};
-  physics::JointPtr propeller_joint_{nullptr};
-  physics::JointPtr gimbal_yaw_joint_{nullptr};
-  physics::JointPtr gimbal_pitch_joint_{nullptr};
-  physics::JointPtr gimbal_roll_joint_{nullptr};
-  common::PID propeller_pid_;
-  common::PID elevator_pid_;
-  common::PID left_elevon_pid_;
-  common::PID right_elevon_pid_;
-  bool use_propeller_pid_{false};
-  bool use_elevator_pid_{false};
-  bool use_left_elevon_pid_{false};
-  bool use_right_elevon_pid_{false};
 
   bool send_vision_estimation_{false};
   bool send_odometry_{false};

--- a/models/delta_wing/delta_wing.sdf
+++ b/models/delta_wing/delta_wing.sdf
@@ -290,20 +290,6 @@
       <hil_mode>false</hil_mode>
       <hil_state_level>false</hil_state_level>
       <motorSpeedCommandPubTopic>/gazebo/command/motor_speed</motorSpeedCommandPubTopic>
-      <!-- no elevator
-      <left_elevon_joint>
-        zephyr_delta_wing::flap_left_joint
-      </left_elevon_joint>
-      <right_elevon_joint>
-        zephyr_delta_wing::flap_right_joint
-      </right_elevon_joint>
-      <propeller_joint>
-        zephyr_delta_wing::propeller_joint
-      </propeller_joint>
-      <elevator_joint>
-        no_elevator_joint_nope
-      </elevator_joint>
-      -->
       <control_channels>
         <channel name="not_used_1">
           <input_index>0</input_index>

--- a/models/rotors_description/urdf/component_snippets.xacro
+++ b/models/rotors_description/urdf/component_snippets.xacro
@@ -546,15 +546,6 @@
             <joint_name>elevator_joint</joint_name>
           </channel>
         </control_channels>
-        <left_elevon_joint>
-          left_elevon_joint
-        </left_elevon_joint>
-        <right_elevon_joint>
-          right_elevon_joint
-        </right_elevon_joint>
-        <elevator_joint>
-          elevator_joint
-        </elevator_joint>
       </plugin>
     </gazebo>
   </xacro:macro>

--- a/models/standard_vtol/standard_vtol.sdf.jinja
+++ b/models/standard_vtol/standard_vtol.sdf.jinja
@@ -1018,15 +1018,6 @@
           <joint_name>elevator_joint</joint_name>
         </channel>
       </control_channels>
-      <left_elevon_joint>
-        left_elevon_joint
-      </left_elevon_joint>
-      <right_elevon_joint>
-        right_elevon_joint
-      </right_elevon_joint>
-      <elevator_joint>
-        elevator_joint
-      </elevator_joint>
     </plugin>
     <static>0</static>
   </model>

--- a/models/standard_vtol_hitl/standard_vtol_hitl.sdf
+++ b/models/standard_vtol_hitl/standard_vtol_hitl.sdf
@@ -1021,15 +1021,6 @@
           <joint_name>elevator_joint</joint_name>
         </channel>
       </control_channels>
-      <left_elevon_joint>
-        left_elevon_joint
-      </left_elevon_joint>
-      <right_elevon_joint>
-        right_elevon_joint
-      </right_elevon_joint>
-      <elevator_joint>
-        elevator_joint
-      </elevator_joint>
     </plugin>
     <static>0</static>
   </model>

--- a/models/tailsitter/tailsitter.sdf
+++ b/models/tailsitter/tailsitter.sdf
@@ -741,12 +741,6 @@
           <joint_name>right_elevon_joint</joint_name>
         </channel>
       </control_channels>
-      <left_elevon_joint>
-        left_elevon_joint
-      </left_elevon_joint>
-      <right_elevon_joint>
-        right_elevon_joint
-      </right_elevon_joint>
     </plugin>
     <static>0</static>
   </model>

--- a/models/tiltrotor/tiltrotor.sdf
+++ b/models/tiltrotor/tiltrotor.sdf
@@ -1215,15 +1215,6 @@
           <joint_name>elevator_joint</joint_name>
         </channel>
       </control_channels>
-      <left_elevon_joint>
-        left_elevon_joint
-      </left_elevon_joint>
-      <right_elevon_joint>
-        right_elevon_joint
-      </right_elevon_joint>
-      <elevator_joint>
-        elevator_joint
-      </elevator_joint>
     </plugin>
     <static>0</static>
   </model>


### PR DESCRIPTION
seems like old leftovers.

@TSC21 @Jaeyoung-Lim can you confirm my PR.
looking on the code its seems like old code that hasn't been removed
