### PR TITLE
Adjust iris obs avoid distance sensor location

### DIFF
--- a/models/iris_obs_avoid/iris_obs_avoid.sdf
+++ b/models/iris_obs_avoid/iris_obs_avoid.sdf
@@ -36,7 +36,7 @@
     <!--forward-facing lidar-->
     <include>
       <uri>model://lidar</uri>
-      <pose>0 0 -0.05 0 -1.57079633 0</pose>
+      <pose>0 0 -0.10 0 -1.57079633 0</pose>
       <name>lidar1</name>
     </include>
 
@@ -48,7 +48,7 @@
     <!--right-facing lidar-->
     <include>
       <uri>model://lidar</uri>
-      <pose>0 0 -0.05 -1.57079633 0 0</pose>
+      <pose>0 0 -0.10 -1.57079633 0 0</pose>
       <name>lidar2</name>
     </include>
 
@@ -60,7 +60,7 @@
     <!--left-facing lidar-->
     <include>
       <uri>model://lidar</uri>
-      <pose>0 0 -0.05 1.57079633 0 0</pose>
+      <pose>0 0 -0.10 1.57079633 0 0</pose>
       <name>lidar3</name>
     </include>
 
@@ -75,7 +75,7 @@
     <!--backward-facing lidar-->
     <!-- <include>
       <uri>model://lidar</uri>
-      <pose>0 0 -0.05 0 1.57079633 0</pose>
+      <pose>0 0 -0.10 0 1.57079633 0</pose>
       <name>lidar4</name>
     </include>
 


### PR DESCRIPTION
Fix #604.

I've moved the horizontal (forward, left, right, back) distance sensors down from -5 cm to -10 cm. This makes them mostly work as they should, but they still sometimes give incorrect (very short) readings. See log below, and gazebo collision box image:

![collision](https://user-images.githubusercontent.com/6639836/94803614-d4f4ac00-03e9-11eb-8d32-8bad0cf793bc.png)
![Screenshot at 2020-10-01 13-27-50](https://user-images.githubusercontent.com/6639836/94803665-eccc3000-03e9-11eb-8d44-df215847b291.png)
