### PR TITLE
Remove vehicle_is_tailsitter tag from models

### DIFF
--- a/models/cloudship/cloudship.sdf.jinja
+++ b/models/cloudship/cloudship.sdf.jinja
@@ -586,7 +586,6 @@
       <enable_lockstep>true</enable_lockstep>
       <use_tcp>true</use_tcp>
 
-      <vehicle_is_tailsitter>false</vehicle_is_tailsitter>
       <send_vision_estimation>true</send_vision_estimation>
       <send_odometry>false</send_odometry>
 

--- a/models/if750a/if750a.sdf
+++ b/models/if750a/if750a.sdf
@@ -478,7 +478,6 @@
       <hil_state_level>false</hil_state_level>
       <enable_lockstep>true</enable_lockstep>
       <use_tcp>true</use_tcp>
-      <vehicle_is_tailsitter>false</vehicle_is_tailsitter>
       <send_vision_estimation>true</send_vision_estimation>
       <send_odometry>false</send_odometry>
       <motorSpeedCommandPubTopic>/gazebo/command/motor_speed</motorSpeedCommandPubTopic>

--- a/models/iris/iris.sdf.jinja
+++ b/models/iris/iris.sdf.jinja
@@ -499,7 +499,6 @@
       <sdk_udp_port>14540</sdk_udp_port>
       <hil_mode>0</hil_mode>
       <hil_state_level>0</hil_state_level>
-      <vehicle_is_tailsitter>0</vehicle_is_tailsitter>
       <send_vision_estimation>0</send_vision_estimation>
       <send_odometry>1</send_odometry>
       <enable_lockstep>1</enable_lockstep>

--- a/models/iris_hitl/iris_hitl.sdf
+++ b/models/iris_hitl/iris_hitl.sdf
@@ -460,7 +460,6 @@
       <sdk_udp_port>14540</sdk_udp_port>
       <hil_mode>1</hil_mode>
       <hil_state_level>0</hil_state_level>
-      <vehicle_is_tailsitter>0</vehicle_is_tailsitter>
       <send_vision_estimation>0</send_vision_estimation>
       <send_odometry>1</send_odometry>
       <enable_lockstep>0</enable_lockstep>

--- a/models/px4vision/px4vision.sdf
+++ b/models/px4vision/px4vision.sdf
@@ -460,7 +460,6 @@
       <sdk_udp_port>14540</sdk_udp_port>
       <hil_mode>0</hil_mode>
       <hil_state_level>0</hil_state_level>
-      <vehicle_is_tailsitter>0</vehicle_is_tailsitter>
       <send_vision_estimation>1</send_vision_estimation>
       <send_odometry>0</send_odometry>
       <enable_lockstep>1</enable_lockstep>

--- a/models/standard_vtol_hitl/standard_vtol_hitl.sdf
+++ b/models/standard_vtol_hitl/standard_vtol_hitl.sdf
@@ -941,7 +941,6 @@
       <sdk_udp_port>14540</sdk_udp_port>
       <hil_mode>1</hil_mode>
       <hil_state_level>0</hil_state_level>
-      <vehicle_is_tailsitter>0</vehicle_is_tailsitter>
       <send_vision_estimation>0</send_vision_estimation>
       <send_odometry>1</send_odometry>
       <enable_lockstep>0</enable_lockstep>

--- a/models/uuv_hippocampus/uuv_hippocampus.sdf
+++ b/models/uuv_hippocampus/uuv_hippocampus.sdf
@@ -537,7 +537,6 @@
       <sdk_udp_port>14540</sdk_udp_port>
       <hil_mode>false</hil_mode>
       <hil_state_level>false</hil_state_level>
-      <vehicle_is_tailsitter>false</vehicle_is_tailsitter>
       <send_vision_estimation>true</send_vision_estimation>
       <send_odometry>false</send_odometry>
       <enable_lockstep>true</enable_lockstep>


### PR DESCRIPTION
**Problem Description**
`vehicle_is_tailsitter` is not being used in the gazebo_mavlink_interface since https://github.com/PX4/sitl_gazebo/pull/515.

**Solution**
The tag was removed from all models that contain the tag