### PR TITLE
Add buoyancy in uuv_plugin

### DIFF
--- a/include/gazebo_uuv_plugin.h
+++ b/include/gazebo_uuv_plugin.h
@@ -39,6 +39,8 @@ class GazeboUUVPlugin : public ModelPlugin {
 
   virtual ~GazeboUUVPlugin();
   virtual void InitializeParams();
+  void ParseBuoyancy(physics::ModelPtr _model);
+  void ApplyBuoyancy();
   virtual void Publish();
  protected:
   virtual void UpdateForcesAndMoments();
@@ -46,6 +48,14 @@ class GazeboUUVPlugin : public ModelPlugin {
   virtual void OnUpdate(const common::UpdateInfo &);
 
  private:
+  struct buoyancy_s {
+    std::string model_name;
+    physics::LinkPtr link;
+    ignition::math::Vector3d buoyancy_force;
+    ignition::math::Vector3d cob;
+    double height_scale_limit;
+  };
+  std::vector<buoyancy_s> buoyancy_links_;
   std::string namespace_;
   std::string link_base_;
 

--- a/include/gazebo_uuv_plugin.h
+++ b/include/gazebo_uuv_plugin.h
@@ -39,7 +39,7 @@ class GazeboUUVPlugin : public ModelPlugin {
 
   virtual ~GazeboUUVPlugin();
   virtual void InitializeParams();
-  void ParseBuoyancy(physics::ModelPtr _model);
+  void ParseBuoyancy(sdf::ElementPtr _sdf);
   void ApplyBuoyancy();
   virtual void Publish();
  protected:

--- a/models/uuv_hippocampus/uuv_hippocampus.sdf
+++ b/models/uuv_hippocampus/uuv_hippocampus.sdf
@@ -414,13 +414,12 @@
     </plugin>
 
     <plugin name='uuv_forces' filename='libgazebo_uuv_plugin.so'>
-      <link name="base_link">
-        <buoyancy>
-          <origin>0 0 0.01</origin>
-          <compensation>1.1</compensation>
-          <height_scale_limit>0.05</height_scale_limit>
-        </buoyancy>
-      </link>
+      <buoyancy>
+        <link_name>base_link</link_name>
+        <origin>0 0 0.01</origin>
+        <compensation>1.1</compensation>
+        <height_scale_limit>0.05</height_scale_limit>
+      </buoyancy>
       <robotNamespace/>
       <baseLinkName>base_link</baseLinkName>
       <addedMassLinear>1.11 2.8 2.8</addedMassLinear>

--- a/models/uuv_hippocampus/uuv_hippocampus.sdf
+++ b/models/uuv_hippocampus/uuv_hippocampus.sdf
@@ -23,8 +23,6 @@
           values used to correct for hydrodynamic effects.
           Real values:  m = 1,47 kg; Ixx = 0,002408 kgm2; Iyy = Izz = 0.010717 kgm2
                         Xu = -1,11 kg; Yv = Zw = -2,8 kg; Kp = -0,00451 kgm2; Mq = Nr = -0,0163 kgm2
-
-          No gravity since weight and draft force are assumed to be equal for the hippocampus uuv
         -->
         <mass>1.47</mass>
         <inertia>
@@ -71,7 +69,6 @@
           </script>
         </material>
       </visual>
-      <gravity>0</gravity>
       <velocity_decay/>
     </link>
 
@@ -85,7 +82,6 @@
 <!-- IMU link -->
     <link name='uuv_hippocampus/imu_link'>
       <pose>0 0 0 0 0 0</pose>
-      <!--<pose>0 0 0 3.1415 0 0</pose>-->
       <inertial>
         <pose>0 0 0 0 0 0</pose>
         <mass>0.015</mass>
@@ -98,7 +94,6 @@
           <izz>1e-05</izz>
         </inertia>
       </inertial>
-      <gravity>0</gravity>
     </link>
 
 <!-- IMU joint -->
@@ -173,7 +168,6 @@
           </script>
         </material>
       </visual>
-      <gravity>0</gravity>
       <velocity_decay/>
     </link>
 
@@ -243,7 +237,6 @@
           </script>
         </material>
       </visual>
-      <gravity>0</gravity>
       <velocity_decay/>
     </link>
 
@@ -313,7 +306,6 @@
           </script>
         </material>
       </visual>
-      <gravity>0</gravity>
       <velocity_decay/>
     </link>
 
@@ -383,7 +375,6 @@
           </script>
         </material>
       </visual>
-      <gravity>0</gravity>
       <velocity_decay/>
     </link>
 
@@ -423,6 +414,12 @@
     </plugin>
 
     <plugin name='uuv_forces' filename='libgazebo_uuv_plugin.so'>
+      <link name="base_link">
+        <buoyancy>
+          <origin>0 0 0.01</origin>
+          <compensation>1.1</compensation>
+        </buoyancy>
+      </link>
       <robotNamespace/>
       <baseLinkName>base_link</baseLinkName>
       <addedMassLinear>1.11 2.8 2.8</addedMassLinear>

--- a/models/uuv_hippocampus/uuv_hippocampus.sdf
+++ b/models/uuv_hippocampus/uuv_hippocampus.sdf
@@ -418,6 +418,7 @@
         <buoyancy>
           <origin>0 0 0.01</origin>
           <compensation>1.1</compensation>
+          <height_scale_limit>0.05</height_scale_limit>
         </buoyancy>
       </link>
       <robotNamespace/>

--- a/src/gazebo_uuv_plugin.cpp
+++ b/src/gazebo_uuv_plugin.cpp
@@ -141,7 +141,12 @@ void GazeboUUVPlugin::OnUpdate(const common::UpdateInfo& _info) {
 void GazeboUUVPlugin::ApplyBuoyancy() {
   ignition::math::Vector3d force, cob;
   for (std::vector<buoyancy_s>::iterator entry = buoyancy_links_.begin(); entry != buoyancy_links_.end(); ++entry) {
-    cob = entry->link->WorldPose().Pos() + entry->link->WorldPose().Rot().RotateVector(entry->cob);
+    #if GAZEBO_MAJOR_VERSION >= 9
+      ignition::math::Pose3d pose = entry->link->WorldPose();
+    #else
+      ignition::math::Pose3d pose = ignitionFromGazeboMath(entry->link->GetWorldPose());
+    #endif
+    cob = pose.Pos() + pose.Rot().RotateVector(entry->cob);
     force = entry->buoyancy_force;
     // apply linear scaling on buoyancy force if center of buoyancy z-coordinate
     // is in range [-height_scale_limit, +height_scale limit].

--- a/src/gazebo_uuv_plugin.cpp
+++ b/src/gazebo_uuv_plugin.cpp
@@ -53,6 +53,7 @@ void GazeboUUVPlugin::ParseBuoyancy(physics::ModelPtr _model) {
         buoyancy_link.link = link_ptr;
         buoyancy_link.buoyancy_force = ignition::math::Vector3d(0, 0, 0);
         buoyancy_link.cob = ignition::math::Vector3d(0, 0, 0);
+        buoyancy_link.height_scale_limit = 0.1;
         double compensation = 0.0;
 
         if (buoyancy_element->HasElement("origin")) {
@@ -61,8 +62,10 @@ void GazeboUUVPlugin::ParseBuoyancy(physics::ModelPtr _model) {
         if (buoyancy_element->HasElement("compensation")) {
           compensation = buoyancy_element->Get<double>("compensation");
         }
+        if (buoyancy_element->HasElement("height_scale_limit")) {
+          buoyancy_link.height_scale_limit = std::abs(buoyancy_element->Get<double>("height_scale_limit"));
+        }
         buoyancy_link.buoyancy_force = -compensation * link_ptr->GetInertial()->Mass() * model_->GetWorld()->Gravity();
-        buoyancy_link.height_scale_limit = 0.1;
         buoyancy_links_.push_back(buoyancy_link);
       }
     }

--- a/src/gazebo_uuv_plugin.cpp
+++ b/src/gazebo_uuv_plugin.cpp
@@ -39,43 +39,57 @@ void GazeboUUVPlugin::InitializeParams() {}
 
 void GazeboUUVPlugin::Publish() {}
 
-void GazeboUUVPlugin::ParseBuoyancy(physics::ModelPtr _model) {
-  physics::LinkPtr link_ptr;
-  for (auto sdf_element = _model->GetSDF()->GetFirstElement(); sdf_element != 0; sdf_element = sdf_element->GetNextElement()) {
-    if (sdf_element->HasElement("link")) {
-      auto link = sdf_element->GetElement("link");
-      auto link_name = link->GetAttribute("name")->GetAsString();
-
-      for (auto buoyancy_element = link->GetElement("buoyancy"); buoyancy_element != NULL; buoyancy_element = buoyancy_element->GetNextElement()) {
-        link_ptr = _model->GetChildLink(link_name);
-        buoyancy_s buoyancy_link;
-        buoyancy_link.model_name = _model->GetName();
-        buoyancy_link.link = link_ptr;
-        buoyancy_link.buoyancy_force = ignition::math::Vector3d(0, 0, 0);
-        buoyancy_link.cob = ignition::math::Vector3d(0, 0, 0);
-        buoyancy_link.height_scale_limit = 0.1;
-        double compensation = 0.0;
-
-        if (buoyancy_element->HasElement("origin")) {
-          buoyancy_link.cob = buoyancy_element->Get<ignition::math::Vector3d>("origin");
-        }
-        if (buoyancy_element->HasElement("compensation")) {
-          compensation = buoyancy_element->Get<double>("compensation");
-        }
-        if (buoyancy_element->HasElement("height_scale_limit")) {
-          buoyancy_link.height_scale_limit = std::abs(buoyancy_element->Get<double>("height_scale_limit"));
-        }
-        buoyancy_link.buoyancy_force = -compensation * link_ptr->GetInertial()->Mass() * model_->GetWorld()->Gravity();
-        buoyancy_links_.push_back(buoyancy_link);
-      }
+void GazeboUUVPlugin::ParseBuoyancy(sdf::ElementPtr _sdf) {
+  for (auto buoyancy_element = _sdf->GetFirstElement(); buoyancy_element != NULL; buoyancy_element = buoyancy_element->GetNextElement()) {
+    // skip element if it is not a buoyancy-element
+    if (buoyancy_element->GetName() != "buoyancy") {
+      continue;
     }
 
+    physics::LinkPtr link_ptr;
+    std::string link_name = "";
+    // check if link_name is specified. Otherwise skip this buoyancy-element.
+    if (!getSdfParam(buoyancy_element, "link_name", link_name, link_name)) {
+      gzwarn << "Skipping buoyancy element with unspecified 'link_name' tag!\n";
+      continue;
+    }
+    link_ptr = model_->GetChildLink(link_name);
+    // Check if link with specified name exists. Otherwise skip this
+    // buoyancy-element.
+    if (link_ptr == NULL) {
+      gzerr << "Model has no link with name '" << link_name << "'!\n";
+      continue;
+    }
+    buoyancy_s buoyancy_link;
+    buoyancy_link.model_name = model_->GetName();
+    buoyancy_link.link = link_ptr;
+    buoyancy_link.buoyancy_force = ignition::math::Vector3d(0, 0, 0);
+    buoyancy_link.cob = ignition::math::Vector3d(0, 0, 0);
+    buoyancy_link.height_scale_limit = 0.1;
+    double compensation = 0.0;
+
+    if (buoyancy_element->HasElement("origin")) {
+      buoyancy_link.cob = buoyancy_element->Get<ignition::math::Vector3d>("origin");
+    }
+    if (buoyancy_element->HasElement("compensation")) {
+      compensation = buoyancy_element->Get<double>("compensation");
+    }
+    if (buoyancy_element->HasElement("height_scale_limit")) {
+      buoyancy_link.height_scale_limit = std::abs(buoyancy_element->Get<double>("height_scale_limit"));
+    }
+    #if GAZEBO_MAJOR_VERSION >= 9
+      buoyancy_link.buoyancy_force = -compensation * link_ptr->GetInertial()->Mass() * model_->GetWorld()->Gravity();
+    #else
+      buoyancy_link.buoyancy_force = -compensation * link_ptr->GetInertial()->GetMass() * model_->GetWorld()->Gravity();
+    #endif
+    buoyancy_links_.push_back(buoyancy_link);
+    gzmsg << "Added buoyancy element for link '" << model_->GetName() << "::" << link_name << "'.\n";
   }
+
 }
 
 void GazeboUUVPlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf) {
   model_ = _model;
-  ParseBuoyancy(_model);
 
   namespace_.clear();
 
@@ -87,6 +101,8 @@ void GazeboUUVPlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf) {
   //Get links
   link_base_ = _sdf->GetElement("baseLinkName")->Get<std::string>();
   baseLink_ = model_->GetLink(link_base_);
+
+  ParseBuoyancy(_sdf);
 
   //Get parameters for added mass and damping
   ignition::math::Vector3d added_mass_linear(0,0,0);


### PR DESCRIPTION
Instead of having the `<gravity>` tag set to 0 in the corresponding .sdf file, the gravity is now compensated by buoyancy forces.
The buoyancy can be set as seen in the following code block.
```
<link name="base_link">
  <buoyancy>
    <origin>0 0 0.01</origin>
    <compensation>1.1</compensation>
    <height_scale_limit>0.05</height_scale_limit>
  </buoyancy>
</link>
```
`origin` describes the center of buoyancy, `compensation` describes the buoyancy force relative to the gravitational force of the corresponding link and the `height_scale_limit` tag describes the distance in negative and positive direction measured from the origin at which a virtual volume generates buoyancy. So in this example where it's value is 0.05, the buoyancy is scaled by 0 if the origin is 0.05m above the water surface. Between 0.05m above and below the surface it is scaled linearly between 0 and 1 and if the center of buoyancy is below 0.05m the force is scaled by 1. This corresponds to a buoyancy generating volume with constant cross sectional area.

Maybe @DanielDuecker also want to have a look on it?