### PR TITLE
Move rover models to jinja templates

### DIFF
--- a/models/r1_rover/r1_rover.sdf.jinja
+++ b/models/r1_rover/r1_rover.sdf.jinja
@@ -169,7 +169,7 @@
           <bounce>
             <restitution_coefficient>0</restitution_coefficient>
             <threshold>1e6</threshold>
-          </bounce>          
+          </bounce>
           <contact>
             <ode>
               <min_depth>0.001</min_depth>
@@ -425,7 +425,7 @@
           <bounce>
             <restitution_coefficient>0</restitution_coefficient>
             <threshold>1e6</threshold>
-          </bounce>          
+          </bounce>
           <contact>
             <ode>
               <min_depth>0.001</min_depth>
@@ -559,7 +559,8 @@
       <magSubTopic>/mag</magSubTopic>
       <baroSubTopic>/baro</baroSubTopic>
       <mavlink_addr>INADDR_ANY</mavlink_addr>
-      <mavlink_udp_port>14560</mavlink_udp_port>
+      <mavlink_tcp_port>{{ mavlink_tcp_port }}</mavlink_tcp_port>
+      <mavlink_udp_port>{{ mavlink_udp_port }}</mavlink_udp_port>
       <serialEnabled>false</serialEnabled>
       <serialDevice>/dev/ttyACM0</serialDevice>
       <baudRate>921600</baudRate>

--- a/models/rover/rover.sdf.jinja
+++ b/models/rover/rover.sdf.jinja
@@ -895,7 +895,8 @@
       <magSubTopic>/mag</magSubTopic>
       <baroSubTopic>/baro</baroSubTopic>
       <mavlink_addr>INADDR_ANY</mavlink_addr>
-      <mavlink_udp_port>14560</mavlink_udp_port>
+      <mavlink_tcp_port>{{ mavlink_tcp_port }}</mavlink_tcp_port>
+      <mavlink_udp_port>{{ mavlink_udp_port }}</mavlink_udp_port>
       <serialEnabled>false</serialEnabled>
       <serialDevice>/dev/ttyACM0</serialDevice>
       <baudRate>921600</baudRate>


### PR DESCRIPTION
**Problem Description**
This moves the following rover models to jinja templates.
- `r1_rover` (Differential Rover)
- `rover` (Ackerman Steering Rover)

Since the TCP ports can be passed on with jinja template arguments, this enables multivehicle support for Rovers