### PR TITLE
mavlink interface poll until actuator received

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,16 @@ models/iris/*.sdf
 *.pyc
 .*.sw?
 *-gen.sdf
+
+models/3DR_gps_mag/3DR_gps_mag.sdf
+models/c920/c920.sdf
+models/cloudship/cloudship.sdf
+models/iris/iris.sdf
+models/matrice_100/matrice_100.sdf
+models/mb1240-xl-ez4/mb1240-xl-ez4.sdf
+models/pixhawk/pixhawk.sdf
+models/plane/plane.sdf
+models/px4flow/px4flow.sdf
+models/r200/r200.sdf
+models/sf10a/sf10a.sdf
+models/standard_vtol/standard_vtol.sdf

--- a/src/mavlink_interface.cpp
+++ b/src/mavlink_interface.cpp
@@ -197,6 +197,8 @@ void MavlinkInterface::pollForMAVLinkMessages()
     return;
   }
 
+  received_actuator_ = false;
+
   do {
     int timeout_ms = (received_first_actuator_ && enable_lockstep_) ? 1000 : 0;
     int ret = ::poll(&fds_[0], N_FDS, timeout_ms);


### PR DESCRIPTION
This is a lockstep fix. If there's a poll error (POLLERR) in `MavlinkInterface::pollForMAVLinkMessages()` then another new `HIL_SENSOR` message is sent before PX4 sends `HIL_ACTUATOR_CONTROLS`.

https://github.com/PX4/sitl_gazebo/blob/e4e32117df1d8aba00b0685ebd0cc5ffc066a970/src/mavlink_interface.cpp#L219-L221