### PR TITLE
mavlink interface round double sim time when converting to microseconds

### DIFF
--- a/src/gazebo_mavlink_interface.cpp
+++ b/src/gazebo_mavlink_interface.cpp
@@ -615,9 +615,9 @@ void GazeboMavlinkInterface::SendSensorMessages()
 
   mavlink_hil_sensor_t sensor_msg;
 #if GAZEBO_MAJOR_VERSION >= 9
-  sensor_msg.time_usec = world_->SimTime().Double() * 1e6;
+  sensor_msg.time_usec = std::round(world_->SimTime().Double() * 1e6);
 #else
-  sensor_msg.time_usec = world_->GetSimTime().Double() * 1e6;
+  sensor_msg.time_usec = std::round(world_->GetSimTime().Double() * 1e6);
 #endif
 
   // send always accel and gyro data (not dependent of the bitmask)
@@ -711,9 +711,9 @@ void GazeboMavlinkInterface::SendGroundTruth()
   // send ground truth
   mavlink_hil_state_quaternion_t hil_state_quat;
 #if GAZEBO_MAJOR_VERSION >= 9
-  hil_state_quat.time_usec = world_->SimTime().Double() * 1e6;
+  hil_state_quat.time_usec = std::round(world_->SimTime().Double() * 1e6);
 #else
-  hil_state_quat.time_usec = world_->GetSimTime().Double() * 1e6;
+  hil_state_quat.time_usec = std::round(world_->GetSimTime().Double() * 1e6);
 #endif
   hil_state_quat.attitude_quaternion[0] = q_nb.W();
   hil_state_quat.attitude_quaternion[1] = q_nb.X();


### PR DESCRIPTION
In PX4/Firmware SITL with lockstep I'm occasionally seeing 3999 us or 4001 us between updates. 

``` Console
INFO  [simulator] HIL_SENSOR: imu time_usec: 66203999, time_usec: 65691999, diff: 3999, step: 1.00
INFO  [simulator] HIL_SENSOR: imu time_usec: 66208000, time_usec: 65696000, diff: 4001, step: 1.00
INFO  [simulator] HIL_SENSOR: imu time_usec: 66215999, time_usec: 65703999, diff: 3999, step: 1.00
INFO  [simulator] HIL_SENSOR: imu time_usec: 66220000, time_usec: 65708000, diff: 4001, step: 1.00
INFO  [simulator] HIL_SENSOR: imu time_usec: 66227999, time_usec: 65715999, diff: 3999, step: 1.00
INFO  [simulator] HIL_SENSOR: imu time_usec: 66232000, time_usec: 65720000, diff: 4001, step: 1.00
INFO  [simulator] HIL_SENSOR: imu time_usec: 66239999, time_usec: 65727999, diff: 3999, step: 1.00
INFO  [simulator] HIL_SENSOR: imu time_usec: 66244000, time_usec: 65732000, diff: 4001, step: 1.00
INFO  [simulator] HIL_SENSOR: imu time_usec: 66251999, time_usec: 65739999, diff: 3999, step: 1.00
INFO  [simulator] HIL_SENSOR: imu time_usec: 66256000, time_usec: 65744000, diff: 4001, step: 1.00
```

``` Console
vehicle_imu: accel update interval: 83202 events, 3999.95us avg, min 3999us max 4001us 0.189us rms
vehicle_imu: gyro update interval: 83202 events, 3999.95us avg, min 3999us max 4001us 0.189us rms
```