### PR TITLE
Update typhoon_h480.sdf (issue #608)

### DIFF
--- a/models/typhoon_h480/typhoon_h480.sdf
+++ b/models/typhoon_h480/typhoon_h480.sdf
@@ -421,7 +421,7 @@
       <axis>
         <xyz>0 -1 0</xyz>
         <limit>
-          <lower>-1.05</lower>
+          <lower>-2.09</lower>
           <upper>2.09</upper>
           <effort>100</effort>
           <velocity>-1</velocity>


### PR DESCRIPTION
The camera was unable to pitch -90 deg to face downwards. Solved increasing lower limit of the `cgo3_camera_joint`.