### PR TITLE
fix #638 - geotagging plugin not working: subscribed to wrong topic

### DIFF
--- a/src/gazebo_geotagged_images_plugin.cpp
+++ b/src/gazebo_geotagged_images_plugin.cpp
@@ -141,7 +141,7 @@ void GeotaggedImagesPlugin::Load(sensors::SensorPtr sensor, sdf::ElementPtr sdf)
     _newFrameConnection = _camera->ConnectNewImageFrame(
                               boost::bind(&GeotaggedImagesPlugin::OnNewFrame, this, _1));
 
-    _gpsSub = _node_handle->Subscribe("~/" + rootModelName + "/gps", &GeotaggedImagesPlugin::OnNewGpsPosition, this);
+    _gpsSub = _node_handle->Subscribe("~/" + rootModelName + "/link/gps", &GeotaggedImagesPlugin::OnNewGpsPosition, this);
 
     _storageDir = "frames";
     boost::filesystem::remove_all(_storageDir); //clear existing images


### PR DESCRIPTION
The geotagging plugin was subscribing to the wrong topic, and the callback was never getting called. This fixes #638.