### PR TITLE
Move typhoon_480 to jinja template for multi sim

### DIFF
--- a/models/typhoon_h480/typhoon_h480.sdf.jinja
+++ b/models/typhoon_h480/typhoon_h480.sdf.jinja
@@ -1,3 +1,4 @@
+<!-- DO NOT EDIT: Generated from iris.sdf.jinja -->
 <sdf version='1.5'>
   <model name='typhoon_h480'>
     <!-- Typhoon H body -->
@@ -1280,15 +1281,16 @@
       <magSubTopic>/mag</magSubTopic>
       <baroSubTopic>/baro</baroSubTopic>
       <mavlink_addr>INADDR_ANY</mavlink_addr>
-      <mavlink_udp_port>14560</mavlink_udp_port>
-      <serialEnabled>false</serialEnabled>
-      <serialDevice>/dev/ttyACM0</serialDevice>
-      <baudRate>921600</baudRate>
+      <mavlink_tcp_port>{{ mavlink_tcp_port }}</mavlink_tcp_port>
+      <mavlink_udp_port>{{ mavlink_udp_port }}</mavlink_udp_port>
+      <serialEnabled>{{ serial_enabled }}</serialEnabled>
+      <serialDevice>{{ serial_device }}</serialDevice>
+      <baudRate>{{ serial_baudrate }}</baudRate>
       <qgc_addr>INADDR_ANY</qgc_addr>
       <qgc_udp_port>14550</qgc_udp_port>
       <sdk_addr>INADDR_ANY</sdk_addr>
       <sdk_udp_port>14540</sdk_udp_port>
-      <hil_mode>false</hil_mode>
+      <hil_mode>{{ hil_mode }}</hil_mode>
       <hil_state_level>false</hil_state_level>
       <enable_lockstep>true</enable_lockstep>
       <use_tcp>true</use_tcp>


### PR DESCRIPTION
This commit changes the typhoon_h480 model to use jinja
templating so multi sim can work.