### PR TITLE
Fix plugin misspelling

### DIFF
--- a/models/flow_cam/model.sdf
+++ b/models/flow_cam/model.sdf
@@ -45,7 +45,7 @@
             <stddev>0.001</stddev>
           </noise>
         </camera>
-        <plugin name="opticalflow_plugin" filename="libgazebo_opticalFlow_plugin.so">
+        <plugin name="opticalflow_plugin" filename="libgazebo_opticalflow_plugin.so">
             <robotNamespace></robotNamespace>
             <outputRate>20</outputRate>
         </plugin>


### PR DESCRIPTION
Just a quick fix on a misspelling.
Optical flow shall be called with lowercase F