### PR TITLE
Introduce a sensor interface for mavlink HIL messages

### DIFF
--- a/include/gazebo_mavlink_interface.h
+++ b/include/gazebo_mavlink_interface.h
@@ -252,10 +252,6 @@ private:
   common::Time last_imu_time_;
   common::Time last_actuator_time_;
 
-  bool mag_updated_{false};
-  bool baro_updated_{false};
-  bool diff_press_updated_{false};
-
   double groundtruth_lat_rad_{0.0};
   double groundtruth_lon_rad_{0.0};
   double groundtruth_altitude_{0.0};
@@ -263,17 +259,12 @@ private:
   double imu_update_interval_{0.004}; ///< Used for non-lockstep
 
   ignition::math::Vector3d velocity_prev_W_;
-  ignition::math::Vector3d mag_n_;
   ignition::math::Vector3d wind_vel_;
-
-  double temperature_{25.0};
-  double pressure_alt_{0.0};
-  double abs_pressure_{0.0};
 
   bool close_conn_{false};
 
   double optflow_distance_{0.0};
-  double diff_pressure_{0.0};
+  double sonar_distance;
 
   bool enable_lockstep_{false};
   double speed_factor_{1.0};

--- a/include/mavlink_interface.h
+++ b/include/mavlink_interface.h
@@ -82,6 +82,44 @@ enum class SensorSource {
   DIFF_PRESS	= 0b10000000000,
 };
 
+namespace SensorData {
+    struct Imu {
+        Eigen::Vector3d accel_b;
+        Eigen::Vector3d gyro_b;
+    };
+
+    struct Barometer {
+        double temperature;
+        double abs_pressure;
+        double pressure_alt;
+    };
+
+    struct Magnetometer {
+        Eigen::Vector3d mag_b;
+    };
+
+    struct Airspeed {
+        double diff_pressure;
+    };
+
+    struct Gps {
+        int time_utc_usec;
+        int fix_type;
+        double latitude_deg;
+        double longitude_deg;
+        double altitude;
+        double eph;
+        double epv;
+        double velocity;
+        double velocity_north;
+        double velocity_east;
+        double velocity_down;
+        double cog;
+        double satellites_visible;
+        int id;
+    };
+}
+
 class MavlinkInterface {
 public:
     MavlinkInterface();
@@ -93,6 +131,12 @@ public:
     void open();
     void close();
     void Load();
+    void SendSensorMessages(int time_usec);
+    void SendGpsMessages(const SensorData::Gps &data);
+    void UpdateBarometer(const SensorData::Barometer &data);
+    void UpdateAirspeed(const SensorData::Airspeed &data);
+    void UpdateIMU(const SensorData::Imu &data);
+    void UpdateMag(const SensorData::Magnetometer &data);
     Eigen::VectorXd GetActuatorControls();
     bool GetArmedState();
     void onSigInt();
@@ -189,6 +233,7 @@ private:
     
     std::recursive_mutex mutex_;
     std::mutex actuator_mutex_;
+    std::mutex sensor_msg_mutex_;
 
     std::array<uint8_t, MAX_SIZE> rx_buf_{};
     unsigned int baudrate_{kDefaultBaudRate};
@@ -197,6 +242,19 @@ private:
 
     bool hil_mode_;
     bool hil_state_level_;
+
+    bool baro_updated_;
+    bool diff_press_updated_;
+    bool mag_updated_;
+    bool imu_updated_;
+
+    double temperature_;
+    double pressure_alt_;
+    double abs_pressure_;
+    double diff_pressure_;
+    Eigen::Vector3d mag_b_;
+    Eigen::Vector3d accel_b_;
+    Eigen::Vector3d gyro_b_;
 
     std::atomic<bool> gotSigInt_ {false};
 };

--- a/src/gazebo_magnetometer_plugin.cpp
+++ b/src/gazebo_magnetometer_plugin.cpp
@@ -194,17 +194,27 @@ void MagnetometerPlugin::OnUpdate(const common::UpdateInfo&)
     float X = H * cosf(declination_rad);
     float Y = H * sinf(declination_rad);
 
+    ignition::math::Vector3d magnetic_field_I(X, Y, Z);
+
+#if GAZEBO_MAJOR_VERSION >= 9
+    ignition::math::Pose3d T_W_I = model_->WorldPose();
+#else
+    ignition::math::Pose3d T_W_I = ignitionFromGazeboMath(model_->GetWorldPose());
+#endif
+    ignition::math::Quaterniond q_body_to_world = q_ENU_to_NED * T_W_I.Rot() * q_FLU_to_FRD.Inverse();
+
+    ignition::math::Vector3d magnetic_field_B = q_body_to_world.RotateVectorReverse(magnetic_field_I);
     // Magnetometer noise
-    Eigen::Vector3d magnetic_field_I(X, Y, Z);
-    addNoise(&magnetic_field_I, dt);
+    Eigen::Vector3d measured_mag(magnetic_field_B.X(), magnetic_field_B.Y(), magnetic_field_B.Z());
+    addNoise(&measured_mag, dt);
 
     // Fill magnetometer messgae
     mag_message_.set_time_usec(current_time.Double() * 1e6);
 
     gazebo::msgs::Vector3d* magnetic_field = new gazebo::msgs::Vector3d();
-    magnetic_field->set_x(magnetic_field_I[0]);
-    magnetic_field->set_y(magnetic_field_I[1]);
-    magnetic_field->set_z(magnetic_field_I[2]);
+    magnetic_field->set_x(measured_mag[0]);
+    magnetic_field->set_y(measured_mag[1]);
+    magnetic_field->set_z(measured_mag[2]);
     mag_message_.set_allocated_magnetic_field(magnetic_field);
 
     last_pub_time_ = current_time;


### PR DESCRIPTION
**Problem Description**
This introduces a abstact sensor interface for HIL Mavlink messages. This allows the `gazebo_mavlink_interface` be able to interact with the `mavlink_interface` and not use mavlink directly.