### PR TITLE
Update container versions for tests

### DIFF
--- a/.github/workflows/catkin_build_test.yml
+++ b/.github/workflows/catkin_build_test.yml
@@ -14,9 +14,9 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {rosdistro: 'kinetic', container: 'px4io/px4-dev-ros-kinetic:2020-07-18'} 
-          - {rosdistro: 'melodic', container: 'px4io/px4-dev-ros-melodic:2020-08-14'}
-          - {rosdistro: 'noetic', container: 'px4io/px4-dev-ros-noetic:2020-08-20'}
+          - {rosdistro: 'kinetic', container: 'px4io/px4-dev-ros-kinetic:2020-11-18'} 
+          - {rosdistro: 'melodic', container: 'px4io/px4-dev-ros-melodic:2020-11-18'}
+          - {rosdistro: 'noetic', container: 'px4io/px4-dev-ros-noetic:2020-11-18'}
     container: ${{ matrix.config.container }}
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/firmware_build_test.yml
+++ b/.github/workflows/firmware_build_test.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   Firmware-build:
     runs-on: ubuntu-latest
-    container: px4io/px4-dev-simulation-focal:2020-08-14
+    container: px4io/px4-dev-simulation-focal:2020-11-18
     steps:
     - name: Checkout Firmware master
       uses: actions/checkout@v2.3.1


### PR DESCRIPTION
**Problem Description**
Recently there has been catkin build tests failing in this repository. This updates the base container versions for running tests

Since we have a new `mavlink_gbp_release` the builds should start passing: https://github.com/mavlink/mavlink-gbp-release/releases/tag/upstream%2F2020.12.12