### PR TITLE
Update mavsdk version for SITL tests

### DIFF
--- a/.github/workflows/firmware_build_test.yml
+++ b/.github/workflows/firmware_build_test.yml
@@ -22,9 +22,9 @@ jobs:
         fetch-depth: 0
         submodules: recurvise
     - name: Download MAVSDK
-      run: wget https://github.com/mavlink/MAVSDK/releases/download/v0.30.1/mavsdk_0.30.1_ubuntu20.04_amd64.deb
+      run: wget https://github.com/mavlink/MAVSDK/releases/download/v0.33.1/mavsdk_0.33.1_ubuntu20.04_amd64.deb
     - name: Install MAVSDK
-      run: dpkg -i mavsdk_0.30.1_ubuntu20.04_amd64.deb
+      run: dpkg -i mavsdk_0.33.1_ubuntu20.04_amd64.deb
     - name: Checkout matching branch on PX4/Firmware if possible
       run: |
         git checkout ${{github.head_ref}} || echo "Firmware branch: ${{github.head_ref}} not found, using master instead"

--- a/.github/workflows/firmware_build_test.yml
+++ b/.github/workflows/firmware_build_test.yml
@@ -11,7 +11,15 @@ on:
 jobs:
   Firmware-build:
     runs-on: ubuntu-latest
-    container: px4io/px4-dev-simulation-focal:2020-11-18
+    strategy:
+      fail-fast: false
+      matrix:
+        model:
+          - "iris"
+          - "standard_vtol"
+    container:
+      image: px4io/px4-dev-simulation-focal:2020-11-18
+      options: --privileged --ulimit core=-1 --security-opt seccomp=unconfined
     steps:
     - name: Checkout Firmware master
       uses: actions/checkout@v2.3.1
@@ -74,4 +82,4 @@ jobs:
       run: ccache -s
     - name: Run SITL tests
       working-directory: Firmware
-      run: test/mavsdk_tests/mavsdk_test_runner.py --speed-factor 20 --abort-early Tools/sitl_gazebo/resources/sitl.json
+      run: test/mavsdk_tests/mavsdk_test_runner.py --speed-factor 20 --abort-early --model ${{matrix.model}} test/mavsdk_tests/configs/sitl.json


### PR DESCRIPTION
**Problem Description**
SITL tests has been failing recently due to a outdated mavsdk version.

This updates the MAVSDK version from 30.1 to 33.1 as used in the firmware