### PR TITLE
Fix wind transmormations for motor model

### DIFF
--- a/src/gazebo_motor_model.cpp
+++ b/src/gazebo_motor_model.cpp
@@ -209,11 +209,16 @@ void GazeboMotorModel::UpdateForcesAndMoments() {
   //
 #if GAZEBO_MAJOR_VERSION >= 9
   ignition::math::Vector3d body_velocity = link_->WorldLinearVel();
+  ignition::math::Vector3d joint_axis = joint_->GlobalAxis(0);
 #else
   ignition::math::Vector3d body_velocity = ignitionFromGazeboMath(link_->GetWorldLinearVel());
+  ignition::math::Vector3d joint_axis = ignitionFromGazeboMath(joint_->GetGlobalAxis(0));
 #endif
-  double vel = body_velocity.Length();
-  double scalar = 1 - vel / 25.0; // at 50 m/s the rotor will not produce any force anymore
+
+  ignition::math::Vector3d relative_wind_velocity = body_velocity - wind_vel_;
+  ignition::math::Vector3d velocity_parallel_to_rotor_axis = (relative_wind_velocity.Dot(joint_axis)) * joint_axis;
+  double vel = velocity_parallel_to_rotor_axis.Length();
+  double scalar = 1 - vel / 25.0; // at 25 m/s the rotor will not produce any force anymore
   scalar = ignition::math::clamp(scalar, 0.0, 1.0);
   // Apply a force to the link.
   link_->AddRelativeForce(ignition::math::Vector3d(0, 0, force * scalar));
@@ -222,14 +227,8 @@ void GazeboMotorModel::UpdateForcesAndMoments() {
   // 2010 IEEE Conference on Robotics and Automation paper
   // The True Role of Accelerometer Feedback in Quadrotor Control
   // - \omega * \lambda_1 * V_A^{\perp}
-#if GAZEBO_MAJOR_VERSION >= 9
-  ignition::math::Vector3d joint_axis = joint_->GlobalAxis(0);
-#else
-  ignition::math::Vector3d joint_axis = ignitionFromGazeboMath(joint_->GetGlobalAxis(0));
-#endif
-  ignition::math::Vector3d relative_wind_velocity = body_velocity - wind_vel_;
-  ignition::math::Vector3d body_velocity_perpendicular = relative_wind_velocity - (relative_wind_velocity.Dot(joint_axis)) * joint_axis;
-  ignition::math::Vector3d air_drag = -std::abs(real_motor_velocity) * rotor_drag_coefficient_ * body_velocity_perpendicular;
+  ignition::math::Vector3d velocity_perpendicular_to_rotor_axis = relative_wind_velocity - (relative_wind_velocity.Dot(joint_axis)) * joint_axis;
+  ignition::math::Vector3d air_drag = -std::abs(real_motor_velocity) * rotor_drag_coefficient_ * velocity_perpendicular_to_rotor_axis;
   // Apply air_drag to link.
   link_->AddForce(air_drag);
   // Moments
@@ -248,7 +247,7 @@ void GazeboMotorModel::UpdateForcesAndMoments() {
 
   ignition::math::Vector3d rolling_moment;
   // - \omega * \mu_1 * V_A^{\perp}
-  rolling_moment = -std::abs(real_motor_velocity) * rolling_moment_coefficient_ * body_velocity_perpendicular;
+  rolling_moment = -std::abs(real_motor_velocity) * rolling_moment_coefficient_ * velocity_perpendicular_to_rotor_axis;
   parent_links.at(0)->AddTorque(rolling_moment);
   // Apply the filter on the motor's velocity.
   double ref_motor_rot_vel;


### PR DESCRIPTION
**Problem Description**
Previously, the motor model plugin was wrongly taking the intertial velocity when compensating thrust for the axial velocity. 

As you can see in the following logs, before the PR higher throttle inputs are required when flying in a tailwind, and less throttle is required for flying in a headwind with the same airspeed setpoint. This is because the motor model is wrongly assuming the axial velocity flow is higher when the groundspeed is higher.
 
Before PR: https://review.px4.io/plot_app?log=73d235fe-254d-4d7c-9e1c-a66175cd1f62
After PR: https://review.px4.io/plot_app?log=46b416e8-4103-46d0-b072-63784dba2d11

This PR fixes the plugin to use the wind relative velocity.

**Additional Context**
- Fixes https://github.com/PX4/PX4-SITL_gazebo/issues/583
- Fixes https://github.com/PX4/PX4-SITL_gazebo/issues/520