### PR TITLE
tiltrotor: increase wing area to 0.5 per side

### DIFF
--- a/models/tiltrotor/tiltrotor.sdf.jinja
+++ b/models/tiltrotor/tiltrotor.sdf.jinja
@@ -889,7 +889,7 @@
       <cda_stall>-0.9233984055</cda_stall>
       <cma_stall>0</cma_stall>
       <cp>-0.05 0.3 0.05</cp>
-      <area>0.12</area>
+      <area>0.5</area>
       <air_density>1.2041</air_density>
       <forward>1 0 0</forward>
       <upward>0 0 1</upward>
@@ -911,7 +911,7 @@
       <cda_stall>-0.9233984055</cda_stall>
       <cma_stall>0</cma_stall>
       <cp>-0.05 -0.3 0.05</cp>
-      <area>0.12</area>
+      <area>0.5</area>
       <air_density>1.2041</air_density>
       <forward>1 0 0</forward>
       <upward>0 0 1</upward>


### PR DESCRIPTION
Increase are of the wings for the tiltrotor to 0.5 each (same as in standard VTOL model).
With the previous, lower, area, a very high airspeed and/or pitch was needed to fly level.