### PR TITLE
Fix lightsource for high fidelity worlds

### DIFF
--- a/worlds/baylands.world
+++ b/worlds/baylands.world
@@ -7,6 +7,9 @@
           <speed>12</speed>
         </clouds>
       </sky>
+      <ambient>0.95 0.95 0.95 1</ambient>
+      <background>0.3 0.3 0.3 1</background>
+      <shadows>true</shadows>
     </scene>
     <!-- A global light source -->
     <include>

--- a/worlds/ksql_airport.world
+++ b/worlds/ksql_airport.world
@@ -7,6 +7,9 @@
           <speed>12</speed>
         </clouds>
       </sky>
+      <ambient>0.95 0.95 0.95 1</ambient>
+      <background>0.3 0.3 0.3 1</background>
+      <shadows>true</shadows>
     </scene>
 
     <!-- A global light source -->

--- a/worlds/mcmillan_airfield.world
+++ b/worlds/mcmillan_airfield.world
@@ -7,6 +7,9 @@
           <speed>12</speed>
         </clouds>
       </sky>
+      <ambient>0.95 0.95 0.95 1</ambient>
+      <background>0.3 0.3 0.3 1</background>
+      <shadows>true</shadows>
     </scene>
     <!-- A global light source -->
     <include>

--- a/worlds/sonoma_raceway.world
+++ b/worlds/sonoma_raceway.world
@@ -2,6 +2,11 @@
 <sdf version="1.6">
   <world name="default">
     <!-- A global light source -->
+    <scene>
+      <ambient>0.95 0.95 0.95 1</ambient>
+      <background>0.3 0.3 0.3 1</background>
+      <shadows>true</shadows>
+    </scene>
     <include>
       <uri>model://sun</uri>
     </include>

--- a/worlds/yosemite.world
+++ b/worlds/yosemite.world
@@ -7,6 +7,9 @@
           <speed>12</speed>
         </clouds>
       </sky>
+      <ambient>0.95 0.95 0.95 1</ambient>
+      <background>0.3 0.3 0.3 1</background>
+      <shadows>true</shadows>
     </scene>
     <!-- A global light source -->
     <include>


### PR DESCRIPTION
**Problem Description**
This PR fixes the problem where the scene looks very dark due to some shadows in gazebo.

This has been pulled out of https://github.com/PX4/PX4-SITL_gazebo/pull/651

**Before PR**
![image](https://user-images.githubusercontent.com/5248102/103229294-0de1e580-4933-11eb-8592-ee3ca4a683d6.png)

**After PR**
![image](https://user-images.githubusercontent.com/5248102/103229471-5bf6e900-4933-11eb-83b2-20cbed5a9902.png)



**Additional Context**
- Fixes https://github.com/PX4/PX4-SITL_gazebo/issues/642
- Related: https://github.com/osrf/gazebo/issues/2854
