### PR TITLE
Correct calculate airspeed with wind

### DIFF
--- a/src/liftdrag_plugin/liftdrag_plugin.cpp
+++ b/src/liftdrag_plugin/liftdrag_plugin.cpp
@@ -191,9 +191,9 @@ void LiftDragPlugin::OnUpdate()
   GZ_ASSERT(this->link, "Link was NULL");
   // get linear velocity at cp in inertial frame
 #if GAZEBO_MAJOR_VERSION >= 9
-  ignition::math::Vector3d vel = this->link->WorldLinearVel(this->cp) - wind_vel_;
+  ignition::math::Vector3d vel = this->link->WorldLinearVel(this->cp) + wind_vel_;
 #else
-  ignition::math::Vector3d vel = ignitionFromGazeboMath(this->link->GetWorldLinearVel(this->cp)) - wind_vel_;
+  ignition::math::Vector3d vel = ignitionFromGazeboMath(this->link->GetWorldLinearVel(this->cp)) + wind_vel_;
 #endif
   ignition::math::Vector3d velI = vel;
   velI.Normalize();


### PR DESCRIPTION
For calculation of airspeed, wind velocity must be added not decreased because it is a vector.

log of the result:
https://logs.px4.io/plot_app?log=92f74f21-366f-4cbe-8dab-e3b17c2eee66

fixed this issue:
https://github.com/PX4/PX4-Autopilot/issues/16441

https://discuss.px4.io/t/vtol-cant-control-airspeed-in-sitl-gazebo-in-wind/20285