### PR TITLE
Fixes for camera manager to support multi-video stream

### DIFF
--- a/include/gazebo_geotagged_images_plugin.h
+++ b/include/gazebo_geotagged_images_plugin.h
@@ -113,6 +113,10 @@ private:
     struct sockaddr_in          _gcsaddr;   ///< GCS target
     struct pollfd               _fds[1];
     std::mutex                  _captureMutex;
+    int                         _streamURI{5600};
+    int                         _systemID{1};
+    int                         _componentID{MAV_COMP_ID_CAMERA};
+    int                         _camPort{14530};
 };
 
 } /* namespace gazebo */

--- a/include/gazebo_geotagged_images_plugin.h
+++ b/include/gazebo_geotagged_images_plugin.h
@@ -113,10 +113,10 @@ private:
     struct sockaddr_in          _gcsaddr;   ///< GCS target
     struct pollfd               _fds[1];
     std::mutex                  _captureMutex;
-    int                         _streamURI{5600};
+    int                         _videoURI{5600};
     int                         _systemID{1};
     int                         _componentID{MAV_COMP_ID_CAMERA};
-    int                         _camPort{14530};
+    int                         _mavlinkCamPort{14530};
 };
 
 } /* namespace gazebo */

--- a/models/typhoon_h480/typhoon_h480.sdf.jinja
+++ b/models/typhoon_h480/typhoon_h480.sdf.jinja
@@ -404,7 +404,7 @@
         <plugin name="GstCameraPlugin" filename="libgazebo_gst_camera_plugin.so">
             <robotNamespace></robotNamespace>
             <udpHost>127.0.0.1</udpHost>
-            <udpPort>5600</udpPort>
+            <udpPort>{{ gst_udp_port }}</udpPort>
         </plugin>
         <plugin name="GeotaggedImagesPlugin" filename="libgazebo_geotagged_images_plugin.so">
             <robotNamespace>typhoon_h480</robotNamespace>
@@ -412,6 +412,10 @@
             <width>3840</width>
             <height>2160</height>
             <maximum_zoom>8.0</maximum_zoom>
+            <video_uri>{{ video_uri }}</video_uri>
+            <system_id>{{ mavlink_id }}</system_id>
+            <cam_component_id>{{ cam_component_id }}</cam_component_id>
+            <mavlink_cam_udp_port>{{ mavlink_cam_udp_port }}</mavlink_cam_udp_port>
         </plugin>
       </sensor>
     </link>

--- a/scripts/jinja_gen.py
+++ b/scripts/jinja_gen.py
@@ -26,6 +26,11 @@ if __name__ == "__main__":
     parser.add_argument('--hil_mode', default=0, help="Enable HIL mode for HITL simulation")
     parser.add_argument('--output-file', help="sdf output file")
     parser.add_argument('--stdout', action='store_true', default=False, help="dump to stdout instead of file")
+    parser.add_argument('--mavlink_id', default=1, help="Mavlink system ID")
+    parser.add_argument('--cam_component_id', default=100, help="Mavlink camera component ID")
+    parser.add_argument('--gst_udp_port', default=5600, help="Gstreamer UDP port for SITL")
+    parser.add_argument('--video_uri', default=5600, help="Mavlink camera URI for SITL")
+    parser.add_argument('--mavlink_cam_udp_port', default=14530, help="Mavlink camera UDP port for SITL")
     args = parser.parse_args()
     env = jinja2.Environment(loader=jinja2.FileSystemLoader(args.env_dir))
     template = env.get_template(os.path.relpath(args.filename, args.env_dir))
@@ -44,6 +49,11 @@ if __name__ == "__main__":
          'serial_enabled': args.serial_enabled, \
          'serial_device': args.serial_device, \
          'serial_baudrate': args.serial_baudrate, \
+         'mavlink_id': args.mavlink_id, \
+         'cam_component_id': args.cam_component_id, \
+         'gst_udp_port': args.gst_udp_port, \
+         'video_uri': args.video_uri, \
+         'mavlink_cam_udp_port': args.mavlink_cam_udp_port, \
          'hil_mode': args.hil_mode}
 
     result = template.render(d)

--- a/src/gazebo_geotagged_images_plugin.cpp
+++ b/src/gazebo_geotagged_images_plugin.cpp
@@ -114,6 +114,19 @@ void GeotaggedImagesPlugin::Load(sensors::SensorPtr sensor, sdf::ElementPtr sdf)
         _maxZoom = sdf->GetElement("maximum_zoom")->Get<float>();
     }
 
+    if (sdf->HasElement("stream_uri")) {
+        _streamURI = sdf->GetElement("stream_uri")->Get<int>();
+    }
+    if (sdf->HasElement("system_id")) {
+        _systemID = sdf->GetElement("system_id")->Get<int>();
+    }
+    if (sdf->HasElement("component_id")) {
+        _componentID = sdf->GetElement("component_id")->Get<int>();
+    }
+    if (sdf->HasElement("component_id")) {
+        _camPort = sdf->GetElement("cam_port")->Get<int>();
+    }
+
     //check if exiftool exists
     if (system("exiftool -ver &>/dev/null") != 0) {
         gzerr << "exiftool not found. geotagging_images plugin will be disabled" << endl;
@@ -237,8 +250,8 @@ void GeotaggedImagesPlugin::OnNewFrame(const unsigned char * image)
     // Send indication to GCS
     mavlink_message_t msg;
     mavlink_msg_camera_image_captured_pack_chan(
-        1,
-        MAV_COMP_ID_CAMERA,
+        _systemID,
+        _componentID,
         MAVLINK_COMM_1,
         &msg,
         currentTime.Double() * 1e3, // time boot ms
@@ -290,7 +303,7 @@ void GeotaggedImagesPlugin::_handle_message(mavlink_message_t *msg, struct socka
         mavlink_command_long_t cmd;
         mavlink_msg_command_long_decode(msg, &cmd);
         mavlink_command_long_t digicam_ctrl_cmd;
-        if (cmd.target_component == MAV_COMP_ID_CAMERA) {
+        if (cmd.target_component == _componentID) {
             switch (cmd.command) {
             case MAV_CMD_IMAGE_START_CAPTURE:
                 _handle_take_photo(msg, srcaddr);
@@ -359,8 +372,8 @@ void GeotaggedImagesPlugin::_send_cmd_ack(uint8_t target_sysid, uint8_t target_c
 {
     mavlink_message_t msg;
     mavlink_msg_command_ack_pack_chan(
-        1,
-        MAV_COMP_ID_CAMERA,
+        _systemID,
+        _componentID,
         MAVLINK_COMM_1,
         &msg,
         cmd,
@@ -375,7 +388,7 @@ void GeotaggedImagesPlugin::_send_cmd_ack(uint8_t target_sysid, uint8_t target_c
 void GeotaggedImagesPlugin::_send_heartbeat()
 {
     mavlink_message_t msg;
-    mavlink_msg_heartbeat_pack_chan(1, MAV_COMP_ID_CAMERA, MAVLINK_COMM_1, &msg, MAV_TYPE_GENERIC, MAV_AUTOPILOT_GENERIC, 0, 0, 0);
+    mavlink_msg_heartbeat_pack_chan(_systemID, _componentID, MAVLINK_COMM_1, &msg, MAV_TYPE_GENERIC, MAV_AUTOPILOT_GENERIC, 0, 0, 0);
     // Send to GCS port directly
     _send_mavlink_message(&msg);
     // Gazebo log output is using buffered IO for some reason
@@ -456,7 +469,7 @@ bool GeotaggedImagesPlugin::_init_udp(sdf::ElementPtr sdf) {
     _myaddr.sin_family = AF_INET;
     _myaddr.sin_addr.s_addr = htonl(INADDR_ANY);
     // Choose the default cam port
-    _myaddr.sin_port = htons(14530);
+    _myaddr.sin_port = htons(_camPort);
     if (::bind(_fd, (struct sockaddr *)&_myaddr, sizeof(_myaddr)) < 0) {
         gzerr << "Bind failed for camera UDP plugin" << endl;
         return false;
@@ -468,7 +481,8 @@ bool GeotaggedImagesPlugin::_init_udp(sdf::ElementPtr sdf) {
     _fds[0].events = POLLIN;
     mavlink_status_t* chan_state = mavlink_get_channel_status(MAVLINK_COMM_1);
     chan_state->flags &= ~(MAVLINK_STATUS_FLAG_OUT_MAVLINK1);
-    gzmsg << "Camera on udp port 14530\n";
+    std::string debug_msg = "[Camera manager plugin]: Camera on udp port " + std::to_string(_camPort) + "\n";
+    gzmsg << debug_msg;
     return true;
 }
 
@@ -546,8 +560,8 @@ void GeotaggedImagesPlugin::_handle_camera_info(const mavlink_message_t *pMsg, s
 
     mavlink_message_t msg;
     mavlink_msg_camera_information_pack_chan(
-        1,
-        MAV_COMP_ID_CAMERA,
+        _systemID,
+        _componentID,
         MAVLINK_COMM_1,
         &msg,
         0,                         // time_boot_ms
@@ -582,8 +596,8 @@ void GeotaggedImagesPlugin::_handle_request_camera_settings(const mavlink_messag
     _send_cmd_ack(pMsg->sysid, pMsg->compid, MAV_CMD_REQUEST_CAMERA_SETTINGS, MAV_RESULT_ACCEPTED, srcaddr);
     mavlink_message_t msg;
     mavlink_msg_camera_settings_pack_chan(
-        1,
-        MAV_COMP_ID_CAMERA,
+        _systemID,
+        _componentID,
         MAVLINK_COMM_1,
         &msg,
         0,                      // time_boot_ms
@@ -609,8 +623,8 @@ void GeotaggedImagesPlugin::_handle_request_video_stream_status(const mavlink_me
     _send_cmd_ack(pMsg->sysid, pMsg->compid, MAV_CMD_REQUEST_VIDEO_STREAM_STATUS, MAV_RESULT_ACCEPTED, srcaddr);
     mavlink_message_t msg;
     mavlink_msg_video_stream_status_pack_chan(
-        1,
-        MAV_COMP_ID_CAMERA,                                     // Component ID
+        _systemID,
+        _componentID,                                     // Component ID
         MAVLINK_COMM_1,
         &msg,
         static_cast<uint8_t>(sid),                              // Stream ID
@@ -641,12 +655,12 @@ void GeotaggedImagesPlugin::_handle_request_video_stream_information(const mavli
 
     // ACK command received and accepted
     _send_cmd_ack(pMsg->sysid, pMsg->compid, MAV_CMD_REQUEST_VIDEO_STREAM_INFORMATION, MAV_RESULT_ACCEPTED, srcaddr);
-    std::string uri = "5600";
+    std::string uri = std::to_string(_streamURI);
 
     mavlink_message_t msg;
     mavlink_msg_video_stream_information_pack_chan(
-        1,
-        MAV_COMP_ID_CAMERA,                         // Component ID
+        _systemID,
+        _componentID,                         // Component ID
         MAVLINK_COMM_1,
         &msg,
         1,                                          // Stream ID
@@ -714,8 +728,8 @@ void GeotaggedImagesPlugin::_send_capture_status(struct sockaddr* srcaddr)
 
     mavlink_message_t msg;
     mavlink_msg_camera_capture_status_pack_chan(
-        1,
-        MAV_COMP_ID_CAMERA,
+        _systemID,
+        _componentID,
         MAVLINK_COMM_1,
         &msg,
         current_time.Double() * 1e3,
@@ -740,8 +754,8 @@ void GeotaggedImagesPlugin::_handle_storage_info(const mavlink_message_t *pMsg, 
     _send_cmd_ack(pMsg->sysid, pMsg->compid, MAV_CMD_REQUEST_STORAGE_INFORMATION, MAV_RESULT_ACCEPTED, srcaddr);
     mavlink_message_t msg;
     mavlink_msg_storage_information_pack_chan(
-        1,
-        MAV_COMP_ID_CAMERA,
+        _systemID,
+        _componentID,
         MAVLINK_COMM_1,
         &msg,
         0,                                  // time_boot_ms

--- a/src/gazebo_geotagged_images_plugin.cpp
+++ b/src/gazebo_geotagged_images_plugin.cpp
@@ -114,8 +114,8 @@ void GeotaggedImagesPlugin::Load(sensors::SensorPtr sensor, sdf::ElementPtr sdf)
         _maxZoom = sdf->GetElement("maximum_zoom")->Get<float>();
     }
 
-    if (sdf->HasElement("stream_uri")) {
-        _streamURI = sdf->GetElement("stream_uri")->Get<int>();
+    if (sdf->HasElement(" video_uri")) {
+        _streamURI = sdf->GetElement(" video_uri")->Get<int>();
     }
     if (sdf->HasElement("system_id")) {
         _systemID = sdf->GetElement("system_id")->Get<int>();

--- a/src/gazebo_geotagged_images_plugin.cpp
+++ b/src/gazebo_geotagged_images_plugin.cpp
@@ -481,8 +481,7 @@ bool GeotaggedImagesPlugin::_init_udp(sdf::ElementPtr sdf) {
     _fds[0].events = POLLIN;
     mavlink_status_t* chan_state = mavlink_get_channel_status(MAVLINK_COMM_1);
     chan_state->flags &= ~(MAVLINK_STATUS_FLAG_OUT_MAVLINK1);
-    std::string debug_msg = "[Camera manager plugin]: Camera on udp port " + std::to_string(_camPort) + "\n";
-    gzmsg << debug_msg;
+    gzmsg << "[Camera manager plugin]: Camera on udp port " + std::to_string(_camPort) + "\n";
     return true;
 }
 

--- a/src/gazebo_geotagged_images_plugin.cpp
+++ b/src/gazebo_geotagged_images_plugin.cpp
@@ -114,17 +114,17 @@ void GeotaggedImagesPlugin::Load(sensors::SensorPtr sensor, sdf::ElementPtr sdf)
         _maxZoom = sdf->GetElement("maximum_zoom")->Get<float>();
     }
 
-    if (sdf->HasElement(" video_uri")) {
-        _streamURI = sdf->GetElement(" video_uri")->Get<int>();
+    if (sdf->HasElement("video_uri")) {
+        _videoURI = sdf->GetElement("video_uri")->Get<int>();
     }
     if (sdf->HasElement("system_id")) {
         _systemID = sdf->GetElement("system_id")->Get<int>();
     }
-    if (sdf->HasElement("component_id")) {
-        _componentID = sdf->GetElement("component_id")->Get<int>();
+    if (sdf->HasElement("cam_component_id")) {
+        _componentID = sdf->GetElement("cam_component_id")->Get<int>();
     }
-    if (sdf->HasElement("cam_port")) {
-        _camPort = sdf->GetElement("cam_port")->Get<int>();
+    if (sdf->HasElement("mavlink_cam_udp_port")) {
+        _mavlinkCamPort = sdf->GetElement("mavlink_cam_udp_port")->Get<int>();
     }
 
     //check if exiftool exists
@@ -469,7 +469,7 @@ bool GeotaggedImagesPlugin::_init_udp(sdf::ElementPtr sdf) {
     _myaddr.sin_family = AF_INET;
     _myaddr.sin_addr.s_addr = htonl(INADDR_ANY);
     // Choose the default cam port
-    _myaddr.sin_port = htons(_camPort);
+    _myaddr.sin_port = htons(_mavlinkCamPort);
     if (::bind(_fd, (struct sockaddr *)&_myaddr, sizeof(_myaddr)) < 0) {
         gzerr << "Bind failed for camera UDP plugin" << endl;
         return false;
@@ -481,7 +481,7 @@ bool GeotaggedImagesPlugin::_init_udp(sdf::ElementPtr sdf) {
     _fds[0].events = POLLIN;
     mavlink_status_t* chan_state = mavlink_get_channel_status(MAVLINK_COMM_1);
     chan_state->flags &= ~(MAVLINK_STATUS_FLAG_OUT_MAVLINK1);
-    gzmsg << "[Camera manager plugin]: Camera on udp port " + std::to_string(_camPort) + "\n";
+    gzmsg << "[Camera manager plugin]: Camera on udp port " + std::to_string(_mavlinkCamPort) + "\n";
     return true;
 }
 
@@ -654,7 +654,7 @@ void GeotaggedImagesPlugin::_handle_request_video_stream_information(const mavli
 
     // ACK command received and accepted
     _send_cmd_ack(pMsg->sysid, pMsg->compid, MAV_CMD_REQUEST_VIDEO_STREAM_INFORMATION, MAV_RESULT_ACCEPTED, srcaddr);
-    std::string uri = std::to_string(_streamURI);
+    std::string uri = std::to_string(_videoURI);
 
     mavlink_message_t msg;
     mavlink_msg_video_stream_information_pack_chan(

--- a/src/gazebo_geotagged_images_plugin.cpp
+++ b/src/gazebo_geotagged_images_plugin.cpp
@@ -123,7 +123,7 @@ void GeotaggedImagesPlugin::Load(sensors::SensorPtr sensor, sdf::ElementPtr sdf)
     if (sdf->HasElement("component_id")) {
         _componentID = sdf->GetElement("component_id")->Get<int>();
     }
-    if (sdf->HasElement("component_id")) {
+    if (sdf->HasElement("cam_port")) {
         _camPort = sdf->GetElement("cam_port")->Get<int>();
     }
 


### PR DESCRIPTION
This PR is for issue https://github.com/PX4/PX4-SITL_gazebo/issues/683

There will be required updates in 
* Any vehicle model that includes the `libgazebo_gst_camera_plugin` and `libgazebo_geotagged_images_plugin`
  * Parametrize the gst udp port(e.g.  replace the hard-coded `5600` port with  `gst_udp_port`, [in here](https://github.com/PX4/PX4-SITL_gazebo/blob/master/models/typhoon_h480/typhoon_h480.sdf.jinja#L407))
  * Adding new tags to the [libgazebo_geotagged_images_plugin.so block](https://github.com/PX4/PX4-SITL_gazebo/blob/master/models/typhoon_h480/typhoon_h480.sdf.jinja#L409-L415) such as `<system_id>`, `<component_id>`, `<stream_uri>`, `<cam_port>`, with jinja arguments in order to be able to modify these parameters which are introduced in this PR

* Adding the above mentioned jinja arguments to  [jinja_gen.py](https://github.com/PX4/PX4-SITL_gazebo/blob/master/scripts/jinja_gen.py), to be able to replace them in the `.jinja` files during the SDF generation of multiple models.

* **PX4 modification**: Modify the [single_vehicle_spawn.launch](https://github.com/PX4/PX4-Autopilot/blob/master/launch/single_vehicle_spawn.launch#L23), and add the arguments that are added to the `jinja_gen.py` script mentioned above