### PR TITLE
Add user camera plugin with gui plugin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -439,6 +439,14 @@ if (GSTREAMER_FOUND)
   endif()
 endif()
 
+QT5_WRAP_CPP(headers_MOC2 include/gazebo_user_camera_plugin.h)
+add_library(gazebo_user_camera_plugin SHARED ${headers_MOC2} src/gazebo_user_camera_plugin.cpp)
+target_link_libraries(gazebo_user_camera_plugin ${GAZEBO_LIBRARIES} ${Qt5Core_LIBRARIES} ${Qt5Widgets_LIBRARIES} ${Qt5Test_LIBRARIES})
+set(plugins
+  ${plugins}
+  gazebo_user_camera_plugin
+)
+
 # Linux is not consistent with plugin availability, even on Gazebo 7
 #if("${GAZEBO_VERSION}" VERSION_LESS "7.0")
   add_library(LiftDragPlugin SHARED src/liftdrag_plugin/liftdrag_plugin.cpp)

--- a/include/gazebo_user_camera_plugin.h
+++ b/include/gazebo_user_camera_plugin.h
@@ -1,0 +1,74 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+/**
+ * @brief User Camera Plugin
+ *
+ * This plugin controls the camera view in gzclient
+ *
+ * @author Jaeyoung Lim <jaeyoung@auterion.com>
+ */
+
+#ifndef _USER_CAMERA_PLUGIN_H_
+#define _USER_CAMERA_PLUGIN_H_
+
+#include <gazebo/common/common.hh>
+#include <gazebo/common/Plugin.hh>
+#include <gazebo/gui/GuiPlugin.hh>
+#ifndef Q_MOC_RUN  // See: https://bugreports.qt-project.org/browse/QTBUG-22829
+#   if GAZEBO_MAJOR_VERSION >= 9
+#include <gazebo/transport/transport.hh>
+#   else
+#include <gazebo/transport/transport.hh>
+#include <gazebo/gui/gui.hh>
+#   endif
+#endif
+
+namespace gazebo
+{
+    class GAZEBO_VISIBLE UserCameraPlugin : public GUIPlugin
+    {
+      Q_OBJECT
+
+      public: 
+        UserCameraPlugin();
+        virtual ~UserCameraPlugin();
+
+      private:
+        void OnUpdate();
+
+        transport::NodePtr node;
+        event::ConnectionPtr update_connection_;
+        std::string model_name_{""};
+    };
+}
+#endif

--- a/src/gazebo_user_camera_plugin.cpp
+++ b/src/gazebo_user_camera_plugin.cpp
@@ -1,0 +1,84 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+/**
+ * @brief User Camera Plugin
+ *
+ * This plugin controls the camera view in gzclient
+ *
+ * @author Jaeyoung Lim <jaeyoung@auterion.com>
+ */
+
+#include <sstream>
+#include <gazebo/msgs/msgs.hh>
+#include <gazebo/gui/GuiIface.hh>
+#include <gazebo/rendering/rendering.hh>
+#include "Int32.pb.h"
+#include "gazebo_user_camera_plugin.h"
+
+using namespace gazebo;
+
+GZ_REGISTER_GUI_PLUGIN(UserCameraPlugin)
+
+UserCameraPlugin::UserCameraPlugin()
+  : GUIPlugin()
+{
+  // This is a workaround to make the button invisible
+  this->resize(0, 0);
+
+  this->node = transport::NodePtr(new transport::Node());
+  this->node->Init();
+
+  update_connection_ =
+      event::Events::ConnectPreRender(
+          boost::bind(&UserCameraPlugin::OnUpdate, this));
+  
+  const char *model = std::getenv("PX4_SIM_MODEL");
+  if (model) {
+    model_name_ = std::string(model);
+  }
+}
+
+/////////////////////////////////////////////////
+UserCameraPlugin::~UserCameraPlugin()
+{
+}
+
+void UserCameraPlugin::OnUpdate() {
+
+  rendering::UserCameraPtr user_camera = gui::get_active_camera();
+
+  if(user_camera && !model_name_.empty()) {
+    user_camera->TrackVisual(model_name_);
+  }
+
+}


### PR DESCRIPTION
**Problem Description**
Very often you end up clicking the follow target through the gazebo GUI, and this is cumbersome. To prevent this, gazebo provides you an interface to predefine your visual follow target in your `world` file. However, this makes it complicating if you want to use a single world file for multiple vehicles or if you have multiple vehicles in your world. 

**Solution**
This commit adds a `user_camera_plugin` which configures the gazebo GUI to follow the vehicle on startup. It tries to track the model with the same name as the environment variable `PX4_SIM_MODEL`

Since this interacts directly with the gui API, this would help on further optimizing the viewpoints in the future. (e.g. Simulating view point from the ground) Note that the plug is a gui plugin and is directly loaded from the gzclient, therefore this plugin does not have any influence when running in headless mode

**Alternatives**
We can also try templating `.world` files, but I see this blow up for maintenance since there will be too many configurations.

**Tests**
```
make px4_sitl gazebo_standard_vtol
```

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/5248102/104814427-18471f00-580f-11eb-8dcf-c0d33c84f31d.gif)

**Additional Context**
- This was first proposed in https://github.com/PX4/PX4-SITL_gazebo/pull/685 and replaces it
- This requires a firmware PR to work together