### PR TITLE
Rename geotagged_images_plugin to camera_manager_plugin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -334,7 +334,7 @@ link_libraries(mav_msgs nav_msgs std_msgs sensor_msgs)
 link_libraries(physics_msgs)
 
 add_library(gazebo_airspeed_plugin SHARED src/gazebo_airspeed_plugin.cpp)
-add_library(gazebo_geotagged_images_plugin SHARED src/gazebo_geotagged_images_plugin.cpp)
+add_library(gazebo_camera_manager_plugin SHARED src/gazebo_camera_manager_plugin.cpp)
 add_library(gazebo_gps_plugin SHARED src/gazebo_gps_plugin.cpp)
 add_library(gazebo_groundtruth_plugin SHARED src/gazebo_groundtruth_plugin.cpp)
 add_library(gazebo_irlock_plugin SHARED src/gazebo_irlock_plugin.cpp)
@@ -360,7 +360,7 @@ add_library(gazebo_airship_dynamics_plugin SHARED src/gazebo_airship_dynamics_pl
 
 set(plugins
   gazebo_airspeed_plugin
-  gazebo_geotagged_images_plugin
+  gazebo_camera_manager_plugin
   gazebo_gps_plugin
   gazebo_groundtruth_plugin
   gazebo_irlock_plugin

--- a/include/gazebo_camera_manager_plugin.h
+++ b/include/gazebo_camera_manager_plugin.h
@@ -38,15 +38,15 @@ namespace gazebo
 typedef const boost::shared_ptr<const sensor_msgs::msgs::SITLGps> GpsPtr;
 
 /**
- * @class GeotaggedImagesPlugin
+ * @class CameraManagerPlugin
  * Gazebo plugin that saves geotagged camera images to disk.
  */
-class GAZEBO_VISIBLE GeotaggedImagesPlugin : public SensorPlugin
+class GAZEBO_VISIBLE CameraManagerPlugin : public SensorPlugin
 {
 public:
-    GeotaggedImagesPlugin();
+    CameraManagerPlugin();
 
-    virtual ~GeotaggedImagesPlugin();
+    virtual ~CameraManagerPlugin();
     virtual void Load(sensors::SensorPtr sensor, sdf::ElementPtr sdf);
 
     void OnNewFrame(const unsigned char *image);

--- a/models/geotagged_cam/geotagged_cam.sdf
+++ b/models/geotagged_cam/geotagged_cam.sdf
@@ -39,7 +39,7 @@
             <robotNamespace></robotNamespace>
             <udpPort>5600</udpPort>
         </plugin>
-        <plugin name="GeotaggedImagesPlugin" filename="libgazebo_geotagged_images_plugin.so">
+        <plugin name="CameraManagerPlugin" filename="libgazebo_camera_manager_plugin.so">
           <robotNamespace></robotNamespace>
           <interval>1</interval>
           <width>3840</width>

--- a/models/typhoon_h480/typhoon_h480.sdf.jinja
+++ b/models/typhoon_h480/typhoon_h480.sdf.jinja
@@ -406,7 +406,7 @@
             <udpHost>127.0.0.1</udpHost>
             <udpPort>{{ gst_udp_port }}</udpPort>
         </plugin>
-        <plugin name="GeotaggedImagesPlugin" filename="libgazebo_geotagged_images_plugin.so">
+        <plugin name="CameraManagerPlugin" filename="libgazebo_camera_manager_plugin.so">
             <robotNamespace>typhoon_h480</robotNamespace>
             <interval>1</interval>
             <width>3840</width>


### PR DESCRIPTION
**Problem Description**
The `geotagged_images_plugn` naming is confusing, since it does much more than just geotagging images. - It is a mavlink camera implementation, following the [mavlink camera protocol](https://mavlink.io/en/services/camera.html). 

**Solution**
This commit renames the geotagged_images_plugin to the camera_manager_plugin, since it is more representative on what it actually is

**Tests**
Tested in SITL,
```
make px4_sitl gazebo_typhoon_h480
```