### PR TITLE
Added GPS and changed the Thruster config of the bluerov2 SDF file

### DIFF
--- a/models/uuv_bluerov2_heavy/uuv_bluerov2_heavy.sdf
+++ b/models/uuv_bluerov2_heavy/uuv_bluerov2_heavy.sdf
@@ -31,6 +31,60 @@
 
         </link>
 
+
+<!-- GPS for getting the local pose -->
+    <model name='gps0'>
+      <link name='link'>
+        <pose>0 0 0 0 0 0</pose>
+        <inertial>
+          <pose>0 0 0 0 0 0</pose>
+          <mass>0.01</mass>
+          <inertia>
+            <ixx>2.1733e-06</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>2.1733e-06</iyy>
+            <iyz>0</iyz>
+            <izz>1.8e-07</izz>
+          </inertia>
+        </inertial>
+        <visual name='visual'>
+          <geometry>
+            <cylinder>
+              <radius>0.01</radius>
+              <length>0.002</length>
+            </cylinder>
+          </geometry>
+          <material>
+            <script>
+              <name>Gazebo/Black</name>
+              <uri>__default__</uri>
+            </script>
+          </material>
+        </visual>
+        <sensor name='gps' type='gps'>
+          <pose>0 0 0 0 0 0</pose>
+          <plugin name='gps_plugin' filename='libgazebo_gps_plugin.so'>
+            <robotNamespace/>
+            <gpsNoise>1</gpsNoise>
+            <gpsXYRandomWalk>2.0</gpsXYRandomWalk>
+            <gpsZRandomWalk>4.0</gpsZRandomWalk>
+            <gpsXYNoiseDensity>0.0002</gpsXYNoiseDensity>
+            <gpsZNoiseDensity>0.0004</gpsZNoiseDensity>
+            <gpsVXYNoiseDensity>0.2</gpsVXYNoiseDensity>
+            <gpsVZNoiseDensity>0.4</gpsVZNoiseDensity>
+          </plugin>
+        </sensor>
+      </link>
+    </model>
+    <joint name='gps0_joint' type='fixed'>
+      <parent>base_link</parent>
+      <child>gps0::link</child>
+    </joint>
+
+
+
+<!-- Start of Thrusters  -->
         <link name="thruster1">
             <pose>0.14 -0.10 0 0 1.570796 0.78539815</pose>
             <inertial>
@@ -202,7 +256,7 @@
             <timeConstantDown>0.025</timeConstantDown>
             <maxRotVelocity>1100</maxRotVelocity>
             <motorConstant>-10</motorConstant>
-            <momentConstant>0.01</momentConstant>
+            <momentConstant>-0.01</momentConstant>
             <rotorDragCoefficient>0</rotorDragCoefficient>
             <rollingMomentCoefficient>0</rollingMomentCoefficient>
             <commandSubTopic>/gazebo/command/motor_speed</commandSubTopic>
@@ -262,7 +316,7 @@
             <timeConstantDown>0.025</timeConstantDown>
             <maxRotVelocity>1100</maxRotVelocity>
             <motorConstant>-10</motorConstant>
-            <momentConstant>0.01</momentConstant>
+            <momentConstant>-0.01</momentConstant>
             <rotorDragCoefficient>0</rotorDragCoefficient>
             <rollingMomentCoefficient>0</rollingMomentCoefficient>
             <commandSubTopic>/gazebo/command/motor_speed</commandSubTopic>
@@ -382,7 +436,7 @@
             <timeConstantDown>0.025</timeConstantDown>
             <maxRotVelocity>1100</maxRotVelocity>
             <motorConstant>-10</motorConstant>
-            <momentConstant>0.01</momentConstant>
+            <momentConstant>-0.01</momentConstant>
             <rotorDragCoefficient>0</rotorDragCoefficient>
             <rollingMomentCoefficient>0</rollingMomentCoefficient>
             <commandSubTopic>/gazebo/command/motor_speed</commandSubTopic>
@@ -443,7 +497,7 @@
             <timeConstantDown>0.025</timeConstantDown>
             <maxRotVelocity>1100</maxRotVelocity>
             <motorConstant>-10</motorConstant>
-            <momentConstant>0.01</momentConstant>
+            <momentConstant>-0.01</momentConstant>
             <rotorDragCoefficient>0</rotorDragCoefficient>
             <rollingMomentCoefficient>0</rollingMomentCoefficient>
             <commandSubTopic>/gazebo/command/motor_speed</commandSubTopic>
@@ -561,8 +615,8 @@
             <hil_mode>false</hil_mode>
             <hil_state_level>false</hil_state_level>
             <vehicle_is_tailsitter>false</vehicle_is_tailsitter>
-            <send_vision_estimation>true</send_vision_estimation>
-            <send_odometry>false</send_odometry>
+            <send_vision_estimation>0</send_vision_estimation>
+            <send_odometry>1</send_odometry>
             <enable_lockstep>true</enable_lockstep>
             <use_tcp>true</use_tcp>
             <motorSpeedCommandPubTopic>/gazebo/command/motor_speed</motorSpeedCommandPubTopic>

--- a/models/uuv_bluerov2_heavy/uuv_bluerov2_heavy.sdf
+++ b/models/uuv_bluerov2_heavy/uuv_bluerov2_heavy.sdf
@@ -616,7 +616,7 @@
             <hil_state_level>false</hil_state_level>
             <vehicle_is_tailsitter>false</vehicle_is_tailsitter>
             <send_vision_estimation>0</send_vision_estimation>
-            <send_odometry>1</send_odometry>
+            <send_odometry>0</send_odometry>
             <enable_lockstep>true</enable_lockstep>
             <use_tcp>true</use_tcp>
             <motorSpeedCommandPubTopic>/gazebo/command/motor_speed</motorSpeedCommandPubTopic>


### PR DESCRIPTION
The GPS is added in order to provide a global position for the px4 EKF2 module.

Additionally, the thruster configuration is changed to match the sitl mixer which is provided in the next pull request on the PX4 software.
This pull request can be seen here: