### PR TITLE
Implement gimbal controller as MAVLink gimbal v2 device

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -309,4 +309,16 @@ inline const bool checkWorldHomePosition(gazebo::physics::WorldPtr& world,
   return (world_latitude && world_latitude && world_latitude) ? true : false;
 }
 
+template <typename T>
+inline T degrees(T radians)
+{
+    return radians * static_cast<T>(180.0) / static_cast<T>(M_PI);
+}
+
+template <typename T>
+inline T radians(T degrees)
+{
+    return radians / static_cast<T>(180.0) * static_cast<T>(M_PI);
+}
+
 #endif  // SITL_GAZEBO_COMMON_H_

--- a/include/gazebo_gimbal_controller_plugin.hh
+++ b/include/gazebo_gimbal_controller_plugin.hh
@@ -26,6 +26,7 @@
 #include <vector>
 #include <mutex>
 #include <memory>
+#include <optional>
 #include <thread>
 
 #include <gazebo/common/PID.hh>
@@ -94,6 +95,8 @@ namespace gazebo
     private: void HandleRequestMessage(uint8_t target_sysid, uint8_t target_compid, const mavlink_command_long_t& command_long);
     private: void HandleSetMessageInterval(uint8_t target_sysid, uint8_t target_compid, const mavlink_command_long_t& command_long);
 
+    private: static std::optional<double> calcSetpoint(double dt, double lastSetpoint, double newSetpoint, double newRateSetpoint);
+
     private: std::mutex cmd_mutex;
 
     private: sdf::ElementPtr sdf;
@@ -120,10 +123,16 @@ namespace gazebo
     private: double yDir;
 
     private: std::mutex setpointMutex {};
+    private: double lastRollSetpoint {0.0};
+    private: double lastPitchSetpoint {0.0};
+    private: double lastYawSetpoint {0.0};
     private: double rollSetpoint {0.0};
     private: double pitchSetpoint {0.0};
     private: double yawSetpoint {0.0};
     private: bool yawLock {false};
+    private: double rollRateSetpoint {NAN};
+    private: double pitchRateSetpoint {NAN};
+    private: double yawRateSetpoint {NAN};
 
     private: transport::NodePtr node;
 

--- a/include/gazebo_gimbal_controller_plugin.hh
+++ b/include/gazebo_gimbal_controller_plugin.hh
@@ -37,8 +37,6 @@
 #include <ignition/math.hh>
 #include <mavlink/v2.0/common/mavlink.h>
 
-#include "Groundtruth.pb.h"
-
 namespace gazebo
 {
   // Default PID gains
@@ -71,8 +69,6 @@ namespace gazebo
   static double kPitchDir = -1.0;
   static double kYawDir = 1.0;
 
-  typedef const boost::shared_ptr<const sensor_msgs::msgs::Groundtruth> GtPtr;
-
   class GAZEBO_VISIBLE GimbalControllerPlugin : public ModelPlugin
   {
     public: GimbalControllerPlugin();
@@ -83,8 +79,6 @@ namespace gazebo
     public: virtual void Init();
 
     private: void OnUpdate();
-
-    private: void GroundTruthCallback(GtPtr& imu_message);
 
     private: bool InitUdp();
     private: void SendHeartbeat();
@@ -106,8 +100,6 @@ namespace gazebo
 
     private: std::vector<event::ConnectionPtr> connections;
 
-    private: transport::SubscriberPtr imuSub;
-
     private: physics::ModelPtr model;
 
     /// \brief yaw camera
@@ -120,8 +112,7 @@ namespace gazebo
     private: physics::JointPtr pitchJoint;
 
     private: sensors::ImuSensorPtr cameraImuSensor;
-    private: double vehicleYaw;
-
+    private: double vehicleYawRad {0.0};
     private: std::string status;
 
     private: double rDir;
@@ -132,6 +123,7 @@ namespace gazebo
     private: double rollSetpoint {0.0};
     private: double pitchSetpoint {0.0};
     private: double yawSetpoint {0.0};
+    private: bool yawLock {false};
 
     private: transport::NodePtr node;
 

--- a/models/typhoon_h480/typhoon_h480.sdf.jinja
+++ b/models/typhoon_h480/typhoon_h480.sdf.jinja
@@ -244,8 +244,8 @@
       <axis>
         <xyz>0 0 1</xyz>
         <limit>
-          <lower>-1e16</lower>
-          <upper>1e16</upper>
+          <lower>-inf</lower>
+          <upper>inf</upper>
           <effort>100</effort>
           <velocity>-1</velocity>
         </limit>
@@ -426,8 +426,8 @@
       <axis>
         <xyz>0 -1 0</xyz>
         <limit>
-          <lower>-2.09</lower>
-          <upper>2.09</upper>
+          <lower>-1.5708</lower>
+          <upper>0.7854</upper>
           <effort>100</effort>
           <velocity>-1</velocity>
         </limit>

--- a/models/typhoon_h480/typhoon_h480.sdf.jinja
+++ b/models/typhoon_h480/typhoon_h480.sdf.jinja
@@ -244,8 +244,8 @@
       <axis>
         <xyz>0 0 1</xyz>
         <limit>
-          <lower>-inf</lower>
-          <upper>inf</upper>
+          <lower>-1e+16</lower>
+          <upper>1e+16</upper>
           <effort>100</effort>
           <velocity>-1</velocity>
         </limit>

--- a/models/typhoon_h480/typhoon_h480.sdf.jinja
+++ b/models/typhoon_h480/typhoon_h480.sdf.jinja
@@ -1437,8 +1437,8 @@
       <control_gimbal_channels>
         <channel>
           <joint_control_pid>
-            <p>0.6</p>
-            <i>0.1</i>
+            <p>0.4</p>
+            <i>0.05</i>
             <d>0.02</d>
             <iMax>0</iMax>
             <iMin>0</iMin>
@@ -1461,9 +1461,9 @@
         </channel>
         <channel>
           <joint_control_pid>
-            <p>2.068</p>
+            <p>0.3</p>
             <i>0.01245</i>
-            <d>0.01</d>
+            <d>0.015</d>
             <iMax>0</iMax>
             <iMin>0</iMin>
             <cmdMax>0.3</cmdMax>

--- a/src/gazebo_camera_manager_plugin.cpp
+++ b/src/gazebo_camera_manager_plugin.cpp
@@ -344,6 +344,14 @@ void CameraManagerPlugin::_handle_message(mavlink_message_t *msg, struct sockadd
                 // Just ACK and ignore
                 _send_cmd_ack(msg->sysid, msg->compid, MAV_CMD_STORAGE_FORMAT, MAV_RESULT_ACCEPTED, srcaddr);
                 break;
+            case MAV_CMD_VIDEO_START_STREAMING:
+                // Just ACK and ignore
+                _send_cmd_ack(msg->sysid, msg->compid, MAV_CMD_VIDEO_START_STREAMING, MAV_RESULT_ACCEPTED, srcaddr);
+                break;
+            case MAV_CMD_VIDEO_STOP_STREAMING:
+                // Just ACK and ignore
+                _send_cmd_ack(msg->sysid, msg->compid, MAV_CMD_VIDEO_STOP_STREAMING, MAV_RESULT_ACCEPTED, srcaddr);
+                break;
             }
         }
         break;

--- a/src/gazebo_gimbal_controller_plugin.cpp
+++ b/src/gazebo_gimbal_controller_plugin.cpp
@@ -844,7 +844,7 @@ void GimbalControllerPlugin::HandleRequestMessage(uint8_t target_sysid, uint8_t 
       SendGimbalDeviceInformation();
       break;
     default:
-      SendResult(target_sysid, target_compid, command_long.command, MAV_RESULT_DENIED);
+      // Ignore messages that we don't support.
       break;
   }
 }

--- a/src/gazebo_gimbal_controller_plugin.cpp
+++ b/src/gazebo_gimbal_controller_plugin.cpp
@@ -739,7 +739,7 @@ void GimbalControllerPlugin::SendMavlinkMessage(const mavlink_message_t &msg)
   sockaddr_in dest_addr {};
   dest_addr.sin_family = AF_INET;
   inet_pton(AF_INET, "127.0.0.1", &dest_addr.sin_addr.s_addr);
-  dest_addr.sin_port = htons(14520);
+  dest_addr.sin_port = htons(13030);
 
   const ssize_t len = sendto(this->sock, buffer, packetlen, 0, reinterpret_cast<sockaddr *>(&dest_addr), sizeof(dest_addr));
   if (len <= 0) {

--- a/src/gazebo_gimbal_controller_plugin.cpp
+++ b/src/gazebo_gimbal_controller_plugin.cpp
@@ -413,7 +413,7 @@ void GimbalControllerPlugin::OnUpdate()
 
       // Without this minus, the gimbal yaw is inverted.
       const auto maybeNewYawSetpoint = calcSetpoint(
-          dt, this->lastYawSetpoint, -this->yawSetpoint + (this->yawLock ? M_PI/2.0 : this->vehicleYawRad), -this->yawRateSetpoint);
+          dt, this->lastYawSetpoint, -this->yawSetpoint, -this->yawRateSetpoint);
       if (maybeNewYawSetpoint) {
         this->lastYawSetpoint = maybeNewYawSetpoint.value();
       }
@@ -427,7 +427,7 @@ void GimbalControllerPlugin::OnUpdate()
     double pitchLimited = ignition::math::clamp(this->lastPitchSetpoint,
       pDir*this->pitchJoint->UpperLimit(0),
       pDir*this->pitchJoint->LowerLimit(0));
-    double yawLimited = ignition::math::clamp(this->lastYawSetpoint,
+    double yawLimited = ignition::math::clamp(this->lastYawSetpoint + (this->yawLock ? M_PI/2.0 : this->vehicleYawRad),
       yDir*this->yawJoint->LowerLimit(0),
     yDir*this->yawJoint->UpperLimit(0));
 #else
@@ -437,7 +437,7 @@ void GimbalControllerPlugin::OnUpdate()
     double pitchLimited = ignition::math::clamp(this->lastPitchSetpoint,
       pDir*this->pitchJoint->GetUpperLimit(0).Radian(),
       pDir*this->pitchJoint->GetLowerLimit(0).Radian());
-    double yawLimited = ignition::math::clamp(this->lastYawSetpoint,
+    double yawLimited = ignition::math::clamp(this->lastYawSetpoint + (this->yawLock ? M_PI/2.0 : this->vehicleYawRad),
       yDir*this->yawJoint->GetLowerLimit(0).Radian(),
     yDir*this->yawJoint->GetUpperLimit(0).Radian());
 #endif

--- a/src/gazebo_gimbal_controller_plugin.cpp
+++ b/src/gazebo_gimbal_controller_plugin.cpp
@@ -640,14 +640,12 @@ void GimbalControllerPlugin::SendGimbalDeviceInformation()
     GIMBAL_DEVICE_CAP_FLAGS_HAS_YAW_FOLLOW |
     GIMBAL_DEVICE_CAP_FLAGS_SUPPORTS_INFINITE_YAW;
 
-  const float tiltMax = this->pitchJoint->UpperLimit(0);
-  const float tiltMin = this->pitchJoint->LowerLimit(0);
-  const float panMax = this->yawJoint->LowerLimit(0);
-  const float panMin = this->yawJoint->UpperLimit(0);
-
-  // Somewhat arbitrary limits:
-  const float panRateMin = 60.0 / 180.0 * M_PI;
-  const float tiltRateMax = 60 / 180.0 * M_PI;
+  const float rollMax = this->rollJoint->UpperLimit(0);
+  const float rollMin = this->rollJoint->LowerLimit(0);
+  const float pitchMax = this->pitchJoint->UpperLimit(0);
+  const float pitchMin = this->pitchJoint->LowerLimit(0);
+  const float yawMax = this->yawJoint->LowerLimit(0);
+  const float yawMin = this->yawJoint->UpperLimit(0);
 
   mavlink_message_t msg;
   mavlink_msg_gimbal_device_information_pack_chan(
@@ -664,12 +662,12 @@ void GimbalControllerPlugin::SendGimbalDeviceInformation()
     uid,
     capFlags,
     0, // custom_cap_flags
-    tiltMax,
-    tiltMin,
-    tiltRateMax,
-    panMax,
-    panMin,
-    panRateMin);
+    rollMin,
+    rollMax,
+    pitchMin,
+    pitchMax,
+    yawMin,
+    yawMax);
   SendMavlinkMessage(msg);
 }
 

--- a/src/gazebo_gimbal_controller_plugin.cpp
+++ b/src/gazebo_gimbal_controller_plugin.cpp
@@ -627,13 +627,14 @@ void GimbalControllerPlugin::SendGimbalDeviceInformation()
     GIMBAL_DEVICE_CAP_FLAGS_HAS_YAW_FOLLOW |
     GIMBAL_DEVICE_CAP_FLAGS_SUPPORTS_INFINITE_YAW;
 
+  const float tiltMax = this->pitchJoint->UpperLimit(0);
+  const float tiltMin = this->pitchJoint->LowerLimit(0);
+  const float panMax = this->yawJoint->LowerLimit(0);
+  const float panMin = this->yawJoint->UpperLimit(0);
+
   // Somewhat arbitrary limits:
-  const float tiltMax = 20.0 / 180.0 * M_PI;
-  const float tiltMin = -90.0 / 180.0 * M_PI;
-  const float tiltRateMax = 60 / 180.0 * M_PI;
-  const float panMax = 360.0 / 180.0 * M_PI;
-  const float panMin = -360.0 / 180.0 * M_PI;
   const float panRateMin = 60.0 / 180.0 * M_PI;
+  const float tiltRateMax = 60 / 180.0 * M_PI;
 
   mavlink_message_t msg;
   mavlink_msg_gimbal_device_information_pack_chan(


### PR DESCRIPTION
This adds a gimbal controller which communicates via MAVLink to PX4 and implements the gimbal v2 device interface as described in https://mavlink.io/en/services/gimbal_v2.html#how-to-implement-the-gimbal-device-interface.