### PR TITLE
gazebo_mavlink_interface: generate subscribers for nested models with sensors

### DIFF
--- a/include/gazebo_mavlink_interface.h
+++ b/include/gazebo_mavlink_interface.h
@@ -74,9 +74,9 @@
 #include "msgbuffer.h"
 
 //! Default distance sensor model joint naming
-static const std::regex kDefaultLidarModelJointNaming(".*(lidar|sf10a)(.*_joint)");
-static const std::regex kDefaultSonarModelJointNaming(".*(sonar|mb1240-xl-ez4)(.*_joint)");
-static const std::regex kDefaultGPSModelJointNaming(".*(gps|ublox-neo-7M)(.*_joint)");
+static const std::regex kDefaultLidarModelNaming(".*(lidar|sf10a)(.*)");
+static const std::regex kDefaultSonarModelNaming(".*(sonar|mb1240-xl-ez4)(.*)");
+static const std::regex kDefaultGPSModelNaming(".*(gps|ublox-neo-7M)(.*)");
 
 namespace gazebo {
 
@@ -210,7 +210,7 @@ private:
   template <typename GazeboMsgT>
   void CreateSensorSubscription(
       void (GazeboMavlinkInterface::*fp)(const boost::shared_ptr<GazeboMsgT const>&, const int&),
-      GazeboMavlinkInterface* ptr, const physics::Joint_V& joints, const std::regex& model);
+      GazeboMavlinkInterface* ptr, const physics::Joint_V& joints, physics::ModelPtr& nested_model, const std::regex& model);
 
   static const unsigned n_out_max = 16;
 


### PR DESCRIPTION
**Problem description**

While testing some `iris` models that contain nested models (ex: `iris_opt_flow` includes `iris`), I found out that no GPS data was being propagated through `HIL_GPS`, meaning then that there were no subscribers to the GPS topic(s) present in the model.
An inspection lead me to find that included models do not advertise their joints at the parent model level (at least from what I can see in Gazebo 11, I am not sure if this problem was also present in Gazebo 9), so since for the sensor topic subscription mapping we were capturing the existing sensor joints, any other sensor inside the <include> models were not being found (which means that no subscription was being created to the present sensors).


**Proposed solution**

Fortunately the Gazebo API provides a way of getting the nested models present in the base model, so we can basically just capture those and generate the subscriptions when a sensor is found. Note that this solution is mostly to find the GPS nested models, and will not capture other sensor models added without being nested.

Tested with `iris`, `iris_opt_flow`, `iris_dual_gps` and `iris_obs_avoid`.

@markusachtelik FYI.