### PR TITLE
add jinja file for iris_rtps

### DIFF
--- a/models/iris_rtps/iris_rtps.sdf.jinja
+++ b/models/iris_rtps/iris_rtps.sdf.jinja
@@ -1,0 +1,9 @@
+<!-- DO NOT EDIT: Generated from iris_rtps.sdf.jinja -->
+<sdf version='1.6'>
+  <model name='iris_rtps'>
+    <include>
+      <uri>model://iris</uri>
+    </include>
+  </model>
+  <!-- This model will include in the future a RTPS/DDS interface plugin -->
+</sdf>


### PR DESCRIPTION
I found some exception about "jinja2.exceptions.TemplateNotFound: models/iris_rtps/iris_rtps.sdf.jinja" , when runing gazebo_sitl_multiple_run.sh

To solve this problem, I add jinja file for the iris_rtps.

```bash
$ Tools/gazebo_sitl_multiple_run.sh -t px4_sitl_rtps -m iris_rtps -n 2

[Msg] Waiting for master.
[Msg] Connected to gazebo master @ http://127.0.0.1:11345
[Msg] Publicized address: 192.168.0.105
starting instance 0 in /root/multi_vehicle/PX4-Autopilot/build/px4_sitl_rtps/instance_0
Traceback (most recent call last):
  File "/root/multi_vehicle/PX4-Autopilot/Tools/../Tools/sitl_gazebo/scripts/jinja_gen.py", line 38, in <module>
    template = env.get_template(os.path.relpath(args.filename, args.env_dir))
  File "/usr/local/lib/python3.6/dist-packages/jinja2/environment.py", line 883, in get_template
    return self._load_template(name, self.make_globals(globals))
  File "/usr/local/lib/python3.6/dist-packages/jinja2/environment.py", line 857, in _load_template
    template = self.loader.load(self, name, globals)
  File "/usr/local/lib/python3.6/dist-packages/jinja2/loaders.py", line 117, in load
    source, filename, uptodate = self.get_source(environment, name)
  File "/usr/local/lib/python3.6/dist-packages/jinja2/loaders.py", line 199, in get_source
    raise TemplateNotFound(template)
jinja2.exceptions.TemplateNotFound: models/iris_rtps/iris_rtps.sdf.jinja
Spawning iris_rtps_0
```

