### PR TITLE
Simulating lidar in foggy environment

### DIFF
--- a/include/gazebo_lidar_plugin.h
+++ b/include/gazebo_lidar_plugin.h
@@ -75,6 +75,7 @@ namespace gazebo
       double max_distance_;
       double low_signal_strength_;
       double high_signal_strength_;
+      bool simulate_fog_;
 
       gazebo::msgs::Quaternion orientation_;
 

--- a/models/foggy_lidar/foggy_lidar.sdf
+++ b/models/foggy_lidar/foggy_lidar.sdf
@@ -1,0 +1,64 @@
+<?xml version="1.0" ?>
+<sdf version="1.5">
+  <model name="foggy_lidar">
+    <link name="link">
+
+      <inertial>
+        <pose>0 0 0 0 0 0</pose>
+        <mass>0.19</mass>
+        <inertia>
+          <ixx>4.15e-6</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>2.407e-6</iyy>
+          <iyz>0</iyz>
+          <izz>2.407e-6</izz>
+        </inertia>
+      </inertial>
+
+      <visual name="visual">
+        <geometry>
+          <box>
+            <size>0.02 0.05 0.05</size>
+          </box>
+        </geometry>
+      </visual>
+
+      <sensor name="laser" type="ray">
+        <pose>0 0 0 0 1.51 0</pose>
+        <always_on>1</always_on>
+        <update_rate>5.5</update_rate>
+        <visualize>true</visualize>
+        <ray>
+          <scan>
+            <horizontal>
+              <samples>360</samples>
+              <resolution>1</resolution>
+              <min_angle>-3.14</min_angle>
+              <max_angle>3.14</max_angle>
+            </horizontal>
+          </scan>
+          <range>
+            <min>0.06</min>
+            <max>120</max>
+            <resolution>0.05</resolution>
+          </range>
+          <noise>
+            <type>gaussian</type>
+            <mean>0.0</mean>
+            <stddev>1.0</stddev>
+          </noise>
+        </ray>
+        <plugin name="LaserPlugin"
+          filename="libgazebo_lidar_plugin.so">
+          <robotNamespace></robotNamespace>
+          <min_distance>0.1</min_distance>
+          <max_distance>100.0</max_distance>
+          <simulate_fog>true</simulate_fog>
+        </plugin>
+      </sensor>
+    </link>
+  </model>
+</sdf>
+
+<!-- vim: set et fenc= ff=unix sts=0 sw=2 ts=2 : -->

--- a/models/foggy_lidar/model.config
+++ b/models/foggy_lidar/model.config
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+
+<model>
+  <name>foggy_lidar</name>
+  <version>1.0</version>
+  <sdf>foggy_lidar.sdf</sdf>
+
+  <author>
+    <name>David Jablonski</name>
+    <email>dayjaby@gmail.com</email>
+  </author>
+
+  <description>
+		This lidar simulates a foggy environment with an average distance measurement of 2m and a standard deviation of 1.
+  </description>
+</model>
+
+<!-- vim: set noet fenc= ff=unix sts=0 sw=2 ts=2 : -->

--- a/models/iris_foggy_lidar/iris_foggy_lidar.sdf
+++ b/models/iris_foggy_lidar/iris_foggy_lidar.sdf
@@ -1,0 +1,29 @@
+<?xml version="1.0" ?>
+<sdf version='1.5'>
+  <model name='iris_foggy_lidar'>
+
+    <include>
+      <uri>model://iris</uri>
+    </include> 
+
+    <include>
+      <uri>model://foggy_lidar</uri>
+      <pose>0 0 0.1 0 1.571 0</pose>
+    </include>
+    <joint name="foggy_lidar_joint" type="revolute">
+      <parent>iris::base_link</parent>
+      <child>foggy_lidar::link</child>
+      <pose>0 0 0.1 0 1.571 0</pose>
+      <axis>
+        <xyz>0 0 1</xyz>
+        <limit>
+          <upper>0</upper>
+          <lower>0</lower>
+        </limit>
+      </axis>
+    </joint>
+
+  </model>
+</sdf>
+<!-- vim: set noet fenc=utf-8 ff=unix sts=0 sw=4 ts=4 : -->
+

--- a/models/iris_foggy_lidar/model.config
+++ b/models/iris_foggy_lidar/model.config
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<model>
+  <name>3DR Iris with a foggy lidar measurement</name>
+  <version>1.0</version>
+  <sdf>iris_foggy_lidar.sdf</sdf>
+
+  <author>
+   <name>David Jablonski</name>
+   <email>dayjaby@gmail.com</email>
+  </author>
+
+  <description>
+    This is a model of the 3DR Iris Quadrotor with a foggy lidar measurement.
+  </description>
+</model>


### PR DESCRIPTION
Since having a flight with bad altitude estimation due to malicious distance sensor measurements in dense fog (https://review.px4.io/plot_app?log=c9482a7a-0608-4cab-9ad3-5a6dbef7f2f7), I was looking forward to implement this in gazebo to verify the behaviour of newer firmware versions for foggy flights.

This PR simulates fog by creating distance measurements of 2m with 0.1 stddev:
![Screenshot from 2021-03-08 23-44-46](https://user-images.githubusercontent.com/164396/110391865-61299000-8068-11eb-851c-e460b8361632.png)

In newer versions (tested on PX4 master), the altitude estimation seems to be not prone to bad distance measurements anymore: https://logs.px4.io/plot_app?log=813654b1-2be4-418c-b3f5-3bd9af216c36