### PR TITLE
gst camera: add RTMP streaming and nvidia encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,21 @@ make install
 
 When writing test it’s important to be careful which API functions of Gazebo are called. As no Gazebo server is running during the tests some functions can produce undefined behaviour (e.g. segfaults).
 
+## CUDA Hardware Acceleration (optional)
+
+1. Download CUDA 10.0 from https://developer.nvidia.com/cuda-toolkit-archive.
+2. Download Video Codec SDK 9.0 from https://developer.nvidia.com/video-codec-sdk-archive.
+3. Install both
+```bash
+wget https://raw.githubusercontent.com/jackersson/env-setup/master/gst-nvidia-docker/install_video_codec_sdk.sh
+chmod +x install_video_codec_sdk.sh
+sudo ./install_video_codec_sdk.sh
+sudo dpkg -i cuda-repo-ubuntu*.deb
+sudo apt-key add /var/cuda-repo-<version>/7fa2af80.pub
+sudo apt-get update
+sudo apt-get install cuda
+```
+4. Reboot your system.
 
 #### *catkin tools*
 

--- a/README.md
+++ b/README.md
@@ -127,11 +127,12 @@ make install
 
 When writing test it’s important to be careful which API functions of Gazebo are called. As no Gazebo server is running during the tests some functions can produce undefined behaviour (e.g. segfaults).
 
-## CUDA Hardware Acceleration (optional)
+## CUDA Hardware Accelerated H264 encoding (optional)
 
 1. Download CUDA 10.0 from https://developer.nvidia.com/cuda-toolkit-archive.
 2. Download Video Codec SDK 9.0 from https://developer.nvidia.com/video-codec-sdk-archive.
-3. Install both
+3. Install both archives:
+
 ```bash
 wget https://raw.githubusercontent.com/jackersson/env-setup/master/gst-nvidia-docker/install_video_codec_sdk.sh
 chmod +x install_video_codec_sdk.sh
@@ -141,7 +142,19 @@ sudo apt-key add /var/cuda-repo-<version>/7fa2af80.pub
 sudo apt-get update
 sudo apt-get install cuda
 ```
-4. Reboot your system.
+
+4. Reboot your system and run the command `nvidia-smi` to verify the successul installation of CUDA.
+5. Install GStreamer 1.18.3:
+
+```bash
+git clone https://github.com/GStreamer/gst-build -b 1.18.3
+cd gst-build
+meson -Dbuildtype=release -Dstrip=true -Dgst-plugins-bad:introspection=enabled -Dgst-plugins-bad:nvcodec=enabled builddir
+ninja -C builddir
+sudo meson install -C builddir
+```
+
+6. Add `<useCuda>true</useCuda>` to any `gazebo_gst_camera_plugin` in a SDF file. For example `./models/fpv_cam/fpv_cam.sdf`.
 
 #### *catkin tools*
 

--- a/include/gazebo_gst_camera_plugin.h
+++ b/include/gazebo_gst_camera_plugin.h
@@ -70,6 +70,7 @@ class GAZEBO_VISIBLE GstCameraPlugin : public SensorPlugin
     int udpPort;
     bool useRtmp;
     std::string rtmpLocation;
+    bool useCuda;
 
   protected: sensors::CameraSensorPtr parentSensor;
   protected: rendering::CameraPtr camera;

--- a/include/gazebo_gst_camera_plugin.h
+++ b/include/gazebo_gst_camera_plugin.h
@@ -65,8 +65,11 @@ class GAZEBO_VISIBLE GstCameraPlugin : public SensorPlugin
   float rate;
   protected: std::string format;
 
-  protected: std::string udpHost;
-  protected: int udpPort;
+  protected:
+    std::string udpHost;
+    int udpPort;
+    bool useRtmp;
+    std::string rtmpLocation;
 
   protected: sensors::CameraSensorPtr parentSensor;
   protected: rendering::CameraPtr camera;

--- a/models/fpv_cam/fpv_cam.sdf
+++ b/models/fpv_cam/fpv_cam.sdf
@@ -89,6 +89,7 @@
           <plugin name="GstCameraPlugin" filename="libgazebo_gst_camera_plugin.so">
             <robotNamespace></robotNamespace>
             <udpPort>5600</udpPort>
+            <useCuda>true</useCuda>
           </plugin>
         </sensor>
         <self_collide>0</self_collide>

--- a/models/fpv_cam/fpv_cam.sdf
+++ b/models/fpv_cam/fpv_cam.sdf
@@ -89,7 +89,6 @@
           <plugin name="GstCameraPlugin" filename="libgazebo_gst_camera_plugin.so">
             <robotNamespace></robotNamespace>
             <udpPort>5600</udpPort>
-            <useCuda>true</useCuda>
           </plugin>
         </sensor>
         <self_collide>0</self_collide>

--- a/src/gazebo_gst_camera_plugin.cpp
+++ b/src/gazebo_gst_camera_plugin.cpp
@@ -97,10 +97,38 @@ void GstCameraPlugin::startGstThread() {
   GstElement* dataSrc = gst_element_factory_make("appsrc", "AppSrc");
   GstElement* testSrc = gst_element_factory_make("videotestsrc", "FileSrc");
   GstElement* conv  = gst_element_factory_make("videoconvert", "Convert");
-  GstElement* encoder = gst_element_factory_make("x264enc", "AvcEncoder");
+
+  GstElement* encoder = gst_element_factory_make("nvh264enc", "AvcEncoder");
+  if (!encoder) {
+    encoder = gst_element_factory_make("x264enc", "AvcEncoder");
+    g_object_set(G_OBJECT(encoder), "bitrate", 800, NULL);
+    g_object_set(G_OBJECT(encoder), "speed-preset", 2, NULL); //lower = faster, 6=medium
+    //g_object_set(G_OBJECT(encoder), "tune", "zerolatency", NULL);
+    //g_object_set(G_OBJECT(encoder), "low-latency", 1, NULL);
+    //g_object_set(G_OBJECT(encoder), "control-rate", 2, NULL);
+  } else {
+    g_object_set(G_OBJECT(encoder), "bitrate", 800, NULL);
+    g_object_set(G_OBJECT(encoder), "preset", 1, NULL); //lower = faster, 6=medium
+  }
   GstElement* parser  = gst_element_factory_make("h264parse", "Parser");
-  GstElement* payload = gst_element_factory_make("rtph264pay", "PayLoad");
-  GstElement* sink  = gst_element_factory_make("udpsink", "UdpSink");
+  GstElement* payload;
+  GstElement* sink;
+ 
+  if (useRtmp) {
+    g_object_set(G_OBJECT(parser), "config-interval", 1, NULL);
+    payload = gst_element_factory_make("flvmux", "FLVMux");
+    sink = gst_element_factory_make("rtmpsink", "RtmpSink");
+    g_object_set(G_OBJECT(sink), "location", this->rtmpLocation.c_str(), NULL);
+  } else {
+    payload = gst_element_factory_make("rtph264pay", "PayLoad");
+    g_object_set(G_OBJECT(payload), "config-interval", 1, NULL);
+    sink  = gst_element_factory_make("udpsink", "UdpSink");
+    g_object_set(G_OBJECT(sink), "host", this->udpHost.c_str(), NULL);
+    g_object_set(G_OBJECT(sink), "port", this->udpPort, NULL);
+    //g_object_set(G_OBJECT(sink), "sync", false, NULL);
+    //g_object_set(G_OBJECT(sink), "async", false, NULL);
+  }
+
   if (!dataSrc || !testSrc || !conv || !encoder || !parser || !payload || !sink) {
     gzerr << "ERR: Create elements failed. \n";
     return;
@@ -120,22 +148,6 @@ void GstCameraPlugin::startGstThread() {
       NULL),
       "is-live", TRUE,
       NULL);
-
-  // Config encoder
-  g_object_set(G_OBJECT(encoder), "bitrate", 800, NULL);
-  g_object_set(G_OBJECT(encoder), "speed-preset", 2, NULL); //lower = faster, 6=medium
-  //g_object_set(G_OBJECT(encoder), "tune", "zerolatency", NULL);
-  //g_object_set(G_OBJECT(encoder), "low-latency", 1, NULL);
-  //g_object_set(G_OBJECT(encoder), "control-rate", 2, NULL);
-
-  // Config payload
-  g_object_set(G_OBJECT(payload), "config-interval", 1, NULL);
-
-  // Config udpsink
-  g_object_set(G_OBJECT(sink), "host", this->udpHost.c_str(), NULL);
-  g_object_set(G_OBJECT(sink), "port", this->udpPort, NULL);
-  //g_object_set(G_OBJECT(sink), "sync", false, NULL);
-  //g_object_set(G_OBJECT(sink), "async", false, NULL);
 
   // Connect all elements to pipeline
   gst_bin_add_many(GST_BIN(pipeline), dataSrc, conv, encoder, parser, payload, sink, NULL);
@@ -253,12 +265,19 @@ void GstCameraPlugin::Load(sensors::SensorPtr sensor, sdf::ElementPtr sdf)
 
   this->udpHost = "127.0.0.1";
   if (sdf->HasElement("udpHost")) {
-	this->udpHost = sdf->GetElement("udpHost")->Get<string>();
+    this->udpHost = sdf->GetElement("udpHost")->Get<string>();
   }
 	
   this->udpPort = 5600;
   if (sdf->HasElement("udpPort")) {
-	this->udpPort = sdf->GetElement("udpPort")->Get<int>();
+    this->udpPort = sdf->GetElement("udpPort")->Get<int>();
+  }
+
+  if (sdf->HasElement("rtmpLocation")) {
+    this->rtmpLocation = sdf->GetElement("rtmpLocation")->Get<string>();
+    this->useRtmp = true;
+  } else {
+    this->useRtmp = false;
   }
 
   node_handle_ = transport::NodePtr(new transport::Node());


### PR DESCRIPTION
This PR adds two new features (sorry for making one PR with two features.-.):
- RTMP streaming
- using nvh264enc if available

RTMP streaming, as an alternative to the previous UDP solution, can be enabled by simply adding a `rtmpLocation` tag:
```
<sensor name='camera' type='camera'>
  ...
  <plugin name="GstRTMPCameraPlugin" filename="libgazebo_gst_camera_plugin.so">
    <robotNamespace></robotNamespace>
    <rtmpLocation>rtmp://127.0.0.1:1935/live/simulation-fpv</rtmpLocation>
  </plugin>
</sensor>
```

The nvidia encoder was tested on a Ubuntu 18.04 computer, following the first steps in `http://lifestyletransfer.com/how-to-install-nvidia-gstreamer-plugins-nvenc-nvdec-on-ubuntu/` and compiling GStreamer version 1.18.3 via [gst-build](https://github.com/GStreamer/gst-build) and enabling nvcodec explicitly:

```
meson -Dbuildtype=release -Dstrip=true -Dgst-plugins-bad:introspection=enabled -Dgst-plugins-bad:nvcodec=enabled builddir
ninja -C builddir
sudo meson install -C builddir
```

The GPU confirms to be used by gazebo:
```
$ nvidia-smi
Sun Mar 14 15:59:50 2021       
+-----------------------------------------------------------------------------+
| NVIDIA-SMI 410.48                 Driver Version: 410.48                    |
|-------------------------------+----------------------+----------------------+
| GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |
|===============================+======================+======================|
|   0  GeForce GTX 108...  Off  | 00000000:01:00.0 Off |                  N/A |
| 45%   40C    P2    61W / 250W |    310MiB / 11178MiB |      0%      Default |
+-------------------------------+----------------------+----------------------+
                                                                               
+-----------------------------------------------------------------------------+
| Processes:                                                       GPU Memory |
|  GPU       PID   Type   Process name                             Usage      |
|=============================================================================|
|    0     17523      C   gzserver                                     300MiB |
+-----------------------------------------------------------------------------+
```

The tested nvidia installations are:
- cuda-repo-ubuntu1804-10-0-local-10.0.130-410.48_1.0-1_amd64.deb
- Video_Codec_SDK_9.0.20.zip

ToDo: 
- test everything on Ubuntu 20.04 with latest cuda and video codec sdk versions
- create more detailed installation steps