### PR TITLE
tailsitter: fix airspeed orientation

### DIFF
--- a/models/tailsitter/tailsitter.sdf
+++ b/models/tailsitter/tailsitter.sdf
@@ -87,7 +87,7 @@
     </joint>
     <include>
       <uri>model://airspeed</uri>
-      <pose>0 0 0 0 0 0</pose>
+      <pose>0 0 0 0 -1.57 0</pose>
       <name>airspeed</name>
     </include>
     <joint name='airspeed_joint' type='fixed'>


### PR DESCRIPTION
The orientation of the airspeed sensor got missed in https://github.com/PX4/PX4-SITL_gazebo/pull/731/files#diff-0020558d0aae9f87a3eabf04651b92582eb94089e78c860d631c8a693b523923L89.