### PR TITLE
Switch tailsitter sdf version to 1.6

### DIFF
--- a/models/tailsitter/model.config
+++ b/models/tailsitter/model.config
@@ -2,7 +2,7 @@
 <model>
   <name>Tailsitter</name>
   <version>1.0</version>
-  <sdf version='1.4'>tailsitter.sdf</sdf>
+  <sdf version='1.6'>tailsitter.sdf</sdf>
 
   <author>
    <name>Roman Bapst</name>

--- a/models/tailsitter/tailsitter.sdf
+++ b/models/tailsitter/tailsitter.sdf
@@ -1,4 +1,4 @@
-<sdf version='1.5'>
+<sdf version='1.6'>
   <model name='tailsitter'>
     <link name='base_link'>
       <pose>0 0 0.2 0 0 0</pose>


### PR DESCRIPTION
**Problem Description**
This fixes the issue of tailsitter not taking off on gazebo9. This is a regression caused by https://github.com/PX4/PX4-SITL_gazebo/pull/731, where nested models have been started to use for airspeed sensors and a version mismatch of the model with nested models can result in a failure

**Testing**
Tested on Gazebo 9 
```
make px4_sitl gazebo_tailsitter
```