### PR TITLE
fix the direction of the force for bi-directional thrust

### DIFF
--- a/src/gazebo_motor_model.cpp
+++ b/src/gazebo_motor_model.cpp
@@ -198,7 +198,7 @@ void GazeboMotorModel::UpdateForcesAndMoments() {
     gzerr << "Aliasing on motor [" << motor_number_ << "] might occur. Consider making smaller simulation time steps or raising the rotor_velocity_slowdown_sim_ param.\n";
   }
   double real_motor_velocity = motor_rot_vel_ * rotor_velocity_slowdown_sim_;
-  double force = real_motor_velocity * std::abs(real_motor_velocity) * motor_constant_;
+  double force = turning_direction_ * real_motor_velocity * std::abs(real_motor_velocity) * motor_constant_;
   if(!reversible_) {
     // Not allowed to have negative thrust.
     force = std::abs(force);


### PR DESCRIPTION
If ```reversible``` is set to false, the force will have a negative value.
It is a problem if ```reversible``` is set to true.
Stick-up lowers the thrust, and stick-down raises the thrust.
It is the opposite sign, so I used ```turning_direction_``` to fix it.

[Bi-directional thrust test video - youtube](https://youtube.com/shorts/A2KOobSMzBc?feature=share) 