### PR TITLE
Update mavsdk versions for firmware SITL tests

### DIFF
--- a/.github/workflows/firmware_build_test.yml
+++ b/.github/workflows/firmware_build_test.yml
@@ -30,9 +30,9 @@ jobs:
         fetch-depth: 0
         submodules: recurvise
     - name: Download MAVSDK
-      run: wget https://github.com/mavlink/MAVSDK/releases/download/v0.37.0/mavsdk_0.37.0_ubuntu20.04_amd64.deb
+      run: wget https://github.com/mavlink/MAVSDK/releases/download/v0.38.0/mavsdk_0.38.0_ubuntu20.04_amd64.deb
     - name: Install MAVSDK
-      run: dpkg -i mavsdk_0.37.0_ubuntu20.04_amd64.deb
+      run: dpkg -i mavsdk_0.38.0_ubuntu20.04_amd64.deb
     - name: Checkout matching branch on PX4/Firmware if possible
       run: |
         git checkout ${{github.head_ref}} || echo "Firmware branch: ${{github.head_ref}} not found, using master instead"

--- a/.github/workflows/firmware_build_test.yml
+++ b/.github/workflows/firmware_build_test.yml
@@ -30,9 +30,9 @@ jobs:
         fetch-depth: 0
         submodules: recurvise
     - name: Download MAVSDK
-      run: wget https://github.com/mavlink/MAVSDK/releases/download/v0.38.0/mavsdk_0.38.0_ubuntu20.04_amd64.deb
+      run: wget https://github.com/mavlink/MAVSDK/releases/download/v0.39.0/mavsdk_0.39.0_ubuntu20.04_amd64.deb
     - name: Install MAVSDK
-      run: dpkg -i mavsdk_0.38.0_ubuntu20.04_amd64.deb
+      run: dpkg -i mavsdk_0.39.0_ubuntu20.04_amd64.deb
     - name: Checkout matching branch on PX4/Firmware if possible
       run: |
         git checkout ${{github.head_ref}} || echo "Firmware branch: ${{github.head_ref}} not found, using master instead"


### PR DESCRIPTION
**Problem Description**
This commit updates the mavsdk version for firmware SITL tests. The tests were failing due to an update on the firmware side. (https://github.com/PX4/PX4-Autopilot/pull/17332)

**Additional Context**
- This has become a pattern where whenver there is a mavsdk update on the firmware side, SITL testing is broken in this repo.
This is partly because mavsdk is not part of the dev container and is installed directly in the github actions of the firmware SITL tests: https://github.com/PX4/PX4-Autopilot/blob/master/.github/workflows/sitl_tests.yml
@TSC21 Any ideas how we can do a better job for this?