### PR TITLE
mavlink_interface: use uint64_t for timestamp

### DIFF
--- a/include/mavlink_interface.h
+++ b/include/mavlink_interface.h
@@ -42,6 +42,7 @@
 #include <random>
 #include <stdio.h>
 #include <math.h>
+#include <cstdint>
 #include <cstdlib>
 #include <string>
 #include <sys/socket.h>
@@ -106,7 +107,7 @@ namespace SensorData {
     };
 
     struct Gps {
-        int time_utc_usec;
+        uint64_t time_utc_usec;
         int fix_type;
         double latitude_deg;
         double longitude_deg;
@@ -151,8 +152,8 @@ public:
     void open();
     void close();
     void Load();
-    void SendSensorMessages(const int &time_usec);
-    void SendSensorMessages(const int &time_usec, HILData &hil_data);
+    void SendSensorMessages(const uint64_t time_usec);
+    void SendSensorMessages(const uint64_t time_usec, HILData &hil_data);
     void SendGpsMessages(const SensorData::Gps &data);
     void UpdateBarometer(const SensorData::Barometer &data, const int id = 0);
     void UpdateAirspeed(const SensorData::Airspeed &data, const int id = 0);

--- a/msgs/SITLGps.proto
+++ b/msgs/SITLGps.proto
@@ -3,8 +3,8 @@ package sensor_msgs.msgs;
 
 message SITLGps
 {
-  required int64  time_usec             = 1;
-  optional int64  time_utc_usec         = 2;
+  required uint64  time_usec            = 1;
+  optional uint64  time_utc_usec        = 2;
   required double latitude_deg          = 3;
   required double longitude_deg         = 4;
   required double altitude              = 5;

--- a/src/gazebo_mavlink_interface.cpp
+++ b/src/gazebo_mavlink_interface.cpp
@@ -681,9 +681,9 @@ void GazeboMavlinkInterface::SendSensorMessages()
   }
 
 #if GAZEBO_MAJOR_VERSION >= 9
-  int time_usec = std::round(world_->SimTime().Double() * 1e6);
+  uint64_t time_usec = std::llround(world_->SimTime().Double() * 1e6);
 #else
-  int time_usec = std::round(world_->GetSimTime().Double() * 1e6);
+  uint64_t time_usec = std::llround(world_->GetSimTime().Double() * 1e6);
 #endif
 
   // send always accel and gyro data (not dependent of the bitmask)

--- a/src/mavlink_interface.cpp
+++ b/src/mavlink_interface.cpp
@@ -192,7 +192,7 @@ void MavlinkInterface::Load()
   // hil_data_.resize(1);
 }
 
-void MavlinkInterface::SendSensorMessages(const int &time_usec) {
+void MavlinkInterface::SendSensorMessages(uint64_t time_usec) {
   for (auto& data : hil_data_) {
     if (data.baro_updated | data.diff_press_updated | data.mag_updated | data.imu_updated) {
       SendSensorMessages(time_usec, data);
@@ -200,7 +200,7 @@ void MavlinkInterface::SendSensorMessages(const int &time_usec) {
   }
 }
 
-void MavlinkInterface::SendSensorMessages(const int &time_usec, HILData &hil_data) {
+void MavlinkInterface::SendSensorMessages(uint64_t time_usec, HILData &hil_data) {
   const std::lock_guard<std::mutex> lock(sensor_msg_mutex_);
 
   HILData* data = &hil_data;


### PR DESCRIPTION
This fixes the problem where the simulation fails after 2^31 us.
Microsecond timestamps always need to be 64 bits to avoid overflow within the timescale that we care about.

Addresses https://github.com/PX4/PX4-Autopilot/issues/17455.

Thanks for the hint @LorenzMeier.