### PR TITLE
Fix gstreamer camera

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,6 +213,7 @@ link_libraries(
 if (GSTREAMER_FOUND)
   link_libraries(
     ${GSTREAMER_LIBRARIES}
+    gstapp-1.0
     ${GLIB_LDFLAGS}
     gobject-2.0
   )

--- a/include/gazebo_gst_camera_plugin.h
+++ b/include/gazebo_gst_camera_plugin.h
@@ -85,11 +85,8 @@ class GAZEBO_VISIBLE GstCameraPlugin : public SensorPlugin
   private: const std::string mTopicName = "~/video_stream";
   private: bool mIsActive;
 
-  GstBuffer *frameBuffer;
-  std::mutex frameBufferMutex;
-  GMainLoop *mainLoop;
-  GstClockTime gstTimestamp;
-
+  GMainLoop *gst_loop;
+  GstElement *source;
 };
 
 } /* namespace gazebo */


### PR DESCRIPTION
This PR:

- fixes gstreamer timestamps (they were totally broken - for live sources gstreamer assumes to align timestamps with pipeline's start time, not 0. Also distance between frames are not constant - incrementing timestamp by 1/fps does not have big sense IMO)
- uses push mode all the way (previous version used push-pull bridge which is not as good as push-push)
- avoids duplicated frame encoding (pull frame callback was called at rate 300Hz+ sometimes, I don't fully understand how gstreamer worked in these conditions but pull callback had to clear (release) fremeBuffer after sending it downstream - this would made push-pull working but still not as good as push-push is)
- cleanups things a bit there and here (just some sugar to keep it more consistent, but only for places which I was touching)

Hope it is not very radical change and will be merged soon.