### PR TITLE
Lower sonar sensor distance publication rates

### DIFF
--- a/models/sonar/model.sdf
+++ b/models/sonar/model.sdf
@@ -38,7 +38,7 @@
           <robotNamespace></robotNamespace>
         </plugin>
         <always_on>1</always_on>
-        <update_rate>20</update_rate>
+        <update_rate>10</update_rate>
         <visualize>true</visualize>
       </sensor>
     </link>


### PR DESCRIPTION
**Problem Description**
This fixes the problem of estimator issues as reported in #755 by lowering the sonar publication rate
```
ERROR [ekf2] 3 - distance_sensor lost, generation 284 -> 286
ERROR [ekf2] 4 - distance_sensor lost, generation 284 -> 286
ERROR [ekf2] 5 - distance_sensor lost, generation 284 -> 286
ERROR [ekf2] 0 - distance_sensor lost, generation 336 -> 338
ERROR [ekf2] 2 - distance_sensor lost, generation 336 -> 338
ERROR [ekf2] 1 - distance_sensor lost, generation 336 -> 338
ERROR [ekf2] 4 - distance_sensor lost, generation 336 -> 338
ERROR [ekf2] 3 - distance_sensor lost, generation 336 -> 338
ERROR [ekf2] 5 - distance_sensor lost, generation 336 -> 338
```

**Testing**
This PR can be tested using
```
make px4_sitl gazebo_typhoon_h480
```

**Additional Context**
- Fixes #755 