### PR TITLE
Improvements and fixes to GPS and depth camera sensor setup and handling

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -15,8 +15,8 @@ jobs:
       fail-fast: false
       matrix:
         container:
-        - 'px4io/px4-dev-simulation-focal:2020-11-18' # Gazebo 11
-        - 'px4io/px4-dev-simulation-bionic:2020-11-18' # Gazebo 9
+        - 'px4io/px4-dev-simulation-focal:2021-05-31' # Gazebo 11
+        - 'px4io/px4-dev-simulation-bionic:2021-05-31' # Gazebo 9
     container: ${{ matrix.container }}
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/catkin_build_test.yml
+++ b/.github/workflows/catkin_build_test.yml
@@ -14,8 +14,8 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {rosdistro: 'melodic', container: 'px4io/px4-dev-ros-melodic:2020-11-18'}
-          - {rosdistro: 'noetic', container: 'px4io/px4-dev-ros-noetic:2020-11-18'}
+          - {rosdistro: 'melodic', container: 'px4io/px4-dev-ros-melodic:2021-05-31'}
+          - {rosdistro: 'noetic', container: 'px4io/px4-dev-ros-noetic:2021-05-31'}
     container: ${{ matrix.config.container }}
     steps:
     - uses: actions/checkout@v1
@@ -25,7 +25,7 @@ jobs:
     - name: submodule update
       run: git submodule update --init --recursive
     - name: release_build_test
-      working-directory: 
+      working-directory:
       run: |
         mkdir -p $HOME/catkin_ws/src;
         cd $HOME/catkin_ws

--- a/.github/workflows/firmware_build_test.yml
+++ b/.github/workflows/firmware_build_test.yml
@@ -18,7 +18,7 @@ jobs:
           - "iris"
           - "standard_vtol"
     container:
-      image: px4io/px4-dev-simulation-focal:2021-02-04
+      image: px4io/px4-dev-simulation-focal:2021-05-31
       options: --privileged --ulimit core=-1 --security-opt seccomp=unconfined
     steps:
     - name: Checkout Firmware master

--- a/.github/workflows/validate_sdf.yml
+++ b/.github/workflows/validate_sdf.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   validate-sdf:
     runs-on: ubuntu-latest
-    container: px4io/px4-dev-simulation-bionic:2020-08-14
+    container: px4io/px4-dev-simulation-bionic:2021-05-31
     steps:
     - uses: actions/checkout@v1
     - name: submodule update

--- a/models/depth_camera/depth_camera.sdf.jinja
+++ b/models/depth_camera/depth_camera.sdf.jinja
@@ -25,7 +25,7 @@
         </geometry>
       </visual>
       <sensor name="depth_camera" type="depth">
-        {% if ros_version == 2 %}
+        {%- if ros_version == '2' -%}
         <always_on>0</always_on>
         <update_rate>20</update_rate>
         <camera name="camera_name">
@@ -56,7 +56,7 @@
           <min_depth>0.1</min_depth>
           <max_depth>12</max_depth>
         </plugin>
-        {% else %}
+        {%- else -%}
         <update_rate>20</update_rate>
         <camera>
           <horizontal_fov>1.02974</horizontal_fov>
@@ -88,7 +88,7 @@
           <distortion_t1>0.0</distortion_t1>
           <distortion_t2>0.0</distortion_t2>
         </plugin>
-        {% endif %}
+        {%- endif -%}
       </sensor>
     </link>
   </model>

--- a/models/depth_camera/depth_camera.sdf.jinja
+++ b/models/depth_camera/depth_camera.sdf.jinja
@@ -27,7 +27,7 @@
       <sensor name="depth_camera" type="depth">
         {%- if ros_version == '2' -%}
         <always_on>0</always_on>
-        <update_rate>20</update_rate>
+        <update_rate>30</update_rate>
         <camera name="camera_name">
           <horizontal_fov>1.02974</horizontal_fov>
           <image>
@@ -57,7 +57,7 @@
           <max_depth>12</max_depth>
         </plugin>
         {%- else -%}
-        <update_rate>20</update_rate>
+        <update_rate>30</update_rate>
         <camera>
           <horizontal_fov>1.02974</horizontal_fov>
           <image>

--- a/models/depth_camera/depth_camera.sdf.jinja
+++ b/models/depth_camera/depth_camera.sdf.jinja
@@ -32,8 +32,8 @@
           <horizontal_fov>1.02974</horizontal_fov>
           <image>
             <format>R8G8B8</format>
-            <width>64</width>
-            <height>48</height>
+            <width>640</width>
+            <height>480</height>
           </image>
           <clip>
             <near>0.5</near>
@@ -62,8 +62,8 @@
           <horizontal_fov>1.02974</horizontal_fov>
           <image>
             <format>R8G8B8</format>
-            <width>64</width>
-            <height>48</height>
+            <width>640</width>
+            <height>480</height>
           </image>
           <clip>
             <near>0.5</near>

--- a/models/iris/iris.sdf.jinja
+++ b/models/iris/iris.sdf.jinja
@@ -418,53 +418,14 @@
       <motorSpeedPubTopic>/motor_speed/3</motorSpeedPubTopic>
       <rotorVelocitySlowdownSim>10</rotorVelocitySlowdownSim>
     </plugin>
-    <model name='gps0'>
-      <link name='link'>
-        <pose>0 0 0 0 0 0</pose>
-        <inertial>
-          <pose>0 0 0 0 0 0</pose>
-          <mass>0.01</mass>
-          <inertia>
-            <ixx>2.1733e-06</ixx>
-            <ixy>0</ixy>
-            <ixz>0</ixz>
-            <iyy>2.1733e-06</iyy>
-            <iyz>0</iyz>
-            <izz>1.8e-07</izz>
-          </inertia>
-        </inertial>
-        <visual name='visual'>
-          <geometry>
-            <cylinder>
-              <radius>0.01</radius>
-              <length>0.002</length>
-            </cylinder>
-          </geometry>
-          <material>
-            <script>
-              <name>Gazebo/Black</name>
-              <uri>__default__</uri>
-            </script>
-          </material>
-        </visual>
-        <sensor name='gps' type='gps'>
-          <pose>0 0 0 0 0 0</pose>
-          <plugin name='gps_plugin' filename='libgazebo_gps_plugin.so'>
-            <robotNamespace/>
-            <gpsNoise>1</gpsNoise>
-            <gpsXYRandomWalk>2.0</gpsXYRandomWalk>
-            <gpsZRandomWalk>4.0</gpsZRandomWalk>
-            <gpsXYNoiseDensity>0.0002</gpsXYNoiseDensity>
-            <gpsZNoiseDensity>0.0004</gpsZNoiseDensity>
-            <gpsVXYNoiseDensity>0.2</gpsVXYNoiseDensity>
-            <gpsVZNoiseDensity>0.4</gpsVZNoiseDensity>
-          </plugin>
-        </sensor>
-      </link>
-    </model>
+    <include>
+      <uri>model://gps</uri>
+      <pose>0.1 0 0 0 0 0</pose>
+      <name>gps0</name>
+    </include>
     <joint name='gps0_joint' type='fixed'>
-      <parent>base_link</parent>
       <child>gps0::link</child>
+      <parent>base_link</parent>
     </joint>
     <plugin name='groundtruth_plugin' filename='libgazebo_groundtruth_plugin.so'>
       <robotNamespace/>

--- a/models/iris/model.config
+++ b/models/iris/model.config
@@ -2,7 +2,7 @@
 <model>
   <name>3DR Iris</name>
   <version>1.0</version>
-  <sdf version='1.4'>iris.sdf</sdf>
+  <sdf version='1.6'>iris.sdf</sdf>
 
   <author>
    <name>Lorenz Meier and Thomas Gubler</name>

--- a/src/gazebo_gps_plugin.cpp
+++ b/src/gazebo_gps_plugin.cpp
@@ -59,13 +59,15 @@ void GpsPlugin::Load(sensors::SensorPtr _parent, sdf::ElementPtr _sdf)
   names_splitted.erase(std::remove_if(begin(names_splitted), end(names_splitted),
                             [](const string& name)
                             { return name.size() == 0; }), end(names_splitted));
-  const string rootModelName = names_splitted.front(); // The first element is the name of the root model
+
+  // get the root model name
+  const string rootModelName = names_splitted.front();
+
+  // store the model name
+  model_name_ = names_splitted.at(0);
 
   // the second to the last name is the model name
   const string parentSensorModelName = names_splitted.rbegin()[1];
-
-  // store the model name
-  model_name_ = names_splitted[0];
 
   // get gps topic name
   if(_sdf->HasElement("topic")) {
@@ -73,7 +75,7 @@ void GpsPlugin::Load(sensors::SensorPtr _parent, sdf::ElementPtr _sdf)
   } else {
     // if not set by parameter, get the topic name from the model name
     gps_topic_ = parentSensorModelName;
-    gzwarn << "[gazebo_gps_plugin]: " + names_splitted.front() + "::" + names_splitted.rbegin()[1] +
+    gzwarn << "[gazebo_gps_plugin]: " + rootModelName + "::" + parentSensorModelName +
       " using gps topic \"" << parentSensorModelName << "\"\n";
   }
 
@@ -216,7 +218,7 @@ void GpsPlugin::Load(sensors::SensorPtr _parent, sdf::ElementPtr _sdf)
 
   gravity_W_ = world_->Gravity();
 
-  gps_pub_ = node_handle_->Advertise<sensor_msgs::msgs::SITLGps>("~/" + model_name_ + "/link/" + gps_topic_, 10);
+  gps_pub_ = node_handle_->Advertise<sensor_msgs::msgs::SITLGps>("~/" + rootModelName + "/link/" + gps_topic_, 10);
 }
 
 void GpsPlugin::OnWorldUpdate(const common::UpdateInfo& /*_info*/)


### PR DESCRIPTION
1. `iris.sdf` was still using a nested model for the GPS instead of the include clause, resulting in the GPS link not being found when the Iris model is included in another model, like `iris_depth_camera`. This is now fixed;
2. Fixed ROS_VERSION being parsed as a string instead of a int, leading to the comparison in the `depth_camera.sdf.jinja` to never be true;
3. GPS topic was not being set correctly for nested/child models. This is now fixed;
4. Update some configs on the depth camera model.