### PR TITLE
Add plugin allowing to draw a force (e.g. liftdrag)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -311,7 +311,10 @@ set(mav_msgs
   msgs/MotorSpeed.proto
   )
 set(nav_msgs msgs/Odometry.proto)
-set(physics_msgs msgs/Wind.proto)
+set(physics_msgs
+    msgs/Force.proto
+    msgs/Wind.proto
+    )
 set(std_msgs msgs/Int32.proto)
 set(sensor_msgs
   msgs/Airspeed.proto
@@ -465,6 +468,9 @@ set(plugins
 #if("${GAZEBO_VERSION}" VERSION_LESS "7.0")
   add_library(LiftDragPlugin SHARED src/liftdrag_plugin/liftdrag_plugin.cpp)
   list(APPEND plugins LiftDragPlugin)
+
+  add_library(ForceVisual SHARED src/force_visual/force_visual.cpp)
+  list(APPEND plugins ForceVisual)
 #endif()
 
 foreach(plugin ${plugins})

--- a/include/force_visual/force_visual.h
+++ b/include/force_visual/force_visual.h
@@ -1,0 +1,45 @@
+#ifndef _GAZEBO_FORCE_VISUAL_PLUGIN_HH_
+#define _GAZEBO_FORCE_VISUAL_PLUGIN_HH_
+
+#include <gazebo/common/Plugin.hh>
+#include <gazebo/rendering/rendering.hh>
+#include <gazebo/rendering/Visual.hh>
+#include <gazebo/transport/TransportTypes.hh>
+
+#include "Force.pb.h"
+
+namespace gazebo
+{
+  typedef const boost::shared_ptr<const physics_msgs::msgs::Force> ConstForcePtr;
+
+  /// \brief A visual plugin that draws a force published on a topic
+  class GAZEBO_VISIBLE ForceVisualPlugin : public VisualPlugin
+  {
+    /// \brief Constructor.
+    public: ForceVisualPlugin();
+
+    /// \brief Destructor.
+    public: ~ForceVisualPlugin();
+
+    // Documentation Inherited.
+    public: virtual void Load(rendering::VisualPtr _visual, sdf::ElementPtr _sdf);
+
+    // Documentation Inherited.
+    public: virtual void Init();
+
+    /// \brief Pointer to visual containing plugin.
+    protected: rendering::VisualPtr visual;
+
+    /// \brief Pointer to element containing sdf.
+    protected: sdf::ElementPtr sdf;
+
+    private: void OnUpdate(ConstForcePtr& force_msg);
+    private: void UpdateVector(const ignition::math::Vector3d& center, const ignition::math::Vector3d& force);
+
+    private: transport::SubscriberPtr subs;
+    private: transport::NodePtr node;
+    private: rendering::DynamicLinesPtr forceVector;
+  };
+}
+
+#endif

--- a/include/liftdrag_plugin/liftdrag_plugin.h
+++ b/include/liftdrag_plugin/liftdrag_plugin.h
@@ -143,6 +143,9 @@ namespace gazebo
 
     private: transport::NodePtr node_handle_;
     private: transport::SubscriberPtr wind_sub_;
+    private: transport::PublisherPtr lift_force_pub_;
+    private: common::Time last_pub_time;
+    private: msgs::Factory msg_factory_;
     private: std::string namespace_;
     private: std::string wind_sub_topic_ = "world_wind";
     private: ignition::math::Vector3d wind_vel_;

--- a/models/plane/plane.sdf.jinja
+++ b/models/plane/plane.sdf.jinja
@@ -190,6 +190,10 @@
             <uri>__default__</uri>
           </script>
         </material>
+        <plugin name="left_elevon_lift_visual" filename="libForceVisual.so">
+          <topic_name>lift_force/left_elevon</topic_name>
+          <color>Gazebo/Red</color>
+        </plugin>
       </visual>
     </link>
     <link name="right_elevon">
@@ -219,6 +223,10 @@
             <uri>__default__</uri>
           </script>
         </material>
+        <plugin name="right_elevon_lift_visual" filename="libForceVisual.so">
+          <topic_name>lift_force/right_elevon</topic_name>
+          <color>Gazebo/Green</color>
+        </plugin>
       </visual>
     </link>
     <link name="left_flap">
@@ -487,6 +495,7 @@
       <forward>1 0 0</forward>
       <upward>0 0 1</upward>
       <link_name>base_link</link_name>
+      <!--<topic_name>lift_force/left_elevon</topic_name> Uncomment to draw the force -->
       <control_joint_name>
         left_elevon_joint
       </control_joint_name>
@@ -509,6 +518,7 @@
       <forward>1 0 0</forward>
       <upward>0 0 1</upward>
       <link_name>base_link</link_name>
+      <!--<topic_name>lift_force/right_elevon</topic_name> Uncomment to draw the force -->
       <control_joint_name>
         right_elevon_joint
       </control_joint_name>

--- a/msgs/Force.proto
+++ b/msgs/Force.proto
@@ -1,0 +1,10 @@
+syntax = "proto2";
+package physics_msgs.msgs;
+
+import "vector3d.proto";
+
+message Force
+{
+  required gazebo.msgs.Vector3d center = 1;
+  required gazebo.msgs.Vector3d force = 2;
+}

--- a/src/force_visual/force_visual.cpp
+++ b/src/force_visual/force_visual.cpp
@@ -1,0 +1,90 @@
+#include "force_visual/force_visual.h"
+
+using namespace gazebo;
+
+GZ_REGISTER_VISUAL_PLUGIN(ForceVisualPlugin)
+
+ForceVisualPlugin::ForceVisualPlugin() {}
+
+ForceVisualPlugin::~ForceVisualPlugin() {}
+
+void ForceVisualPlugin::Load(rendering::VisualPtr _visual,
+                             sdf::ElementPtr _sdf)
+{
+  GZ_ASSERT(_visual, "ForceVisualPlugin _visual pointer is NULL");
+  GZ_ASSERT(_sdf, "ForceVisualPlugin _sdf pointer is NULL");
+
+  this->visual = _visual;
+  this->sdf = _sdf;
+
+  gzdbg << "Loading ForceVisual plugin" << std::endl;
+}
+
+void ForceVisualPlugin::Init()
+{
+  this->node.reset(new gazebo::transport::Node());
+  this->node->Init();
+  this->subs.reset();
+
+  if (this->sdf->HasElement("topic_name")) {
+      const auto lift_force_topic = this->sdf->Get<std::string>("topic_name");
+      this->subs = this->node->Subscribe("~/" + lift_force_topic, &ForceVisualPlugin::OnUpdate, this);
+      gzdbg << "Subscribing on ~/" << lift_force_topic << std::endl;
+  }
+
+  auto forceVector = this->visual->CreateDynamicLine(rendering::RENDERING_LINE_LIST);
+  this->forceVector.reset(forceVector);
+  this->forceVector->setVisibilityFlags(GZ_VISIBILITY_GUI);
+
+  if (this->sdf->HasElement("color")) {
+      this->forceVector->setMaterial(this->sdf->Get<std::string>("color"));
+  } else {
+      this->forceVector->setMaterial("Gazebo/Blue");
+  }
+
+  if (this->sdf->HasElement("material")) {
+    this->forceVector->setMaterial(this->sdf->Get<std::string>("material"));
+  }
+
+  for(int k = 0; k < 6; ++k) { // -> needs three lines, so 6 points
+    this->forceVector->AddPoint(ignition::math::Vector3d::Zero);
+  }
+
+  this->forceVector->Update();
+}
+
+void ForceVisualPlugin::OnUpdate(ConstForcePtr& force_msg)
+{
+  ignition::math::Vector3d force;
+  auto force_vector_msg = force_msg->force();
+  force.Set(force_vector_msg.x(), force_vector_msg.y(), force_vector_msg.z());
+
+  ignition::math::Vector3d center;
+  auto force_center_msg = force_msg->center();
+  center.Set(force_center_msg.x(), force_center_msg.y(), force_center_msg.z());
+
+  // Note that if the visual is scaled, the center needs to be scaled, too,
+  // such that the force appears on the visual surface control and not on
+  // the actual joint (which will look weird).
+  // I am not sure what happens if both the visual and the joint are scaled,
+  // but I don't see a reason for doing that, like, ever.
+  const auto scale = this->visual->Scale();
+  center = center / scale;
+
+  this->UpdateVector(center, force);
+}
+
+void ForceVisualPlugin::UpdateVector(const ignition::math::Vector3d& center, const ignition::math::Vector3d& force)
+{
+  const float arrow_scale = 0.1;
+
+  ignition::math::Vector3d begin = center;
+  ignition::math::Vector3d end = center + force;
+
+  this->forceVector->SetPoint(0, begin);
+  this->forceVector->SetPoint(1, end);
+  this->forceVector->SetPoint(2, end);
+  this->forceVector->SetPoint(3, end - arrow_scale * ignition::math::Matrix3d(1, 0, 0, 0, 0.9848, -0.1736, 0,  0.1736, 0.9848) * (end - begin));
+  this->forceVector->SetPoint(4, end);
+  this->forceVector->SetPoint(5, end - arrow_scale * ignition::math::Matrix3d(1, 0, 0, 0, 0.9848,  0.1736, 0, -0.1736, 0.9848) * (end - begin));
+}


### PR DESCRIPTION
This adds a visual plugin able to draw a force (in my case I was interested in printing the forces computed by the liftdrag plugin). Not sure if that's worth going upstream, but I wanted to share it in case somebody is interested (@Jaeyoung-Lim).

It requires the force to be published to a topic defined as `<topic_name>` in the sdf file. In the plane example, it appears in two places:

1. In the `<visual>` tag of the link, where it calls the visual plugin (and therefore tells the visual plugin on which topic it should listen for that force)
2. In the call for the LiftDragPlugin, where it tells it to which topic it should publish the force.

I modified the plane.sdf.jinja file in a way that has no impact: the force will not be published because the relevant lines are commented out:

```
<!--<topic_name>lift_force/left_elevon</topic_name> Uncomment to draw the force -->
...
<!--<topic_name>lift_force/right_elevon</topic_name> Uncomment to draw the force -->
```

When those lines are uncommented, the visual plugin will print the forces, as shown on the image below. Also I only print those two forces, but it works for others (e.g. rudder); all it takes is a topic publishing a force.

For some reason, the publishing/subscribing at this rate tends to slow down the simulation a lot on my laptop, which is why it is commented out.

![2021-06-18-011716_483x298_scrot](https://user-images.githubusercontent.com/2606672/122483520-127a8300-cfd3-11eb-8ca4-e2ee7df920ec.png)

You may have noticed that the origin of the arrows is below the wings of the plane, but I think that the rendering is correct: it is where the force is applied, even though the wings are rendered above. I have not been validating the output of this plugin other than by running it and checking visually if the arrows seem reasonable :see_no_evil:.

![2021-06-18-012654_329x270_scrot](https://user-images.githubusercontent.com/2606672/122484145-57eb8000-cfd4-11eb-8a1a-7ab101acbfcc.png)
