### PR TITLE
Add iris model for control allocation development

### DIFF
--- a/models/iris_ctrlalloc/iris_ctrlalloc.sdf
+++ b/models/iris_ctrlalloc/iris_ctrlalloc.sdf
@@ -1,0 +1,8 @@
+<?xml version="1.0" ?>
+<sdf version="1.6">
+  <model name='iris_ctrlalloc'>
+    <include>
+      <uri>model://iris</uri>
+    </include>
+  </model>
+</sdf>

--- a/models/iris_ctrlalloc/model.config
+++ b/models/iris_ctrlalloc/model.config
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<model>
+  <name>Iris Control Allocation Model</name>
+  <version>1.0</version>
+  <sdf version='1.6'>iris_ctrlalloc.sdf</sdf>
+
+  <author>
+   <name>Jaeyoung Lim</name>
+   <email>jalim@ethz.ch</email>
+  </author>
+
+  <description>
+    This is a model for control allocation, that maps to the default iris model
+  </description>
+</model>


### PR DESCRIPTION
**Problem Description**
While control allocation has been merged into master, the `iris_ctrlalloc` model could not be tested in simulation, due to the lack of the model in this repo.

**Proposed Solution**
This PR adds a `iris_ctrlalloc` model which maps to the default `iris` model so that the developer is able to use `iris_ctrlalloc` 