### PR TITLE
Add control allocation model for the typhoon h480

### DIFF
--- a/models/typhoon_h480_ctrlalloc/model.config
+++ b/models/typhoon_h480_ctrlalloc/model.config
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<model>
+  <name>Typhoon H480 Control Allocation Model</name>
+  <version>1.0</version>
+  <sdf version='1.6'>typhoon_h480_ctrlalloc.sdf</sdf>
+
+  <author>
+   <name>Jaeyoung Lim</name>
+   <email>jalim@ethz.ch</email>
+  </author>
+
+  <description>
+    This is a model for control allocation, that maps to the default typhoon h480 model
+  </description>
+</model>

--- a/models/typhoon_h480_ctrlalloc/typhoon_h480_ctrlalloc.sdf
+++ b/models/typhoon_h480_ctrlalloc/typhoon_h480_ctrlalloc.sdf
@@ -1,0 +1,8 @@
+<?xml version="1.0" ?>
+<sdf version="1.6">
+  <model name='typhoon_h480'>
+    <include>
+      <uri>model://typhoon_h480</uri>
+    </include>
+  </model>
+</sdf>


### PR DESCRIPTION
**Problem Description**
I noticed after https://github.com/PX4/PX4-SITL_gazebo/pull/781 that there was another dangling airframe config in the firmware: https://github.com/PX4/PX4-Autopilot/blob/master/ROMFS/px4fmu_common/init.d-posix/airframes/6012_typhoon_ctrlalloc


**Proposed Solution**
This PR adds the control allocation model of the typhoon h480 for this repository