### PR TITLE
Reduce yaw authority on plane

### DIFF
--- a/models/plane/plane.sdf.jinja
+++ b/models/plane/plane.sdf.jinja
@@ -610,7 +610,7 @@
       <control_joint_name> 
          rudder_joint 
       </control_joint_name> 
-      <control_joint_rad_to_cl>4.0</control_joint_rad_to_cl>
+      <control_joint_rad_to_cl>0.8</control_joint_rad_to_cl>
       <robotNamespace></robotNamespace>
       <windSubTopic>world_wind</windSubTopic>
     </plugin>

--- a/models/techpod/techpod.sdf
+++ b/models/techpod/techpod.sdf
@@ -601,7 +601,7 @@
       <control_joint_name>
          rudder_joint
       </control_joint_name>
-      <control_joint_rad_to_cl>4.0</control_joint_rad_to_cl>
+      <control_joint_rad_to_cl>0.8</control_joint_rad_to_cl>
       <robotNamespace></robotNamespace>
       <windSubTopic>world_wind</windSubTopic>
     </plugin>


### PR DESCRIPTION
**Problem Description**
The vehicle will go into a spin if there is a yaw command in stabilized mode. I believe this was due to the vehicle having a too large yaw authority on the control surfaces

**Proposed Solution**
This PR reduces the yaw authority of the vehicle. 