### PR TITLE
Airsim Gazebo plugin for linking camera pose to Airsim

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,8 @@ project(mavlink_sitl_gazebo VERSION 1.0.0)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 
+set(AIRSIM_ROOT "/home/jaeyoung/dev/AirSim")
+
 # Set c++11 or higher
 include(EnableC++XX)
 # Set c11
@@ -98,7 +100,7 @@ else()
   include_directories(SYSTEM ${GAZEBO_INCLUDE_DIRS} ${Qt5Core_INCLUDE_DIRS})
 endif()
 
-link_directories(${GAZEBO_LIBRARY_DIRS})
+link_directories(${GAZEBO_LIBRARY_DIRS} ${AIRSIM_ROOT}/AirLib/lib/x64/Release)
 
 add_subdirectory( external/OpticalFlow OpticalFlow )
 set( OpticalFlow_LIBS "OpticalFlow" )
@@ -194,6 +196,10 @@ include_directories(
   ${OpenCV_INCLUDE_DIRS}
   ${OpticalFlow_INCLUDE_DIRS}
   ${TinyXML_INCLUDE_DIRS}
+  ${AIRSIM_ROOT}/AirLib/deps/eigen3
+  ${AIRSIM_ROOT}/AirLib/deps/rpclib/include
+  ${AIRSIM_ROOT}/AirLib/include
+  ${AIRSIM_ROOT}/AirLib/deps/MavLinkCom/include
   )
 
 if (GSTREAMER_FOUND)
@@ -373,8 +379,10 @@ add_library(gazebo_usv_dynamics_plugin SHARED src/gazebo_usv_dynamics_plugin.cpp
 add_library(gazebo_parachute_plugin SHARED src/gazebo_parachute_plugin.cpp)
 add_library(gazebo_airship_dynamics_plugin SHARED src/gazebo_airship_dynamics_plugin.cpp)
 add_library(gazebo_drop_plugin SHARED src/gazebo_drop_plugin.cpp)
+add_library(gazebo_airsim_plugin SHARED src/gazebo_airsim_plugin.cpp)
 
 set(plugins
+  gazebo_airsim_plugin
   gazebo_airspeed_plugin
   gazebo_camera_manager_plugin
   gazebo_gps_plugin
@@ -406,6 +414,8 @@ foreach(plugin ${plugins})
   target_link_libraries(${plugin} ${Boost_LIBRARIES} ${GAZEBO_LIBRARIES} ${TinyXML_LIBRARIES})
 endforeach()
 target_link_libraries(gazebo_opticalflow_plugin ${OpticalFlow_LIBS})
+
+target_link_libraries(gazebo_airsim_plugin AirLib rpc MavLinkCom)
 
 # If BUILD_ROS_PLUGINS set to ON, build plugins that have ROS dependencies
 # Current plugins that can be used with ROS interface: gazebo_motor_failure_plugin

--- a/include/gazebo_airsim_plugin.h
+++ b/include/gazebo_airsim_plugin.h
@@ -1,0 +1,98 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2021 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+/**
+ * @brief Airsim Plugin
+ *
+ * This plugin interacts with Microsoft Airsim to set the camera pose to the link pose in gazebo
+ *
+ * @author Jaeyoung Lim <jaeyoung@ethz.ch>
+ */
+
+
+#ifndef _GAZEBO_AIRSIM_PLUGIN_HH_
+#define _GAZEBO_AIRSIM_PLUGIN_HH_
+
+
+#include "common/common_utils/StrictMode.hpp"
+STRICT_MODE_OFF
+#ifndef RPCLIB_MSGPACK
+#define RPCLIB_MSGPACK clmdep_msgpack
+#endif  // !RPCLIB_MSGPACK
+#include "rpc/rpc_error.h"
+STRICT_MODE_ON
+
+#include <math.h>
+#include <common.h>
+#include <sdf/sdf.hh>
+
+#include <gazebo/common/common.hh>
+#include <gazebo/common/Plugin.hh>
+#include <gazebo/gazebo.hh>
+#include <gazebo/util/system.hh>
+#include <gazebo/transport/transport.hh>
+#include <gazebo/msgs/msgs.hh>
+#include <gazebo/physics/physics.hh>
+#include <ignition/math.hh>
+
+#include "vehicles/multirotor/api/MultirotorRpcLibClient.hpp"
+#include "common/common_utils/FileSystem.hpp"
+
+namespace gazebo
+{
+
+class GAZEBO_VISIBLE AirsimPlugin : public ModelPlugin
+{
+public:
+  AirsimPlugin();
+  virtual ~AirsimPlugin();
+
+protected:
+  virtual void Load(physics::ModelPtr model, sdf::ElementPtr sdf);
+  virtual void OnUpdate(const common::UpdateInfo&);
+
+private:
+
+  std::string namespace_;
+  physics::ModelPtr model_;
+  physics::WorldPtr world_;
+  physics::LinkPtr link_;
+
+  event::ConnectionPtr _updateConnection;
+  
+  transport::NodePtr node_handle_;
+
+  std::shared_ptr<msr::airlib::RpcLibClientBase> client_;
+
+};     // class GAZEBO_VISIBLE AirsimPlugin
+}      // namespace gazebo
+#endif // _GAZEBO_AIRSIM_PLUGIN_HH_

--- a/models/plane_cam_airsim/model.config
+++ b/models/plane_cam_airsim/model.config
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<model>
+  <name>plane_cam_airsim</name>
+  <version>1.0</version>
+  <sdf version='1.5'>plane_cam_airsim.sdf</sdf>
+  <description>
+    This is a model of a standard plane with an airsim camera
+  </description>  
+</model>

--- a/models/plane_cam_airsim/plane_cam_airsim.sdf
+++ b/models/plane_cam_airsim/plane_cam_airsim.sdf
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<sdf version='1.5'>
+  <model name='plane_cam_airsim'>
+    <include>
+      <uri>model://plane</uri>
+    </include>
+    <!--geotagged images camera-->
+    <include>
+      <uri>model://geotagged_cam</uri>
+      <pose>0 0 0 0 -1.571 0</pose>
+    </include>
+    <joint name="geotagged_cam_joint" type="fixed">
+      <parent>plane::base_link</parent>
+      <child>geotagged_cam::camera_link</child>
+    </joint>
+    <plugin name='airsim_plugin' filename='libgazebo_airsim_plugin.so'>
+      <robotNamespace/>
+      <link_name>geotagged_cam::camera_link</link_name>
+    </plugin>
+  </model>
+</sdf>

--- a/models/typhoon_h480_airsim/model.config
+++ b/models/typhoon_h480_airsim/model.config
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<model>
+  <name>Typhoon H480 Airsim</name>
+  <version>1.0</version>
+  <sdf version="1.5">typhoon_h480_airsim.sdf</sdf>
+
+  <author>
+   <name>Jaeyoung Lim</name>
+   <email>jalim@ethz.ch/email>
+  </author>
+
+  <description>
+    This is a model of the Yuneec Typhoon H480 with camera interfacing with Airsim
+  </description>
+</model>

--- a/models/typhoon_h480_airsim/typhoon_h480_airsim.sdf
+++ b/models/typhoon_h480_airsim/typhoon_h480_airsim.sdf
@@ -1,0 +1,11 @@
+<sdf version='1.6'>
+  <model name='typhoon_h480_airsim'>
+    <include>
+      <uri>model://typhoon_h480</uri>
+    </include>
+    <plugin name='airsim_plugin' filename='libgazebo_airsim_plugin.so'>
+      <robotNamespace/>
+      <link_name>typhoon_h480::cgo3_camera_link</link_name>
+    </plugin>
+  </model>
+</sdf>

--- a/src/gazebo_airsim_plugin.cpp
+++ b/src/gazebo_airsim_plugin.cpp
@@ -1,0 +1,111 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2021 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+/**
+ * @brief Airsim Plugin
+ *
+ * This plugin interacts with Microsoft Airsim to set the camera pose to the link pose in gazebo
+ *
+ * @author Jaeyoung Lim <jaeyoung@ethz.ch>
+ */
+
+#include "gazebo_airsim_plugin.h"
+
+namespace gazebo {
+GZ_REGISTER_MODEL_PLUGIN(AirsimPlugin)
+
+AirsimPlugin::AirsimPlugin() : ModelPlugin()
+{
+  client_ = std::make_shared<msr::airlib::RpcLibClientBase>();
+}
+
+AirsimPlugin::~AirsimPlugin()
+{
+  _updateConnection->~Connection();
+}
+
+void AirsimPlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf)
+{
+  model_ = _model;
+  world_ = model_->GetWorld();
+
+  namespace_.clear();
+  if (_sdf->HasElement("robotNamespace")) {
+    namespace_ = _sdf->GetElement("robotNamespace")->Get<std::string>();
+  } else {
+    gzerr << "[gazebo_catapult_plugin] Please specify a robotNamespace.\n";
+  }
+
+  if (_sdf->HasElement("link_name")) {
+    sdf::ElementPtr elem = _sdf->GetElement("link_name");
+    std::string linkName = elem->Get<std::string>();
+    this->link_ = this->model_->GetLink(linkName);
+
+    if (!this->link_) {
+      gzerr << "[gazebo_airsim_plugin] Link with name[" << linkName << "] not found. "
+        << "Airsim plugin will not be able to launch the vehicle\n";
+    }
+  } else {
+    gzerr << "[gazebo_airsim_plugin] linkName needs to be defined in the model SDF";
+  }
+
+  _updateConnection = event::Events::ConnectWorldUpdateBegin(boost::bind(&AirsimPlugin::OnUpdate, this, _1));
+
+  node_handle_ = transport::NodePtr(new transport::Node());
+  node_handle_->Init(namespace_);
+
+  client_->confirmConnection();
+
+}
+
+void AirsimPlugin::OnUpdate(const common::UpdateInfo&){
+  if (link_ == NULL)
+    gzthrow("[gazebo_airsim_plugin] Couldn't find specified link \n");
+
+  ///TODO: Get Camera pose from gazebo
+  Eigen::Vector3d pos_ned ;
+  Eigen::Vector4d att_ned;
+#if GAZEBO_MAJOR_VERSION >= 9
+  ignition::math::Pose3d T_W_I = link_->WorldPose();
+#else
+  ignition::math::Pose3d T_W_I = ignitionFromGazeboMath(link_->GetWorldPose());
+#endif
+  ignition::math::Vector3d pos = T_W_I.Pos();
+  ignition::math::Quaterniond att = T_W_I.Rot();
+
+  msr::airlib::Vector3r p(pos.X(), -pos.Y(), -pos.Z()); // Convert to NED since airsim position is in NED
+  msr::airlib::Quaternionr o(att.W(), att.X(), -att.Y(), -att.Z()); // Convert to NED since airsim position is in NED
+
+  client_->simSetVehiclePose(msr::airlib::Pose(p, o), true);
+}
+
+} // namespace gazebo


### PR DESCRIPTION
**Problem Description**
While the Gazebo environment is the most widely used environments for PX4 SITL simulation, the rendering quality of gazebo makes it hard to test vision based applications.

While [Microsoft/Airsim](https://github.com/microsoft/AirSim) solves this problem by using advanced game engines such as the Unreal Engine or Unity the physics Airsim can simulate are limited.
- Only multirotors are available, and none of the vehicles have gimbals
- Aerodynamic effects such as Fixedwing/VTOL vehicles are not available for PX4 SITL-Airsim

**Proposed Solution**
We can use the rendering capabilities through airlib-unreal to render physical properties, while still using the physics modeled in Gazebo. 

Therefore, a `gazebo_airsim_plugin` is implemented. The plugin can be attached to a specific link that orients the camera in Airsim. The specific link can be defined in the sdf flile as the following.
```
    <plugin name='airsim_plugin' filename='libgazebo_airsim_plugin.so'>
      <robotNamespace/>
      <link_name>typhoon_h480::cgo3_camera_link</link_name>
    </plugin>
```
This plugin assumes that Airsim is running in "Computer Vision Mode". The configuration file of Airsim is as the following.
```
{
  "SeeDocsAt": "https://github.com/Microsoft/AirSim/blob/master/docs/settings.md",
  "SettingsVersion": 1.2,
  "SimMode": "ComputerVision"
}
```

A special model of a `typhoon_h480` is created to run the plugin. The plugin orients the camera in airsim to the same pose of the camera attached to the gimbal. 

**Alternative Solution**
One alternative solution is to add this plugin inside airsim, and keep the `typhoon_h480_airsim` model in this repository. One step required for this would be to add `GAZEBO_PLUGIN_PATH` to where the `gazebo_airsim_plugin` is built inside airsim.

**Testing**
```
make px4_sitl gazebo_typhoon_h480_airsim
```
[![GazeboAirsim](https://img.youtube.com/vi/dwvVRZZmTX0/0.jpg)](https://youtu.be/dwvVRZZmTX0 "Circular trajectory tracking")

[![GazeboAirsim](https://img.youtube.com/vi/eoL4pxmz0Bc/0.jpg)](https://youtu.be/eoL4pxmz0Bc "Circular trajectory tracking")

**Additional Context**
- The CMakeLists.txt is not finalized. While I find the plugin useful, I am not sure if the plugin should live in this repository, or in [Microsoft/Airsim](https://github.com/microsoft/AirSim). It would be great if we can discuss this in the PR, and I will cleanup the CMakeLists.txt accordingly. @jonyMarino @nikitabeebe FYI
- Video and Image capture are not implemented in this plugin yet
- This complements the `GazeboDrone` example in airsim: https://github.com/microsoft/AirSim/tree/master/GazeboDrone