### PR TITLE
Enable HITL over UDP

### DIFF
--- a/include/mavlink_interface.h
+++ b/include/mavlink_interface.h
@@ -162,21 +162,21 @@ public:
     Eigen::VectorXd GetActuatorControls();
     bool GetArmedState();
     void onSigInt();
-    inline bool GetReceivedFirstActuator() {return received_first_actuator_;}
-    inline void SetBaudrate(int baudrate) {baudrate_ = baudrate;}
-    inline void SetSerialEnabled(bool serial_enabled) {serial_enabled_ = serial_enabled;}
-    inline void SetUseTcp(bool use_tcp) {use_tcp_ = use_tcp;}
-    inline void SetDevice(std::string device) {device_ = device;}
-    inline void SetEnableLockstep(bool enable_lockstep) {enable_lockstep_ = enable_lockstep;}
-    inline void SetMavlinkAddr(std::string mavlink_addr) {mavlink_addr_str_ = mavlink_addr;}
-    inline void SetMavlinkTcpPort(int mavlink_tcp_port) {mavlink_tcp_port_ = mavlink_tcp_port;}
-    inline void SetMavlinkUdpPort(int mavlink_udp_port) {mavlink_udp_port_ = mavlink_udp_port;}
-    inline void SetQgcAddr(std::string qgc_addr) {qgc_addr_ = qgc_addr;}
-    inline void SetQgcUdpPort(int qgc_udp_port) {qgc_udp_port_ = qgc_udp_port;}
-    inline void SetSdkAddr(std::string sdk_addr) {sdk_addr_ = sdk_addr;}
-    inline void SetSdkUdpPort(int sdk_udp_port) {sdk_udp_port_ = sdk_udp_port;}
-    inline void SetHILMode(bool hil_mode) {hil_mode_ = hil_mode;}
-    inline void SetHILStateLevel(bool hil_state_level) {hil_state_level_ = hil_state_level;}
+    bool GetReceivedFirstActuator() {return received_first_actuator_;}
+    void SetBaudrate(int baudrate) {baudrate_ = baudrate;}
+    void SetSerialEnabled(bool serial_enabled) {serial_enabled_ = serial_enabled;}
+    void SetUseTcp(bool use_tcp) {use_tcp_ = use_tcp;}
+    void SetDevice(std::string device) {device_ = device;}
+    void SetEnableLockstep(bool enable_lockstep) {enable_lockstep_ = enable_lockstep;}
+    void SetMavlinkAddr(std::string mavlink_addr) {mavlink_addr_str_ = mavlink_addr;}
+    void SetMavlinkTcpPort(int mavlink_tcp_port) {mavlink_tcp_port_ = mavlink_tcp_port;}
+    void SetMavlinkUdpPort(int mavlink_udp_port) {mavlink_udp_port_ = mavlink_udp_port;}
+    void SetQgcAddr(std::string qgc_addr) {qgc_addr_ = qgc_addr;}
+    void SetQgcUdpPort(int qgc_udp_port) {qgc_udp_port_ = qgc_udp_port;}
+    void SetSdkAddr(std::string sdk_addr) {sdk_addr_ = sdk_addr;}
+    void SetSdkUdpPort(int sdk_udp_port) {sdk_udp_port_ = sdk_udp_port;}
+    void SetHILMode(bool hil_mode) {hil_mode_ = hil_mode;}
+    void SetHILStateLevel(bool hil_state_level) {hil_state_level_ = hil_state_level;}
 
 private:
     bool received_actuator_{false};

--- a/include/mavlink_interface.h
+++ b/include/mavlink_interface.h
@@ -187,6 +187,7 @@ private:
     Eigen::VectorXd input_reference_;
 
     void handle_message(mavlink_message_t *msg);
+    void handle_actuator_controls(mavlink_message_t *msg);
     void acceptConnections();
     void RegisterNewHILSensorInstance(int id);
 

--- a/include/mavlink_interface.h
+++ b/include/mavlink_interface.h
@@ -178,6 +178,8 @@ public:
     void SetHILMode(bool hil_mode) {hil_mode_ = hil_mode;}
     void SetHILStateLevel(bool hil_state_level) {hil_state_level_ = hil_state_level;}
 
+    bool SerialEnabled() const { return serial_enabled_; }
+
 private:
     bool received_actuator_{false};
     bool received_first_actuator_{false};

--- a/src/gazebo_mavlink_interface.cpp
+++ b/src/gazebo_mavlink_interface.cpp
@@ -580,6 +580,9 @@ void GazeboMavlinkInterface::OnUpdate(const common::UpdateInfo&  /*_info*/) {
 
   if (hil_mode_) {
     mavlink_interface_->pollFromQgcAndSdk();
+    if (!mavlink_interface_->SerialEnabled()) {
+      mavlink_interface_->pollForMAVLinkMessages();
+    }
   } else {
     mavlink_interface_->pollForMAVLinkMessages();
   }

--- a/src/gazebo_mavlink_interface.cpp
+++ b/src/gazebo_mavlink_interface.cpp
@@ -330,20 +330,19 @@ void GazeboMavlinkInterface::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf
     mavlink_interface_->SetHILStateLevel(hil_state_level_);
   }
 
-  bool serial_enabled=false;
   if(_sdf->HasElement("serialEnabled"))
   {
-    serial_enabled = _sdf->GetElement("serialEnabled")->Get<bool>();
+    const bool serial_enabled = _sdf->GetElement("serialEnabled")->Get<bool>();
     mavlink_interface_->SetSerialEnabled(serial_enabled);
   }
 
   bool use_tcp = false;
-  if (!serial_enabled && _sdf->HasElement("use_tcp"))
+  if (!mavlink_interface_->SerialEnabled() && _sdf->HasElement("use_tcp"))
   {
     use_tcp = _sdf->GetElement("use_tcp")->Get<bool>();
     mavlink_interface_->SetUseTcp(use_tcp);
   }
-  gzmsg << "Connecting to PX4 SITL using " << (serial_enabled ? "serial" : (use_tcp ? "TCP" : "UDP")) << "\n";
+  gzmsg << "Connecting to PX4 SITL using " << (mavlink_interface_->SerialEnabled() ? "serial" : (use_tcp ? "TCP" : "UDP")) << "\n";
 
   if (!hil_mode_ && _sdf->HasElement("enable_lockstep"))
   {
@@ -510,7 +509,7 @@ void GazeboMavlinkInterface::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf
     mavlink_interface_->SetSdkUdpPort(sdk_udp_port);
   }
 
-  if (serial_enabled) {
+  if (mavlink_interface_->SerialEnabled()) {
     // Set up serial interface
     if(_sdf->HasElement("serialDevice"))
     {

--- a/src/mavlink_interface.cpp
+++ b/src/mavlink_interface.cpp
@@ -161,11 +161,20 @@ void MavlinkInterface::Load()
       fds_[LISTEN_FD].events = POLLIN; // only listens for new connections on tcp
 
     } else {
-      remote_simulator_addr_.sin_addr.s_addr = mavlink_addr_;
-      remote_simulator_addr_.sin_port = htons(mavlink_udp_port_);
-
-      local_simulator_addr_.sin_addr.s_addr = htonl(INADDR_ANY);
-      local_simulator_addr_.sin_port = htons(0);
+      if (!hil_mode_) {
+        // When connecting to SITL, we specify the port where the mavlink traffic originates from.
+        remote_simulator_addr_.sin_addr.s_addr = mavlink_addr_;
+        remote_simulator_addr_.sin_port = htons(mavlink_udp_port_);
+        local_simulator_addr_.sin_addr.s_addr = htonl(INADDR_ANY);
+        local_simulator_addr_.sin_port = htons(0);
+      } else {
+        // When connecting to HITL via UDP, the vehicle talks to a specific port that we need to
+        // listen to.
+        remote_simulator_addr_.sin_addr.s_addr = htonl(INADDR_ANY);
+        remote_simulator_addr_.sin_port = htons(0);
+        local_simulator_addr_.sin_addr.s_addr = mavlink_addr_;
+        local_simulator_addr_.sin_port = htons(mavlink_udp_port_);
+      }
 
       if ((simulator_socket_fd_ = socket(AF_INET, SOCK_DGRAM, 0)) < 0) {
         std::cerr << "Creating UDP socket failed: " << strerror(errno) << ", aborting\n";
@@ -352,7 +361,8 @@ void MavlinkInterface::pollForMAVLinkMessages()
   received_actuator_ = false;
 
   do {
-    int timeout_ms = (received_first_actuator_ && enable_lockstep_) ? 1000 : 0;
+    const bool needs_to_wait_for_actuator = received_first_actuator_ && enable_lockstep_;
+    int timeout_ms = needs_to_wait_for_actuator ? 1000 : 0;
     int ret = ::poll(&fds_[0], N_FDS, timeout_ms);
 
     if (ret < 0) {
@@ -360,8 +370,10 @@ void MavlinkInterface::pollForMAVLinkMessages()
       return;
     }
 
-    if (ret == 0 && timeout_ms > 0) {
-      std::cerr << "poll timeout\n";
+    if (ret == 0) {
+      if (needs_to_wait_for_actuator) {
+        std::cerr << "poll timeout\n";
+      }
       return;
     }
 
@@ -399,7 +411,7 @@ void MavlinkInterface::pollForMAVLinkMessages()
         mavlink_status_t status;
         for (unsigned i = 0; i < len; ++i) {
           if (mavlink_parse_char(MAVLINK_COMM_0, buf_[i], &msg, &status)) {
-            if (hil_mode_) {
+            if (hil_mode_ && serial_enabled_) {
               send_mavlink_message(&msg);
             }
             handle_message(&msg);
@@ -407,7 +419,7 @@ void MavlinkInterface::pollForMAVLinkMessages()
         }
       }
     }
-  } while (!close_conn_ && received_first_actuator_ && !received_actuator_ && enable_lockstep_ && !gotSigInt_);
+  } while (!close_conn_ && !gotSigInt_ && !received_actuator_);
 }
 
 void MavlinkInterface::pollFromQgcAndSdk()
@@ -576,11 +588,13 @@ void MavlinkInterface::send_mavlink_message(const mavlink_message_t *message)
         len = sendto(fds_[CONNECTION_FD].fd, buffer, packetlen, 0, (struct sockaddr *)&remote_simulator_addr_, remote_simulator_addr_len_);
       }
       if (len < 0) {
-        std::cerr << "Failed sending mavlink message: " << strerror(errno) << "\n";
-        if (errno == ECONNRESET || errno == EPIPE) {
-          if (use_tcp_) { // udp socket remains alive
-            std::cerr << "Closing connection." << "\n";
-            close_conn_ = true;
+        if (received_first_actuator_) {
+          std::cerr << "Failed sending mavlink message: " << strerror(errno) << "\n";
+          if (errno == ECONNRESET || errno == EPIPE) {
+            if (use_tcp_) { // udp socket remains alive
+              std::cerr << "Closing connection." << "\n";
+              close_conn_ = true;
+            }
           }
         }
       }


### PR DESCRIPTION
This includes small cleanups and some changes to enable HITL connected over UDP.

To use it, these two settings in the sdf file need to be set:
```
<mavlink_udp_port>14560</mavlink_udp_port>
<serialEnabled>1</serialEnabled>
```

Please review commit by commit.