### PR TITLE
Fix gazebo plugin for laser sensor

### DIFF
--- a/models/rplidar/model.sdf
+++ b/models/rplidar/model.sdf
@@ -24,7 +24,7 @@
         </geometry>
       </visual>
 
-      <sensor name="laser" type="gpu_ray">
+      <sensor name="laser" type="ray">
         <ray>
           <scan>
             <horizontal>
@@ -45,13 +45,13 @@
             <stddev>0.01</stddev>
           </noise>
         </ray>
-        <plugin name="laser" filename="libGpuRayPlugin.so" />
-        <plugin name="gazebo_ros_head_rplidar_controller" filename="libgazebo_ros_gpu_laser.so">
+        <plugin name="laser" filename="libRayPlugin.so" />
+        <plugin name="gazebo_ros_head_rplidar_controller" filename="libgazebo_ros_laser.so">
           <topicName>laser/scan</topicName>
           <frameName>rplidar_link</frameName>
         </plugin>
         <always_on>1</always_on>
-        <update_rate>5.5</update_rate>
+        <update_rate>10</update_rate>
         <visualize>true</visualize>
       </sensor>
     </link>


### PR DESCRIPTION
The GPU plugin didn't work out of the box and lacks basic documentation, the normal plugin works fine. also increased the update rate a bit to 10 hz to match modern lidars