### PR TITLE
Modified the rolling moment formula of rotor. 

### DIFF
--- a/src/gazebo_motor_model.cpp
+++ b/src/gazebo_motor_model.cpp
@@ -247,7 +247,7 @@ void GazeboMotorModel::UpdateForcesAndMoments() {
 
   ignition::math::Vector3d rolling_moment;
   // - \omega * \mu_1 * V_A^{\perp}
-  rolling_moment = -std::abs(real_motor_velocity) * rolling_moment_coefficient_ * velocity_perpendicular_to_rotor_axis;
+  rolling_moment = -std::abs(real_motor_velocity) * turning_direction_ * rolling_moment_coefficient_ * velocity_perpendicular_to_rotor_axis;
   parent_links.at(0)->AddTorque(rolling_moment);
   // Apply the filter on the motor's velocity.
   double ref_motor_rot_vel;


### PR DESCRIPTION
The previous formula did not consider the direction of rotation, which is unreasonable.
https://github.com/PX4/PX4-SITL_gazebo/blob/d8366bf2389eae6106d1dbfaac72ebfdf23a5d2d/src/gazebo_motor_model.cpp#L250
![image](https://user-images.githubusercontent.com/30321432/134860828-b88bedf8-1569-4f22-93ba-7de99cfd3827.png)
