### PR TITLE
Fix mavlink regression regarding STORAGE_USAGE_FLAG added

### DIFF
--- a/src/gazebo_camera_manager_plugin.cpp
+++ b/src/gazebo_camera_manager_plugin.cpp
@@ -774,7 +774,8 @@ void CameraManagerPlugin::_handle_storage_info(const mavlink_message_t *pMsg, st
         NAN,                                // read_speed,
         NAN,                                // write_speed
         STORAGE_TYPE_OTHER,                 // storage type
-        storage_name.c_str()                // storage name
+        storage_name.c_str(),               // storage name
+        STORAGE_USAGE_FLAG_SET              // storage usage
     );
     _send_mavlink_message(&msg, srcaddr);
 }


### PR DESCRIPTION
**Problem Description**
There was an update on mavlink `STORAGE_USAGE_FLAG`, which resulted in a regression with the latest mavlink builds

This PR fixes this by adding the storage usage flag