### PR TITLE
Add storage usage flag to storage information for new version of mavlink

### DIFF
--- a/src/gazebo_camera_manager_plugin.cpp
+++ b/src/gazebo_camera_manager_plugin.cpp
@@ -758,6 +758,7 @@ void CameraManagerPlugin::_handle_storage_info(const mavlink_message_t *pMsg, st
     available_mib = (float)((double)si.available / (1024.0 * 1024.0));
     total_mib     = (float)((double)si.capacity  / (1024.0 * 1024.0));
     _send_cmd_ack(pMsg->sysid, pMsg->compid, MAV_CMD_REQUEST_STORAGE_INFORMATION, MAV_RESULT_ACCEPTED, srcaddr);
+    uint8_t storage_usage = STORAGE_USAGE_FLAG_SET | STORAGE_USAGE_FLAG_PHOTO | STORAGE_USAGE_FLAG_VIDEO | STORAGE_USAGE_FLAG_LOGS;
     mavlink_message_t msg;
     mavlink_msg_storage_information_pack_chan(
         _systemID,
@@ -774,7 +775,8 @@ void CameraManagerPlugin::_handle_storage_info(const mavlink_message_t *pMsg, st
         NAN,                                // read_speed,
         NAN,                                // write_speed
         STORAGE_TYPE_OTHER,                 // storage type
-        storage_name.c_str()                // storage name
+        storage_name.c_str(),               // storage name
+        storage_usage                       // storage usage
     );
     _send_mavlink_message(&msg, srcaddr);
 }


### PR DESCRIPTION
Add storage usage flag for gazebo camera storage information. This is needed in order to upgrade to the latest version of mavlink.
[https://mavlink.io/en/messages/common.html#STORAGE_INFORMATION](https://mavlink.io/en/messages/common.html#STORAGE_INFORMATION)