### PR TITLE
Remove unused configs in windyworld

### DIFF
--- a/include/gazebo_wind_plugin.h
+++ b/include/gazebo_wind_plugin.h
@@ -108,7 +108,6 @@ class GazeboWindPlugin : public WorldPlugin {
   std::default_random_engine wind_gust_velocity_generator_;
   std::normal_distribution<double> wind_gust_velocity_distribution_;
 
-  ignition::math::Vector3d xyz_offset_;
   ignition::math::Vector3d wind_direction_mean_;
   ignition::math::Vector3d wind_gust_direction_mean_;
   double wind_direction_variance_;

--- a/src/gazebo_wind_plugin.cpp
+++ b/src/gazebo_wind_plugin.cpp
@@ -43,10 +43,6 @@ void GazeboWindPlugin::Load(physics::WorldPtr world, sdf::ElementPtr sdf) {
   node_handle_ = transport::NodePtr(new transport::Node());
   node_handle_->Init(namespace_);
 
-  if (sdf->HasElement("xyzOffset"))
-    xyz_offset_ = sdf->GetElement("xyzOffset")->Get<ignition::math::Vector3d>();
-  else
-    gzerr << "[gazebo_wind_plugin] Please specify a xyzOffset.\n";
 
   getSdfParam<std::string>(sdf, "windPubTopic", wind_pub_topic_, wind_pub_topic_);
   double pub_rate = 2.0;

--- a/worlds/windy.world
+++ b/worlds/windy.world
@@ -15,7 +15,6 @@
     <plugin name='wind_plugin' filename='libgazebo_wind_plugin.so'>
       <frameId>base_link</frameId>
       <robotNamespace/>
-      <xyzOffset>1 0 0</xyzOffset>
       <windDirectionMean>0 1 0</windDirectionMean>
       <windVelocityMean>4.0</windVelocityMean>
       <windGustDirection>0 0 0</windGustDirection>


### PR DESCRIPTION
**Problem Description**
xyzoffset was a mandatory configuration that was needed to run windy.world, but was actually not being used by the plugin

**Solution**
Remove `xyzoffset` from `windy.world`.

Found by @tstastny 