### PR TITLE
Windy World: Fixed Naming of Parameter according to wind_plugin.cpp and added missing ones.

### DIFF
--- a/worlds/windy.world
+++ b/worlds/windy.world
@@ -16,12 +16,18 @@
       <frameId>base_link</frameId>
       <robotNamespace/>
       <xyzOffset>1 0 0</xyzOffset>
-      <windDirectionMean>0 1 0</windDirectionMean>
       <windVelocityMean>4.0</windVelocityMean>
-      <windGustDirection>0 0 0</windGustDirection>
-      <windGustDuration>0</windGustDuration>
+      <windVelocityMax>20.0</windVelocityMax>
+      <windVelocityVariance>0</windVelocityVariance>
+      <windDirectionMean>0 1 0</windDirectionMean>
+      <windDirectionVariance>0</windDirectionVariance>
       <windGustStart>0</windGustStart>
+      <windGustDuration>0</windGustDuration>
       <windGustVelocityMean>0</windGustVelocityMean>
+      <windGustVelocityMax>20.0</windGustVelocityMax>
+      <windGustVelocityVariance>0</windGustVelocityVariance>
+      <windGustDirectionMean>1 0 0</windGustDirectionMean>
+      <windGustDirectionVariance>0</windGustDirectionVariance>
       <windPubTopic>world_wind</windPubTopic>
     </plugin>
     <physics name='default_physics' default='0' type='ode'>


### PR DESCRIPTION
Fixed wrong naming of `windGustDirection`, which should be named `windGustDirectionMean` to have an effect. Also added some missing but useful parameters into the windy.world from the wind plugin.
Documentation should be changed accordingly (https://docs.px4.io/master/en/simulation/gazebo.html#change-wind-speed).