### PR TITLE
sync baro and diff pres calculations in airspeed and baro plugins

### DIFF
--- a/include/gazebo_airspeed_plugin.h
+++ b/include/gazebo_airspeed_plugin.h
@@ -36,6 +36,10 @@
  * This plugin publishes Airspeed sensor data
  *
  * @author Jaeyoung Lim <jaeyoung@auterion.com>
+ *
+ * References:
+ * [1] A brief summary of atmospheric modeling with citations:
+ *     Cavcar, M., http://fisicaatmo.at.fcen.uba.ar/practicas/ISAweb.pdf
  */
 
 #ifndef _GAZEBO_AIRSPEED_PLUGIN_HH_
@@ -70,6 +74,14 @@ namespace gazebo
 
 typedef const boost::shared_ptr<const physics_msgs::msgs::Wind> WindPtr;
 
+static constexpr auto DEFAULT_HOME_ALT_AMSL = 488.0; // altitude AMSL at Irchel Park, Zurich, Switzerland [m]
+
+// international standard atmosphere (troposphere model - valid up to 11km) see [1]
+static constexpr auto TEMPERATURE_MSL = 288.15; // temperature at MSL [K] (15 [C])
+static constexpr auto PRESSURE_MSL = 101325.0; // pressure at MSL [Pa]
+static constexpr auto LAPSE_RATE = 0.0065; // reduction in temperature with altitude for troposphere [K/m]
+static constexpr auto AIR_DENSITY_MSL = 1.225; // air density at MSL [kg/m^3]
+
 class GAZEBO_VISIBLE AirspeedPlugin : public SensorPlugin
 {
 public:
@@ -101,14 +113,15 @@ private:
   std::string model_name_;
   std::string airspeed_topic_;
 
-  ignition::math::Vector3d wind_vel_;
-  ignition::math::Vector3d vel_a_;
+  ignition::math::Vector3d wind_vel_; // wind velocity in world frame [m/s]
+  ignition::math::Vector3d air_vel_in_body_; // air velocity in body frame [m/s]
+  ignition::math::Pose3d veh_pose_in_world_; // vehicle pose in world frame
 
   std::default_random_engine random_generator_;
   std::normal_distribution<float> standard_normal_distribution_;
 
-  float diff_pressure_stddev_;
-  float temperature_;
+  float diff_pressure_stddev_; // [hPa]
+  float alt_home_; // home altitude AMSL [m]
 
 };     // class GAZEBO_VISIBLE AirspeedPlugin
 }      // namespace gazebo

--- a/include/gazebo_barometer_plugin.h
+++ b/include/gazebo_barometer_plugin.h
@@ -36,6 +36,10 @@
  * This plugin simulates barometer data
  *
  * @author Elia Tarasov <elias.tarasov@gmail.com>
+ *
+ * References:
+ * [1] A brief summary of atmospheric modeling with citations:
+ *     Cavcar, M., http://fisicaatmo.at.fcen.uba.ar/practicas/ISAweb.pdf
  */
 
 #ifndef _GAZEBO_BAROMETER_PLUGIN_HH_
@@ -59,9 +63,17 @@
 
 namespace gazebo {
 
-  static constexpr auto kDefaultBarometerTopic = "/baro";
-  static constexpr auto kDefaultPubRate = 50.0;  // [Hz]. Note: averages the supported Baro device ODR in PX4
-  static constexpr auto kDefaultAltHome = 488.0; // meters
+  static constexpr auto DEFAULT_BAROMETER_TOPIC = "/baro";
+  static constexpr auto DEFAULT_PUB_RATE = 50.0;  // [Hz]. Note: averages the supported Baro device ODR in PX4
+
+  static constexpr auto DEFAULT_HOME_ALT_AMSL = 488.0; // altitude AMSL at Irchel Park, Zurich, Switzerland [m]
+
+  // international standard atmosphere (troposphere model - valid up to 11km) see [1]
+  static constexpr auto TEMPERATURE_MSL = 288.15; // temperature at MSL [K] (15 [C])
+  static constexpr auto PRESSURE_MSL = 101325.0; // pressure at MSL [Pa]
+  static constexpr auto LAPSE_RATE = 0.0065; // reduction in temperature with altitude for troposphere [K/m]
+  static constexpr auto AIR_DENSITY_MSL = 1.225; // air density at MSL [kg/m^3]
+  static constexpr auto ABSOLUTE_ZERO_C = -273.15; // [C]
 
   class BarometerPlugin : public ModelPlugin {
   public:
@@ -93,8 +105,8 @@ namespace gazebo {
     common::Time last_time_;
 
     ignition::math::Pose3d pose_model_start_;
-    ignition::math::Vector3d gravity_W_;
-    double alt_home_;
+    ignition::math::Vector3d gravity_in_world_; // [m/s^2]
+    double alt_home_; // home altitude AMSL [m]
 
     // state variables for baro pressure sensor random noise generator
     double baro_rnd_y2_;

--- a/src/gazebo_barometer_plugin.cpp
+++ b/src/gazebo_barometer_plugin.cpp
@@ -36,6 +36,8 @@
  * This plugin simulates barometer data
  *
  * @author Elia Tarasov <elias.tarasov@gmail.com>
+ *
+ * References in header.
  */
 
 #include <gazebo_barometer_plugin.h>
@@ -45,8 +47,10 @@ namespace gazebo
 GZ_REGISTER_MODEL_PLUGIN(BarometerPlugin)
 
 BarometerPlugin::BarometerPlugin() : ModelPlugin(),
+    alt_home_(DEFAULT_HOME_ALT_AMSL),
     baro_rnd_y2_(0.0),
     baro_rnd_use_last_(false),
+    baro_drift_pa_per_sec_(0.0),
     baro_drift_pa_(0.0)
 {
 }
@@ -61,9 +65,9 @@ void BarometerPlugin::getSdfParams(sdf::ElementPtr sdf)
   const char *env_alt = std::getenv("PX4_HOME_ALT");
   if (env_alt) {
     alt_home_ = std::stod(env_alt);
-    gzmsg << "[gazebo_barometer_plugin] Home altitude is set to " << alt_home_ << ".\n";
+    gzmsg << "[gazebo_barometer_plugin] Home altitude is set to " << alt_home_ << " m AMSL.\n";
   } else {
-    alt_home_ = kDefaultAltHome;
+    alt_home_ = DEFAULT_HOME_ALT_AMSL;
   }
 
   namespace_.clear();
@@ -76,14 +80,14 @@ void BarometerPlugin::getSdfParams(sdf::ElementPtr sdf)
   if (sdf->HasElement("pubRate")) {
     pub_rate_ = sdf->GetElement("pubRate")->Get<unsigned int>();
   } else {
-    pub_rate_ = kDefaultPubRate;
+    pub_rate_ = DEFAULT_PUB_RATE;
     gzwarn << "[gazebo_barometer_plugin] Using default publication rate of " << pub_rate_ << " Hz\n";
   }
 
   if (sdf->HasElement("baroTopic")) {
     baro_topic_ = sdf->GetElement("baroTopic")->Get<std::string>();
   } else {
-    baro_topic_ = kDefaultBarometerTopic;
+    baro_topic_ = DEFAULT_BAROMETER_TOPIC;
     gzwarn << "[gazebo_barometer_plugin] Using default barometer topic " << baro_topic_ << "\n";
   }
 
@@ -120,7 +124,7 @@ void BarometerPlugin::Load(physics::ModelPtr model, sdf::ElementPtr sdf)
   pub_baro_ = node_handle_->Advertise<sensor_msgs::msgs::Pressure>("~/" + model_->GetName() + baro_topic_, 10);
 
   standard_normal_distribution_ = std::normal_distribution<double>(0.0, 1.0);
-  gravity_W_ = world_->Gravity();
+  gravity_in_world_ = world_->Gravity();
 }
 
 void BarometerPlugin::OnUpdate(const common::UpdateInfo&)
@@ -140,19 +144,17 @@ void BarometerPlugin::OnUpdate(const common::UpdateInfo&)
 #else
     const ignition::math::Pose3d pose_model_world = ignitionFromGazeboMath(model_->GetWorldPose());
 #endif
+
+    // calculate temperature at current altitude
     ignition::math::Pose3d pose_model; // Z-component pose in local frame (relative to where it started)
     pose_model.Pos().Z() = pose_model_world.Pos().Z() - pose_model_start_.Pos().Z();
+    const float alt_rel = pose_model.Pos().Z(); // Z-component from ENU
+    const float alt_amsl = (float)alt_home_ + alt_rel;
+    const float temperature_local = TEMPERATURE_MSL - LAPSE_RATE * alt_amsl;
 
-    const float pose_n_z = -pose_model.Pos().Z(); // convert Z-component from ENU to NED
-
-    // calculate abs_pressure using an ISA model for the tropsphere (valid up to 11km above MSL)
-    const float lapse_rate = 0.0065f; // reduction in temperature with altitude (Kelvin/m)
-    const float temperature_msl = 288.0f; // temperature at MSL (Kelvin)
-    const float alt_msl = (float)alt_home_ - pose_n_z;
-    const float temperature_local = temperature_msl - lapse_rate * alt_msl;
-    const float pressure_ratio = powf(temperature_msl / temperature_local, 5.256f);
-    const float pressure_msl = 101325.0f; // pressure at MSL
-    const float absolute_pressure = pressure_msl / pressure_ratio;
+    // calculate absolute pressure at local temperature
+    const float pressure_ratio = powf(TEMPERATURE_MSL / temperature_local, 5.256f);
+    const float absolute_pressure = PRESSURE_MSL / pressure_ratio;
 
     // generate Gaussian noise sequence using polar form of Box-Muller transformation
     double y1;
@@ -185,17 +187,17 @@ void BarometerPlugin::OnUpdate(const common::UpdateInfo&)
     const float absolute_pressure_noisy_hpa = absolute_pressure_noisy * 0.01f;
     baro_msg_.set_absolute_pressure(absolute_pressure_noisy_hpa);
 
-    // calculate density using an ISA model for the tropsphere (valid up to 11km above MSL)
-    const float density_ratio = powf(temperature_msl / temperature_local, 4.256f);
-    const float rho = 1.225f / density_ratio;
+    // calculate air density at local temperature
+    const float density_ratio = powf(TEMPERATURE_MSL / temperature_local , 4.256f);
+    const float air_density = AIR_DENSITY_MSL / density_ratio;
 
     // calculate pressure altitude including effect of pressure noise
-    baro_msg_.set_pressure_altitude(alt_msl -
+    baro_msg_.set_pressure_altitude(alt_amsl -
                                     (abs_pressure_noise + baro_drift_pa_) /
-                                        (gravity_W_.Length() * rho));
+                                        (gravity_in_world_.Length() * air_density));
 
     // calculate temperature in Celsius
-    baro_msg_.set_temperature(temperature_local - 273.0f);
+    baro_msg_.set_temperature(temperature_local + ABSOLUTE_ZERO_C);
 
     // Fill baro msg
     baro_msg_.set_time_usec(current_time.Double() * 1e6);


### PR DESCRIPTION
**Describe problem solved by this pull request**
1. Airspeed and barometer plugins had inconsistent atmospheric settings. -- this would lead to scale offsets in the airspeed calculation on PX4 (due to inconsistent baro, temp, and diff pressure skewing the onboard dynamic pressure calculation), and consequently an oscillatory wind estimate.
2. These plugins are a bit tedious to read/understand what's happening.

**Describe your solution**
1. Synced the equations and default settings for the plugins, output differential pressure is now consistent with output absolute (barometric) pressure.
2. Started to revise code style, in particular:
    - there were some uninitialized variables in the header
    - convention for constants (all caps and underscored)
    - variables (always lowercase and underscored)
    - more verbose (explanatory) variable names
    - more comment based documentation (e.g. units!!)
    - a brief reference describing the atmospheric models used.