### PR TITLE
Plane.sdf: reduce flaps and aileron effectiveness by reducing the anle-to-lift ratio

### DIFF
--- a/models/plane/plane.sdf.jinja
+++ b/models/plane/plane.sdf.jinja
@@ -499,7 +499,7 @@
       <control_joint_name>
         left_elevon_joint
       </control_joint_name>
-      <control_joint_rad_to_cl>-0.5</control_joint_rad_to_cl>
+      <control_joint_rad_to_cl>-0.3</control_joint_rad_to_cl>
       <robotNamespace></robotNamespace>
       <windSubTopic>world_wind</windSubTopic>
     </plugin>
@@ -522,7 +522,7 @@
       <control_joint_name>
         right_elevon_joint
       </control_joint_name>
-      <control_joint_rad_to_cl>-0.5</control_joint_rad_to_cl>
+      <control_joint_rad_to_cl>-0.3</control_joint_rad_to_cl>
       <robotNamespace></robotNamespace>
       <windSubTopic>world_wind</windSubTopic>
     </plugin>
@@ -544,7 +544,7 @@
       <control_joint_name>
         left_flap_joint
       </control_joint_name>
-      <control_joint_rad_to_cl>-0.5</control_joint_rad_to_cl>
+      <control_joint_rad_to_cl>-0.1</control_joint_rad_to_cl>
       <robotNamespace></robotNamespace>
       <windSubTopic>world_wind</windSubTopic>
     </plugin>
@@ -566,7 +566,7 @@
       <control_joint_name>
         right_flap_joint
       </control_joint_name>
-      <control_joint_rad_to_cl>-0.5</control_joint_rad_to_cl>
+      <control_joint_rad_to_cl>-0.1</control_joint_rad_to_cl>
       <robotNamespace></robotNamespace>
       <windSubTopic>world_wind</windSubTopic>
     </plugin>
@@ -607,9 +607,9 @@
       <forward>1 0 0</forward>
       <upward>0 1 0</upward>
       <link_name>base_link</link_name>
-      <control_joint_name> 
-         rudder_joint 
-      </control_joint_name> 
+      <control_joint_name>
+         rudder_joint
+      </control_joint_name>
       <control_joint_rad_to_cl>0.8</control_joint_rad_to_cl>
       <robotNamespace></robotNamespace>
       <windSubTopic>world_wind</windSubTopic>


### PR DESCRIPTION
The plane was overshooting the landing point by a couple of hundred meters as it was just happily flying level at a thrust setpoint of 5% and very low airspeed. This PR improves the situation slightly by reducing the effectiveness of the flaps, thus the lift coefficient is smaller and more realistic.
Old:
![image](https://user-images.githubusercontent.com/26798987/144832296-34d02fbf-cae6-4559-a0f3-778cea9449a5.png)
New:
![image](https://user-images.githubusercontent.com/26798987/144832415-bfdb794c-583b-4b04-8cc4-382dd8e68b44.png)


If I got it correctly then we currently split the whole wing into 4 equally big control surfaces (2xflaps, 2x ailerons). If we instead can split it into 5 areas, where one is the non-moving "wing" part, then we could tune it by just adapting the surface area of the separate surfaces, instead, like now, tune the effectiveness. Sounds a bit cleaner to me. Realistic stall simulation would be cool as well ofc:)

I've also reduced the effectivenss of the ailerons a bit, seemed to high as well.
