### PR TITLE
Update container tags to fix catkin build workflow

### DIFF
--- a/.github/workflows/catkin_build_test.yml
+++ b/.github/workflows/catkin_build_test.yml
@@ -14,8 +14,8 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {rosdistro: 'melodic', container: 'px4io/px4-dev-ros-melodic:2021-05-31'}
-          - {rosdistro: 'noetic', container: 'px4io/px4-dev-ros-noetic:2021-05-31'}
+          # - {rosdistro: 'melodic', container: 'px4io/px4-dev-ros-melodic:2021-12-11'}
+          - {rosdistro: 'noetic', container: 'px4io/px4-dev-ros-noetic:2022-08-12'}
     container: ${{ matrix.config.container }}
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
**Problem Description**
Catkin build tests has been recently failing: 

```
Errors << mavlink_sitl_gazebo:make /github/home/catkin_ws/logs/mavlink_sitl_gazebo/build.make.000.log
In file included from /github/home/catkin_ws/src/PX4-SITL_gazebo/src/gazebo_camera_manager_plugin.cpp:18:
/github/home/catkin_ws/src/PX4-SITL_gazebo/include/gazebo_camera_manager_plugin.h:21:10: fatal error: development/mavlink.h: No such file or directory
   21 | #include <development/mavlink.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
make[2]: *** [CMakeFiles/gazebo_camera_manager_plugin.dir/build.make:63: CMakeFiles/gazebo_camera_manager_plugin.dir/src/gazebo_camera_manager_plugin.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:776: CMakeFiles/gazebo_camera_manager_plugin.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
make: *** [Makefile:152: all] Error 2
cd /github/home/catkin_ws/build/mavlink_sitl_gazebo; catkin build --get-env mavlink_sitl_gazebo | catkin env -si  /usr/bin/make --jobserver-auth=3,4; cd -
```

Fixes https://github.com/PX4/PX4-SITL_gazebo/pull/869