### PR TITLE
Update cloudship.sdf.jinja

### DIFF
--- a/models/cloudship/cloudship.sdf.jinja
+++ b/models/cloudship/cloudship.sdf.jinja
@@ -383,54 +383,16 @@
         </geometry>
       </collision>
     </link>
-
-    <model name='gps0'>
-      <link name='link'>
-        <pose frame=''>0 0 0 0 0 0</pose>
-        <inertial>
-          <pose frame=''>0 0 0 0 0 0</pose>
-          <mass>0.01</mass>
-          <inertia>
-            <ixx>2.1733e-06</ixx>
-            <ixy>0</ixy>
-            <ixz>0</ixz>
-            <iyy>2.1733e-06</iyy>
-            <iyz>0</iyz>
-            <izz>1.8e-07</izz>
-          </inertia>
-        </inertial>
-        <visual name='visual'>
-          <geometry>
-            <cylinder>
-              <radius>0.01</radius>
-              <length>0.002</length>
-            </cylinder>
-          </geometry>
-          <material>
-            <script>
-              <name>Gazebo/Black</name>
-              <uri>__default__</uri>
-            </script>
-          </material>
-        </visual>
-        <sensor name='gps' type='gps'>
-          <pose frame=''>0 0 0 0 0 0</pose>
-          <plugin name='gps_plugin' filename='libgazebo_gps_plugin.so'>
-            <robotNamespace/>
-            <gpsNoise>1</gpsNoise>
-            <gpsXYRandomWalk>2.0</gpsXYRandomWalk>
-            <gpsZRandomWalk>4.0</gpsZRandomWalk>
-            <gpsXYNoiseDensity>0.0002</gpsXYNoiseDensity>
-            <gpsZNoiseDensity>0.0004</gpsZNoiseDensity>
-            <gpsVXYNoiseDensity>0.2</gpsVXYNoiseDensity>
-            <gpsVZNoiseDensity>0.4</gpsVZNoiseDensity>
-          </plugin>
-        </sensor>
-      </link>
-    </model>
-    <joint name='gps0_joint' type='fixed'>
+    
+    {# GPS joint which includes GPS plugin #}
+    <include>
+      <uri>model://gps</uri>
+      <pose>0 0 0 0 0 0</pose>
+      <name>gps</name>
+    </include>
+    <joint name='gps_joint' type='fixed'>
+      <child>gps::link</child>
       <parent>hull</parent>
-      <child>gps0::link</child>
     </joint>
 
     {# Thrusters Rod #}


### PR DESCRIPTION
Replace GPS joint with statement including GPS joint defined in other GPS model folder. This is adapted from the method that other Gazebo SITL models include the GPS such as the plane. The base_link term is replaced by hull to attach the GPS to the hull.

This will address the issue raised in PX4/PX4-Autopilot #19322. The issue is that if a mission is attempted using the cloudship model, the GPS losses connection. In addition, QGroundcontrol cannot track the position of the airship ever. I suspect this is due to a lack of maintenance on this model. Therefore, I have replaced the old GPS plugin code with the code used in the "plane" model. The only change to this code from plane is that the parent link has been set to "hull".

When I tested this change, QGroundcontrol could determine the position of the airship. Further changes will likely be needed.