### PR TITLE
update the motor failure plugin for ros2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ include(GNUInstallDirs)
 #######################
 
 option(BUILD_GSTREAMER_PLUGIN "enable gstreamer plugin" ON)
-option(BUILD_ROS2_PLUGINS "Enable building ROS2 dependent plugins" ON)
+option(BUILD_ROS2_PLUGINS "Enable building ROS2 dependent plugins" OFF)
 option(GENERATE_ROS_MODELS "Generate model sdf for ROS environment" OFF)
 
 option(SEND_VISION_ESTIMATION_DATA "Send Mavlink VISION_POSITION_ESTIMATE msgs" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ include(GNUInstallDirs)
 #######################
 
 option(BUILD_GSTREAMER_PLUGIN "enable gstreamer plugin" ON)
-option(BUILD_ROS_PLUGINS "Enable building ROS dependent plugins" OFF)
+option(BUILD_ROS2_PLUGINS "Enable building ROS2 dependent plugins" ON)
 option(GENERATE_ROS_MODELS "Generate model sdf for ROS environment" OFF)
 
 option(SEND_VISION_ESTIMATION_DATA "Send Mavlink VISION_POSITION_ESTIMATE msgs" OFF)
@@ -103,12 +103,14 @@ link_directories(${GAZEBO_LIBRARY_DIRS})
 add_subdirectory( external/OpticalFlow OpticalFlow )
 set( OpticalFlow_LIBS "OpticalFlow" )
 
-# for ROS subscribers and publishers
-if (BUILD_ROS_PLUGINS)
+# for ROS2 subscribers and publishers
+if (BUILD_ROS2_PLUGINS)
+  find_package(ament_cmake REQUIRED)
   find_package(geometry_msgs REQUIRED)
-  find_package(roscpp REQUIRED)
+  find_package(rclcpp REQUIRED)
   find_package(sensor_msgs REQUIRED)
 endif()
+
 
 # find MAVLink
 find_package(MAVLink)
@@ -407,11 +409,11 @@ foreach(plugin ${plugins})
 endforeach()
 target_link_libraries(gazebo_opticalflow_plugin ${OpticalFlow_LIBS})
 
-# If BUILD_ROS_PLUGINS set to ON, build plugins that have ROS dependencies
+# If BUILD_ROS2_PLUGINS set to ON, build plugins that have ROS dependencies
 # Current plugins that can be used with ROS interface: gazebo_motor_failure_plugin
-if (BUILD_ROS_PLUGINS)
+if (BUILD_ROS2_PLUGINS)
   add_library(gazebo_motor_failure_plugin SHARED src/gazebo_motor_failure_plugin.cpp)
-  target_link_libraries(gazebo_motor_failure_plugin ${GAZEBO_libraries} ${roscpp_LIBRARIES})
+  target_link_libraries(gazebo_motor_failure_plugin ${GAZEBO_libraries} ${rclcpp_LIBRARIES})
   list(APPEND plugins gazebo_motor_failure_plugin)
   message(STATUS "adding gazebo_motor_failure_plugin to build")
 
@@ -419,11 +421,12 @@ if (BUILD_ROS_PLUGINS)
     include
     ${geometry_msgs_INCLUDE_DIRS}
     ${sensor_msgs_INCLUDE_DIRS}
+    ${rclcpp_INCLUDE_DIRS}
   )
 
   target_link_libraries(gazebo_motor_failure_plugin
-    ${catkin_LIBRARIES}
-    ${roscpp_LIBRARIES}
+    ${ament_LIBRARIES}
+    ${rclcpp_LIBRARIES}
     ${GAZEBO_libraries}
   )
 endif()

--- a/include/gazebo_motor_failure_plugin.h
+++ b/include/gazebo_motor_failure_plugin.h
@@ -1,6 +1,7 @@
 /*
  * Copyright 2017 Nuno Marques, PX4 Pro Dev Team, Lisbon
  * Copyright 2017 Siddharth Patel, NTU Singapore
+ * Copyright 2022 SungTae Moon, KOREATECH Korea
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,10 +29,8 @@
 
 // ROS Topic subscriber
 #include <thread>
-#include "ros/ros.h"
-#include "ros/callback_queue.h"
-#include "ros/subscribe_options.h"
-#include <std_msgs/Int32.h>
+#include <rclcpp/rclcpp.hpp>
+#include <std_msgs/msg/int32.hpp>
 
 namespace gazebo {
 
@@ -43,7 +42,7 @@ class GazeboMotorFailure : public ModelPlugin {
  public:
   GazeboMotorFailure();
 
-  void motorFailNumCallBack(const std_msgs::Int32ConstPtr &_msg);
+  void motorFailNumCallBack(const std_msgs::msg::Int32::SharedPtr msg);
 
   virtual ~GazeboMotorFailure();
 
@@ -57,8 +56,6 @@ class GazeboMotorFailure : public ModelPlugin {
   virtual void OnUpdate(const common::UpdateInfo & /*_info*/);
 
  private:
-
-  void QueueThread();
 
   event::ConnectionPtr updateConnection_;
 
@@ -74,10 +71,9 @@ class GazeboMotorFailure : public ModelPlugin {
   msgs::Int motor_failure_msg_;
   int32_t motor_Failure_Number_;
 
-  // ROS communication
-  ros::NodeHandle* rosNode;
-  ros::Subscriber rosSub;
-  ros::CallbackQueue rosQueue;
-  std::thread rosQueueThread;
+  // ROS2 communication
+  rclcpp::Node::SharedPtr ros_node_;
+  rclcpp::Subscription<std_msgs::msg::Int32>::SharedPtr subscription;
+
 };
 }


### PR DESCRIPTION
The gazebo_motor_failure_plugin has been not used because of too old code, even though  the plugin is necessary for various studies like fault detection. 
So, I update the gazebo_motor_failure_plugin from ROS1 to ROS2. 