### PR TITLE
Fix HITL by sending heartbeats

### DIFF
--- a/include/gazebo_mavlink_interface.h
+++ b/include/gazebo_mavlink_interface.h
@@ -249,6 +249,7 @@ private:
   common::Time last_time_;
   common::Time last_imu_time_;
   common::Time last_actuator_time_;
+  common::Time last_heartbeat_sent_time_{};
 
   double groundtruth_lat_rad_{0.0};
   double groundtruth_lon_rad_{0.0};

--- a/include/mavlink_interface.h
+++ b/include/mavlink_interface.h
@@ -152,6 +152,7 @@ public:
     void open();
     void close();
     void Load();
+    void SendHeartbeat();
     void SendSensorMessages(const uint64_t time_usec);
     void SendSensorMessages(const uint64_t time_usec, HILData &hil_data);
     void SendGpsMessages(const SensorData::Gps &data);
@@ -179,6 +180,7 @@ public:
     void SetHILStateLevel(bool hil_state_level) {hil_state_level_ = hil_state_level;}
 
     bool SerialEnabled() const { return serial_enabled_; }
+    bool ReceivedHeartbeats() const { return received_heartbeats_; }
 
 private:
     bool received_actuator_{false};
@@ -187,6 +189,7 @@ private:
     Eigen::VectorXd input_reference_;
 
     void handle_message(mavlink_message_t *msg);
+    void handle_heartbeat(mavlink_message_t *msg);
     void handle_actuator_controls(mavlink_message_t *msg);
     void acceptConnections();
     void RegisterNewHILSensorInstance(int id);
@@ -271,4 +274,6 @@ private:
 
     std::vector<HILData, Eigen::aligned_allocator<HILData>> hil_data_;
     std::atomic<bool> gotSigInt_ {false};
+
+    bool received_heartbeats_ {false};
 };

--- a/src/gazebo_mavlink_interface.cpp
+++ b/src/gazebo_mavlink_interface.cpp
@@ -587,6 +587,13 @@ void GazeboMavlinkInterface::OnUpdate(const common::UpdateInfo&  /*_info*/) {
     mavlink_interface_->pollForMAVLinkMessages();
   }
 
+  // We need to send out heartbeats at a high rate until the connection is established,
+  // otherwise PX4 on USB doesn't enable mavlink and the buffer fills up.
+  if ((current_time - last_heartbeat_sent_time_).Double() > 1.0 || !mavlink_interface_->ReceivedHeartbeats()) {
+    mavlink_interface_->SendHeartbeat();
+    last_heartbeat_sent_time_ = current_time;
+  }
+
   // Always send Gyro and Accel data at full rate (= sim update rate)
   SendSensorMessages();
 


### PR DESCRIPTION
PX4 no longer starts the mavlink instance on USB by default. This means that the simulator needs to send heartbeats to initialize it.

Sending the heartbeats at 1 Hz however is not enough as we might fill up all the buffers in less than a second which means PX4 never sees a heartbeat, and won't initialize. Therefore, we send heartbeats in every iteration initially until we have received a heartbeat back.