### PR TITLE
Don't reset the world when destroying plugins

### DIFF
--- a/src/gazebo_gps_plugin.cpp
+++ b/src/gazebo_gps_plugin.cpp
@@ -41,7 +41,6 @@ GpsPlugin::~GpsPlugin()
   if (updateSensorConnection_)
     updateSensorConnection_->~Connection();
   parentSensor_.reset();
-  world_->Reset();
 }
 
 void GpsPlugin::Load(sensors::SensorPtr _parent, sdf::ElementPtr _sdf)

--- a/src/gazebo_groundtruth_plugin.cpp
+++ b/src/gazebo_groundtruth_plugin.cpp
@@ -51,7 +51,6 @@ GroundtruthPlugin::~GroundtruthPlugin()
 {
   if (updateConnection_)
     updateConnection_->~Connection();
-  world_->Reset();
 }
 
 void GroundtruthPlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf)

--- a/src/gazebo_lidar_plugin.cpp
+++ b/src/gazebo_lidar_plugin.cpp
@@ -47,7 +47,6 @@ LidarPlugin::~LidarPlugin()
   newLaserScansConnection_->~Connection();
   newLaserScansConnection_.reset();
   parentSensor_.reset();
-  world_->Reset();
 }
 
 /////////////////////////////////////////////////


### PR DESCRIPTION
If the world is edited in some way, then to save this edited world from GUI (to use it later), you have to remove the drone from it. But with latest version of Gazebo and PX4, Gazebo crashes with segfault, when you remove the drone model from the world.

After some investigation I figured out that the cause of this crash is a call of `world_->Reset()` in plugins destructors. I haven't investigated further, but according to the [documentation](https://osrf-distributions.s3.amazonaws.com/gazebo/api/dev/classgazebo_1_1physics_1_1World.html#a372de693ad40b3f42839c8ec6ac845f4), this method «resets time and model poses, configurations in simulation.». But why do we need to do that, only if the drone's model is removed? I guess, we don't. Other plugins I examined doesn't do this as well.

Furthermore this crashes Gazebo, so I propose to remove this.

Please, correct me if I'm wrong.