### PR TITLE
Motor model and MAVLink interface improvements

### DIFF
--- a/include/gazebo_mavlink_interface.h
+++ b/include/gazebo_mavlink_interface.h
@@ -164,6 +164,8 @@ private:
   bool send_odometry_{false};
 
   std::vector<physics::JointPtr> joints_;
+  // Array to indicate if the join uses PID control
+  std::vector<bool> joint_uses_pid_;
   std::vector<common::PID> pids_;
   std::vector<double> joint_max_errors_;
 

--- a/models/boat/boat.sdf.jinja
+++ b/models/boat/boat.sdf.jinja
@@ -489,7 +489,7 @@
       <timeConstantUp>0.0125</timeConstantUp>
       <timeConstantDown>0.025</timeConstantDown>
       <maxRotVelocity>1100</maxRotVelocity>
-      <motorConstant>8.54858e-03</motorConstant>
+      <motorConstant>8.54858e-02</motorConstant>
       <momentConstant>0.01</momentConstant>
       <commandSubTopic>/gazebo/command/motor_speed</commandSubTopic>
       <motorNumber>0</motorNumber>
@@ -506,7 +506,7 @@
       <timeConstantUp>0.0125</timeConstantUp>
       <timeConstantDown>0.025</timeConstantDown>
       <maxRotVelocity>1100</maxRotVelocity>
-      <motorConstant>8.54858e-03</motorConstant>
+      <motorConstant>8.54858e-02/motorConstant>
       <momentConstant>0.01</momentConstant>
       <commandSubTopic>/gazebo/command/motor_speed</commandSubTopic>
       <motorNumber>1</motorNumber>

--- a/msgs/CommandMotorSpeed.proto
+++ b/msgs/CommandMotorSpeed.proto
@@ -3,5 +3,5 @@ package mav_msgs.msgs;
 
 message CommandMotorSpeed
 {
-  repeated float   motor_speed  = 1 [packed=true];
+  repeated float   motor_speed  = 1 [packed=true]; // [rad/s]
 }

--- a/src/gazebo_mavlink_interface.cpp
+++ b/src/gazebo_mavlink_interface.cpp
@@ -619,8 +619,10 @@ void GazeboMavlinkInterface::OnUpdate(const common::UpdateInfo&  /*_info*/) {
     for (int i = 0; i < input_reference_.size(); i++) {
       if (last_actuator_time_ == 0 || (current_time - last_actuator_time_).Double() > 0.2) {
         turning_velocities_msg.add_motor_speed(0);
+
       } else {
         turning_velocities_msg.add_motor_speed(input_reference_[i]);
+
       }
     }
     // TODO Add timestamp and Header
@@ -1122,16 +1124,20 @@ void GazeboMavlinkInterface::handle_actuator_controls() {
   // Read Input References
   input_reference_.resize(n_out_max);
 
+  // Get the normalized (-1 ... +1) actuator controls input from PX4 instance
   Eigen::VectorXd actuator_controls = mavlink_interface_->GetActuatorControls();
+
   if (actuator_controls.size() < n_out_max) return; //TODO: Handle this properly
+
+  // Translate actuator control input into motor input reference [rad/s]
   for (int i = 0; i < input_reference_.size(); i++) {
     if (armed) {
       input_reference_[i] = (actuator_controls[input_index_[i]] + input_offset_[i])
           * input_scaling_[i] + zero_position_armed_[i];
-      // std::cout << input_reference_ << ", ";
+
     } else {
       input_reference_[i] = zero_position_disarmed_[i];
-      // std::cout << input_reference_ << ", ";
+
     }
   }
   // std::cout << "Input Reference: " << input_reference_.transpose() << std::endl;

--- a/src/gazebo_motor_model.cpp
+++ b/src/gazebo_motor_model.cpp
@@ -185,7 +185,11 @@ void GazeboMotorModel::VelocityCallback(CommandMotorSpeedPtr &rot_velocities) {
   if(rot_velocities->motor_speed_size() < motor_number_) {
     std::cout  << "You tried to access index " << motor_number_
       << " of the MotorSpeed message array which is of size " << rot_velocities->motor_speed_size() << "." << std::endl;
-  } else ref_motor_rot_vel_ = std::min(static_cast<double>(rot_velocities->motor_speed(motor_number_)), static_cast<double>(max_rot_velocity_));
+
+  } else {
+    ref_motor_rot_vel_ = std::min(static_cast<double>(rot_velocities->motor_speed(motor_number_)), static_cast<double>(max_rot_velocity_));
+
+  }
 }
 
 void GazeboMotorModel::MotorFailureCallback(const boost::shared_ptr<const msgs::Int> &fail_msg) {
@@ -194,11 +198,14 @@ void GazeboMotorModel::MotorFailureCallback(const boost::shared_ptr<const msgs::
 
 void GazeboMotorModel::UpdateForcesAndMoments() {
   motor_rot_vel_ = joint_->GetVelocity(0);
+
   if (motor_rot_vel_ / (2 * M_PI) > 1 / (2 * sampling_time_)) {
     gzerr << "Aliasing on motor [" << motor_number_ << "] might occur. Consider making smaller simulation time steps or raising the rotor_velocity_slowdown_sim_ param.\n";
   }
+
   double real_motor_velocity = motor_rot_vel_ * rotor_velocity_slowdown_sim_;
   double force = real_motor_velocity * std::abs(real_motor_velocity) * motor_constant_;
+
   if(!reversible_) {
     // Not allowed to have negative thrust.
     force = std::abs(force);
@@ -231,6 +238,7 @@ void GazeboMotorModel::UpdateForcesAndMoments() {
   ignition::math::Vector3d air_drag = -std::abs(real_motor_velocity) * rotor_drag_coefficient_ * velocity_perpendicular_to_rotor_axis;
   // Apply air_drag to link.
   link_->AddForce(air_drag);
+
   // Moments
   // Getting the parent link, such that the resulting torques can be applied to it.
   physics::Link_V parent_links = link_->GetParentJointsLinks();
@@ -249,14 +257,14 @@ void GazeboMotorModel::UpdateForcesAndMoments() {
   // - \omega * \mu_1 * V_A^{\perp}
   rolling_moment = -std::abs(real_motor_velocity) * turning_direction_ * rolling_moment_coefficient_ * velocity_perpendicular_to_rotor_axis;
   parent_links.at(0)->AddTorque(rolling_moment);
-  // Apply the filter on the motor's velocity.
-  double ref_motor_rot_vel;
-  ref_motor_rot_vel = rotor_velocity_filter_->updateFilter(ref_motor_rot_vel_, sampling_time_);
+
+  // Apply the filter and update new rotor velocity
+  const double new_ref_motor_rot_vel = rotor_velocity_filter_->updateFilter(ref_motor_rot_vel_, sampling_time_);
 
 #if 0 //FIXME: disable PID for now, it does not play nice with the PX4 CI system.
   if (use_pid_)
   {
-    double err = joint_->GetVelocity(0) - turning_direction_ * ref_motor_rot_vel / rotor_velocity_slowdown_sim_;
+    double err = joint_->GetVelocity(0) - turning_direction_ * new_ref_motor_rot_vel / rotor_velocity_slowdown_sim_;
     double rotorForce = pid_.Update(err, sampling_time_);
     joint_->SetForce(0, rotorForce);
     // gzerr << "rotor " << joint_->GetName() << " : " << rotorForce << "\n";
@@ -266,16 +274,16 @@ void GazeboMotorModel::UpdateForcesAndMoments() {
 #if GAZEBO_MAJOR_VERSION >= 7
     // Not desirable to use SetVelocity for parts of a moving model
     // impact on rest of the dynamic system is non-physical.
-    joint_->SetVelocity(0, turning_direction_ * ref_motor_rot_vel / rotor_velocity_slowdown_sim_);
+    joint_->SetVelocity(0, turning_direction_ * new_ref_motor_rot_vel / rotor_velocity_slowdown_sim_);
 #elif GAZEBO_MAJOR_VERSION >= 6
     // Not ideal as the approach could result in unrealistic impulses, and
     // is only available in ODE
     joint_->SetParam("fmax", 0, 2.0);
-    joint_->SetParam("vel", 0, turning_direction_ * ref_motor_rot_vel / rotor_velocity_slowdown_sim_);
+    joint_->SetParam("vel", 0, turning_direction_ * new_ref_motor_rot_vel / rotor_velocity_slowdown_sim_);
 #endif
   }
 #else
-  joint_->SetVelocity(0, turning_direction_ * ref_motor_rot_vel / rotor_velocity_slowdown_sim_);
+  joint_->SetVelocity(0, turning_direction_ * new_ref_motor_rot_vel / rotor_velocity_slowdown_sim_);
 #endif /* if 0 */
 }
 

--- a/src/gazebo_motor_model.cpp
+++ b/src/gazebo_motor_model.cpp
@@ -128,7 +128,9 @@ void GazeboMotorModel::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf) {
   getSdfParam<double>(_sdf, "rotorDragCoefficient", rotor_drag_coefficient_, rotor_drag_coefficient_);
   getSdfParam<double>(_sdf, "rollingMomentCoefficient", rolling_moment_coefficient_,
                       rolling_moment_coefficient_);
+  // Maximum motor rotational velocity [rad/s]
   getSdfParam<double>(_sdf, "maxRotVelocity", max_rot_velocity_, max_rot_velocity_);
+  // Motor thrust constant [kg*m]
   getSdfParam<double>(_sdf, "motorConstant", motor_constant_, motor_constant_);
   getSdfParam<double>(_sdf, "momentConstant", moment_constant_, moment_constant_);
 


### PR DESCRIPTION
> Work in progress!

## Improvements
1. Previously the PID based force was always being applied to velocity controlled joints (basically all rotors / motors), but this shouldn't be the case as the motor_model can correctly set the thrust force on it's own

## Comment
I was trying out the boat model and was playing around with the left/right thrusters, and while trying to convert them into the [ignition hydrodynamics model,](https://gazebosim.org/api/gazebo/5.0/underwater_vehicles.html) I realized that there are some improvements to be made in the models in the repo.