### PR TITLE
Clear odom msg repeating fields to reset size

### DIFF
--- a/src/gazebo_vision_plugin.cpp
+++ b/src/gazebo_vision_plugin.cpp
@@ -186,6 +186,11 @@ void VisionPlugin::OnUpdate(const common::UpdateInfo&)
     _bias.Y() += random_walk.Y() * dt - _bias.Y() / _corellation_time;
     _bias.Z() += random_walk.Z() * dt - _bias.Z() / _corellation_time;
 
+    // clear odom msg repeatin fields to reset size
+    odom_msg.clear_velocity_covariance();
+    odom_msg.clear_pose_covariance();
+
+
     // Fill odom msg
     odom_msg.set_time_usec(current_time.Double() * 1e6);
 


### PR DESCRIPTION
This PR ensures that the gazebo odom message does not increase in size. Covariance fields are added in each cycle keeping the old, if not cleared, Addresses https://github.com/PX4/PX4-SITL_gazebo/issues/876.