### PR TITLE
gimbal: fix yaw angle at pitch -90 degrees

### DIFF
--- a/src/gazebo_gimbal_controller_plugin.cpp
+++ b/src/gazebo_gimbal_controller_plugin.cpp
@@ -832,8 +832,11 @@ void GimbalControllerPlugin::HandleGimbalDeviceSetAttitude(const mavlink_message
     this->yawRateSetpoint = NAN;
 
   } else {
-    float rollRad, pitchRad, yawRad;
-    mavlink_quaternion_to_euler(&set_attitude.q[0], &rollRad, &pitchRad, &yawRad);
+    const auto euler = detail::QtoZXY(ignition::math::Quaterniond(
+			    set_attitude.q[0], set_attitude.q[1], set_attitude.q[2], set_attitude.q[3]));
+    const float pitchRad = euler[0];
+    const float rollRad = euler[1];
+    const float yawRad = euler[2];
 
     const std::lock_guard<std::mutex> lock(setpointMutex);
     this->rollSetpoint = rollRad;


### PR DESCRIPTION
This fixes the gimbal at pitch -90 degrees. It is based on the 3-1-2 intrinsic TaitBryan angles rather than the 3-2-1 provided by the MAVLink headers.

Same as https://github.com/PX4/PX4-Autopilot/pull/19951