### PR TITLE
Fix github workflows

### DIFF
--- a/.github/workflows/firmware_build_test.yml
+++ b/.github/workflows/firmware_build_test.yml
@@ -41,10 +41,10 @@ jobs:
         git checkout ${{github.head_ref}}
     - name: Download MAVSDK
       working-directory: Firmware
-      run: wget "https://github.com/mavlink/MAVSDK/releases/download/v$(cat test/mavsdk_tests/MAVSDK_VERSION)/mavsdk_$(cat test/mavsdk_tests/MAVSDK_VERSION)_ubuntu20.04_amd64.deb"
+      run: wget "https://github.com/mavlink/MAVSDK/releases/download/v$(cat test/mavsdk_tests/MAVSDK_VERSION)/libmavsdk-dev_$(cat test/mavsdk_tests/MAVSDK_VERSION)_ubuntu20.04_amd64.deb"
     - name: Install MAVSDK
       working-directory: Firmware
-      run: dpkg -i "mavsdk_$(cat test/mavsdk_tests/MAVSDK_VERSION)_ubuntu20.04_amd64.deb"
+      run: dpkg -i "libmavsdk-dev_$(cat test/mavsdk_tests/MAVSDK_VERSION)_ubuntu20.04_amd64.deb"
     - name: Prepare ccache timestamp
       id: ccache_cache_timestamp
       shell: cmake -P {0}

--- a/.github/workflows/firmware_build_test.yml
+++ b/.github/workflows/firmware_build_test.yml
@@ -3,7 +3,7 @@ name: Firmware Build and SITL Tests
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
       - '*'
@@ -21,17 +21,17 @@ jobs:
       image: px4io/px4-dev-simulation-focal:2021-05-31
       options: --privileged --ulimit core=-1 --security-opt seccomp=unconfined
     steps:
-    - name: Checkout Firmware master
+    - name: Checkout Firmware main
       uses: actions/checkout@v2.3.1
       with:
         repository: PX4/Firmware
-        ref: master
+        ref: main
         path: Firmware
         fetch-depth: 0
         submodules: recurvise
     - name: Checkout matching branch on PX4/Firmware if possible
       run: |
-        git checkout ${{github.head_ref}} || echo "Firmware branch: ${{github.head_ref}} not found, using master instead"
+        git checkout ${{github.head_ref}} || echo "Firmware branch: ${{github.head_ref}} not found, using main instead"
         git submodule update --init --recursive
       working-directory: Firmware
     - name: Configure Firmware to include current sitl_gazebo version

--- a/scripts/validate_sdf.bash
+++ b/scripts/validate_sdf.bash
@@ -54,7 +54,7 @@ if [ -d ${MODELS_DIR} ]; then
 		! -name '3DR_gps_mag.sdf' ! -name 'px4flow.sdf' \
 		! -name 'pixhawk.sdf' ! -name 'c920.sdf' \
 		! -name 'iris.sdf' ! -name 'iris_hitl.sdf' ! -name 'delta_wing.sdf' ! -name 'r1_rover.sdf' \
-		! -name 'fpv_cam.sdf' ! -name 'iris_triple_depth_camera.sdf')"
+		! -name 'fpv_cam.sdf' ! -name 'omnicopter.sdf' ! -name 'iris_triple_depth_camera.sdf')"
 else
 	echo "${MODELS_DIR} doesn't exist!"
 	delete_schema


### PR DESCRIPTION
**Problem Description**
This PR fixes the github actions that were broken

**Proposed Solution**
This commit fixes the github actions workflows due to recent changes in the firmware
- change default branch name from master to main
- do not validate the omnicopter sdf file
- Fix mavsdk download address from `mavsdk~` to `libmavsdk-dev~` 

**Additional Context**
- Catkin build tests are expected to be fixed in https://github.com/PX4/PX4-SITL_gazebo/pull/840