### PR TITLE
tiltrotor: fix actuator index after removing 2 tilts

### DIFF
--- a/models/tiltrotor/tiltrotor.sdf.jinja
+++ b/models/tiltrotor/tiltrotor.sdf.jinja
@@ -973,7 +973,7 @@
           </joint_control_pid>
         </channel>
         <channel name="motor2_tilt">
-          <input_index>6</input_index>
+          <input_index>5</input_index>
           <input_offset>0.785398</input_offset>
           <input_scaling>0.785398</input_scaling>
           <zero_position_disarmed>0</zero_position_disarmed>
@@ -992,7 +992,7 @@
           </joint_control_pid>
         </channel>
         <channel name="left_elevon">
-          <input_index>8</input_index>
+          <input_index>6</input_index>
           <input_offset>0</input_offset>
           <input_scaling>1</input_scaling>
           <zero_position_disarmed>0</zero_position_disarmed>
@@ -1001,7 +1001,7 @@
           <joint_name>left_elevon_joint</joint_name>
         </channel>
         <channel name="right_elevon">
-          <input_index>9</input_index>
+          <input_index>7</input_index>
           <input_offset>0</input_offset>
           <input_scaling>1</input_scaling>
           <zero_position_disarmed>0</zero_position_disarmed>
@@ -1010,7 +1010,7 @@
           <joint_name>right_elevon_joint</joint_name>
         </channel>
         <channel name="elevator">
-          <input_index>10</input_index>
+          <input_index>8</input_index>
           <input_offset>0</input_offset>
           <input_scaling>1</input_scaling>
           <zero_position_disarmed>0</zero_position_disarmed>


### PR DESCRIPTION
Came in with https://github.com/PX4/PX4-SITL_gazebo/commit/1262a58dfdd0df2075d816b1cb4ced4f8f8c6cf6. Let's not keep empty indexes in between.