### PR TITLE
Fix for fatal error: development/mavlink.h: No such file or directory

### DIFF
--- a/.github/workflows/catkin_build_test.yml
+++ b/.github/workflows/catkin_build_test.yml
@@ -14,8 +14,8 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {rosdistro: 'melodic', container: 'px4io/px4-dev-ros-melodic:2021-05-31'}
-          - {rosdistro: 'noetic', container: 'px4io/px4-dev-ros-noetic:2021-05-31'}
+          # - {rosdistro: 'melodic', container: 'px4io/px4-dev-ros-melodic:2021-12-11'}
+          - {rosdistro: 'noetic', container: 'px4io/px4-dev-ros-noetic:2022-08-12'}
     container: ${{ matrix.config.container }}
     steps:
     - uses: actions/checkout@v1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,6 +190,7 @@ include_directories(
   ${EIGEN3_INCLUDE_DIRS}/eigen3	# Workaround for Eigen3
   ${GAZEBO_INCLUDE_DIRS}
   ${GAZEBO_MSG_INCLUDE_DIRS}
+  ${MAVLINK_INCLUDE_DIRS}
   ${MAVLINK_INCLUDE_DIRS}/mavlink/v2.0 # Workaround for "fatal error: development/mavlink.h: No such file or directory"
   ${OGRE_INCLUDE_DIRS}
   ${OGRE_INCLUDE_DIRS}/Paging		# Workaround for "fatal error: OgrePagedWorldSection.h: No such file or directory"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,7 +190,7 @@ include_directories(
   ${EIGEN3_INCLUDE_DIRS}/eigen3	# Workaround for Eigen3
   ${GAZEBO_INCLUDE_DIRS}
   ${GAZEBO_MSG_INCLUDE_DIRS}
-  ${MAVLINK_INCLUDE_DIRS}
+  ${MAVLINK_INCLUDE_DIRS}/mavlink/v2.0 # Workaround for "fatal error: development/mavlink.h: No such file or directory"
   ${OGRE_INCLUDE_DIRS}
   ${OGRE_INCLUDE_DIRS}/Paging		# Workaround for "fatal error: OgrePagedWorldSection.h: No such file or directory"
   ${OpenCV_INCLUDE_DIRS}


### PR DESCRIPTION
The `development` dialect for the mavlink is available with its release `2022.8.8-1`.This PR solves the issue mentioned in https://github.com/mavlink/mavros/issues/1767, https://github.com/PX4/PX4-SITL_gazebo/issues/874, https://github.com/PX4/PX4-SITL_gazebo/issues/823, https://github.com/PX4/PX4-SITL_gazebo/pull/868, and https://github.com/PX4/PX4-SITL_gazebo/pull/840.