### PR TITLE
Gazebo mavlink interface OnUpdate and groundtruth data independent of IMU Message

### DIFF
--- a/include/gazebo_mavlink_interface.h
+++ b/include/gazebo_mavlink_interface.h
@@ -243,9 +243,11 @@ private:
   std::string baro_sub_topic_{kDefaultBarometerTopic};
   std::string wind_sub_topic_{kDefaultWindTopic};
 
-  std::mutex last_imu_message_mutex_ {};
-  std::condition_variable last_imu_message_cond_ {};
-  sensor_msgs::msgs::Imu last_imu_message_;
+  std::mutex imu_received_mutex_ {};
+  std::condition_variable imu_received_cond_ {};
+  bool imu_received_ {false};
+  bool imu_received_once_ {false};
+  int64_t last_imu_message_seq_{0};
   common::Time last_time_;
   common::Time last_imu_time_;
   common::Time last_actuator_time_;
@@ -267,8 +269,8 @@ private:
 
   bool enable_lockstep_{false};
   double speed_factor_{1.0};
-  int64_t previous_imu_seq_{0};
   unsigned update_skip_factor_{1};
+  uint64_t update_counter_{0u};
 
   bool hil_mode_{false};
   bool hil_state_level_{false};


### PR DESCRIPTION
In the current implementation of the gazebo_mavlink_interface, the OnUpdate function uses the imu sequence number to set the update intervall correctly. Furthermore, the imu data is used in the groundtruth data calculation to get the orientation instead of the model rotation directly. Those dependencies can be avoided with the following PR:
- The update frequency can be handled with a counter instead of the Imu sequence number.
- Groundtruth data uses the rotation directly from the model pose instead of using the noisy imu message data.
- IMU data is stored directly in the mavlink_interface data instead of storing it locally in last_imu_mesage_received.

