### PR TITLE
Multi imu and mag support

### DIFF
--- a/include/gazebo_imu_plugin.h
+++ b/include/gazebo_imu_plugin.h
@@ -55,8 +55,6 @@ static constexpr double kDefaultAdisAccelerometerTurnOnBiasSigma =
 // Earth's gravity in Zurich (lat=+47.3667degN, lon=+8.5500degE, h=+500m, WGS84)
 static constexpr double kDefaultGravityMagnitude = 9.8068;
 
-static const std::string kDefaultImuTopic = "imu";
-
 // A description of the parameters:
 // https://github.com/ethz-asl/kalibr/wiki/IMU-Noise-Model-and-Intrinsics
 // TODO(burrimi): Should I have a minimalistic description of the params here?
@@ -95,7 +93,7 @@ struct ImuParameters {
         gravity_magnitude(kDefaultGravityMagnitude) {}
 };
 
-class GazeboImuPlugin : public ModelPlugin {
+class GazeboImuPlugin : public SensorPlugin {
  public:
 
   GazeboImuPlugin();
@@ -105,7 +103,7 @@ class GazeboImuPlugin : public ModelPlugin {
   void Publish();
 
  protected:
-  void Load(physics::ModelPtr _model, sdf::ElementPtr _sdf);
+  void Load(sensors::SensorPtr _parent, sdf::ElementPtr _sdf);
 
   void addNoise(
       Eigen::Vector3d* linear_acceleration,

--- a/include/gazebo_magnetometer_plugin.h
+++ b/include/gazebo_magnetometer_plugin.h
@@ -58,13 +58,15 @@
 
 #include <ignition/math.hh>
 
+#include <gazebo/sensors/SensorTypes.hh>
+#include <gazebo/sensors/MagnetometerSensor.hh>
+
 #include <common.h>
 
 #include <geo_mag_declination.h>
 
 namespace gazebo {
 
-static constexpr auto kDefaultMagnetometerTopic = "mag";
 static constexpr auto kDefaultPubRate = 100.0; // [Hz]. Note: corresponds to most of the mag devices supported in PX4
 
 // Default values for use with ADIS16448 IMU
@@ -74,13 +76,13 @@ static constexpr auto kDefaultBiasCorrelationTime = 6.0e+2; // [s]
 
 typedef const boost::shared_ptr<const sensor_msgs::msgs::Groundtruth> GtPtr;
 
-class MagnetometerPlugin : public ModelPlugin {
+class MagnetometerPlugin : public SensorPlugin {
 public:
   MagnetometerPlugin();
   virtual ~MagnetometerPlugin();
 
 protected:
-  virtual void Load(physics::ModelPtr _model, sdf::ElementPtr _sdf);
+  virtual void Load(sensors::SensorPtr _parent, sdf::ElementPtr _sdf);
   virtual void OnUpdate(const common::UpdateInfo&);
   void addNoise(Eigen::Vector3d* magnetic_field, const double dt);
   void GroundtruthCallback(GtPtr&);
@@ -88,8 +90,12 @@ protected:
 
 private:
   std::string namespace_;
+  sensors::MagnetometerSensorPtr parentSensor_;
+  std::string model_name_;
   physics::ModelPtr model_;
   physics::WorldPtr world_;
+  physics::LinkPtr link_;
+
   std::string mag_topic_;
   transport::NodePtr node_handle_;
   transport::PublisherPtr pub_mag_;

--- a/include/gazebo_mavlink_interface.h
+++ b/include/gazebo_mavlink_interface.h
@@ -78,6 +78,7 @@ static const std::regex kDefaultLidarModelNaming(".*(lidar|sf10a)(.*)");
 static const std::regex kDefaultSonarModelNaming(".*(sonar|mb1240-xl-ez4)(.*)");
 static const std::regex kDefaultGPSModelNaming(".*(gps|ublox-neo-7M)(.*)");
 static const std::regex kDefaultAirspeedModelJointNaming(".*(airspeed)(.*_joint)");
+static const std::regex kDefaultImuModelJointNaming(".*(imu)(\\d*_joint)");
 
 namespace gazebo {
 
@@ -171,7 +172,7 @@ private:
   event::ConnectionPtr updateConnection_;
   event::ConnectionPtr sigIntConnection_;
 
-  void ImuCallback(ImuPtr& imu_msg);
+  void ImuCallback(ImuPtr& imu_msg, const int& id);
   void GpsCallback(GpsPtr& gps_msg, const int& id);
   void GroundtruthCallback(GtPtr& groundtruth_msg);
   void LidarCallback(LidarPtr& lidar_msg, const int& id);

--- a/include/gazebo_mavlink_interface.h
+++ b/include/gazebo_mavlink_interface.h
@@ -79,6 +79,7 @@ static const std::regex kDefaultSonarModelNaming(".*(sonar|mb1240-xl-ez4)(.*)");
 static const std::regex kDefaultGPSModelNaming(".*(gps|ublox-neo-7M)(.*)");
 static const std::regex kDefaultAirspeedModelJointNaming(".*(airspeed)(.*_joint)");
 static const std::regex kDefaultImuModelJointNaming(".*(imu)(\\d*_joint)");
+static const std::regex kDefaultMagModelJointNaming(".*(mag)(\\d*_joint)");
 
 namespace gazebo {
 
@@ -181,7 +182,7 @@ private:
   void OpticalFlowCallback(OpticalFlowPtr& opticalFlow_msg);
   void IRLockCallback(IRLockPtr& irlock_msg);
   void VisionCallback(OdomPtr& odom_msg);
-  void MagnetometerCallback(MagnetometerPtr& mag_msg);
+  void MagnetometerCallback(MagnetometerPtr& mag_msg, const int& i);
   void BarometerCallback(BarometerPtr& baro_msg);
   void WindVelocityCallback(WindPtr& msg);
   void SendSensorMessages();

--- a/models/believer/believer.sdf
+++ b/models/believer/believer.sdf
@@ -50,23 +50,13 @@
       <velocity_decay/>
       <self_collide>0</self_collide>
     </link>
-    <link name='imu_link'>
+    <include>
+      <uri>model://imu</uri>
       <pose>0 0 0 0 0 0</pose>
-      <inertial>
-        <pose>0 0 0 0 0 0</pose>
-        <mass>0.015</mass>
-        <inertia>
-          <ixx>1e-05</ixx>
-          <ixy>0</ixy>
-          <ixz>0</ixz>
-          <iyy>1e-05</iyy>
-          <iyz>0</iyz>
-          <izz>1e-05</izz>
-        </inertia>
-      </inertial>
-    </link>
+      <name>imu</name>
+    </include>
     <joint name='imu_joint' type='revolute'>
-      <child>imu_link</child>
+      <child>imu::link</child>
       <parent>base_link</parent>
       <axis>
         <xyz>1 0 0</xyz>
@@ -562,19 +552,6 @@
       <rotorVelocitySlowdownSim>10</rotorVelocitySlowdownSim>
       <robotNamespace></robotNamespace>
       <windSubTopic>world_wind</windSubTopic>
-    </plugin>
-    <plugin name='gazebo_imu_plugin' filename='libgazebo_imu_plugin.so'>
-      <robotNamespace></robotNamespace>
-      <linkName>imu_link</linkName>
-      <imuTopic>/imu</imuTopic>
-      <gyroscopeNoiseDensity>0.0003394</gyroscopeNoiseDensity>
-      <gyroscopeRandomWalk>3.8785e-05</gyroscopeRandomWalk>
-      <gyroscopeBiasCorrelationTime>1000.0</gyroscopeBiasCorrelationTime>
-      <gyroscopeTurnOnBiasSigma>0.0087</gyroscopeTurnOnBiasSigma>
-      <accelerometerNoiseDensity>0.004</accelerometerNoiseDensity>
-      <accelerometerRandomWalk>0.006</accelerometerRandomWalk>
-      <accelerometerBiasCorrelationTime>300.0</accelerometerBiasCorrelationTime>
-      <accelerometerTurnOnBiasSigma>0.196</accelerometerTurnOnBiasSigma>
     </plugin>
     <plugin name='groundtruth_plugin' filename='libgazebo_groundtruth_plugin.so'>
       <robotNamespace/>

--- a/models/believer/believer.sdf
+++ b/models/believer/believer.sdf
@@ -82,6 +82,15 @@
       <child>airspeed::link</child>
       <parent>base_link</parent>
     </joint>
+    <include>
+      <uri>model://magnetometer</uri>
+      <pose>0 0 0 0 0 0</pose>
+      <name>mag</name>
+    </include>
+    <joint name='mag_joint' type='fixed'>
+      <child>mag::link</child>
+      <parent>base_link</parent>
+    </joint>
     <link name='rotor_right'>
       <pose>0.05 -0.25 0.05 0 1.57 0</pose>
       <inertial>
@@ -555,14 +564,6 @@
     </plugin>
     <plugin name='groundtruth_plugin' filename='libgazebo_groundtruth_plugin.so'>
       <robotNamespace/>
-    </plugin>
-    <plugin name='magnetometer_plugin' filename='libgazebo_magnetometer_plugin.so'>
-      <robotNamespace/>
-      <pubRate>100</pubRate>
-      <noiseDensity>0.0004</noiseDensity>
-      <randomWalk>6.4e-06</randomWalk>
-      <biasCorrelationTime>600</biasCorrelationTime>
-      <magTopic>/mag</magTopic>
     </plugin>
     <plugin name='barometer_plugin' filename='libgazebo_barometer_plugin.so'>
       <robotNamespace/>

--- a/models/boat/boat.sdf.jinja
+++ b/models/boat/boat.sdf.jinja
@@ -394,21 +394,11 @@
         </geometry>
       </visual>
     </link>
-    <link name='boat/imu_link'>
+    <include>
+      <uri>model://imu</uri>
       <pose>0 0 0 0 0 0</pose>
-      <inertial>
-        <pose>0 0 0 0 0 0</pose>
-        <mass>0.015</mass>
-        <inertia>
-          <ixx>1e-05</ixx>
-          <ixy>0</ixy>
-          <ixz>0</ixz>
-          <iyy>1e-05</iyy>
-          <iyz>0</iyz>
-          <izz>1e-05</izz>
-        </inertia>
-      </inertial>
-    </link>
+      <name>imu</name>
+    </include>
     <joint name='right_engine_propeller_joint' type='revolute'>
       <child>right_propeller_link</child>
       <parent>base_link</parent>
@@ -427,8 +417,8 @@
         <use_parent_model_frame>1</use_parent_model_frame>
       </axis>
     </joint>
-    <joint name='boat/imu_joint' type='revolute'>
-      <child>boat/imu_link</child>
+    <joint name='imu_joint' type='revolute'>
+      <child>imu::link</child>
       <parent>base_link</parent>
       <axis>
         <xyz>1 0 0</xyz>
@@ -454,19 +444,6 @@
       <child>gps::link</child>
       <parent>base_link</parent>
     </joint>
-    <plugin name='gazebo_imu_plugin' filename='libgazebo_imu_plugin.so'>
-      <robotNamespace></robotNamespace>
-      <linkName>boat/imu_link</linkName>
-      <imuTopic>/imu</imuTopic>
-      <gyroscopeNoiseDensity>0.0003394</gyroscopeNoiseDensity>
-      <gyroscopeRandomWalk>3.8785e-05</gyroscopeRandomWalk>
-      <gyroscopeBiasCorrelationTime>1000.0</gyroscopeBiasCorrelationTime>
-      <gyroscopeTurnOnBiasSigma>0.0087</gyroscopeTurnOnBiasSigma>
-      <accelerometerNoiseDensity>0.004</accelerometerNoiseDensity>
-      <accelerometerRandomWalk>0.006</accelerometerRandomWalk>
-      <accelerometerBiasCorrelationTime>300.0</accelerometerBiasCorrelationTime>
-      <accelerometerTurnOnBiasSigma>0.196</accelerometerTurnOnBiasSigma>
-    </plugin>
     <plugin name='magnetometer_plugin' filename='libgazebo_magnetometer_plugin.so'>
       <robotNamespace/>
       <pubRate>100</pubRate>

--- a/models/boat/boat.sdf.jinja
+++ b/models/boat/boat.sdf.jinja
@@ -444,13 +444,15 @@
       <child>gps::link</child>
       <parent>base_link</parent>
     </joint>
-    <plugin name='magnetometer_plugin' filename='libgazebo_magnetometer_plugin.so'>
-      <robotNamespace/>
-      <pubRate>100</pubRate>
-      <noiseDensity>0.0004</noiseDensity>
-      <randomWalk>6.4e-06</randomWalk>
-      <biasCorrelationTime>600</biasCorrelationTime>
-      <magTopic>/mag</magTopic>
+    <include>
+      <uri>model://magnetometer</uri>
+      <pose>0 0 0 0 0 0</pose>
+      <name>mag</name>
+    </include>
+    <joint name='mag_joint' type='fixed'>
+      <child>mag::link</child>
+      <parent>base_link</parent>
+    </joint>
     </plugin>
     <plugin name='barometer_plugin' filename='libgazebo_barometer_plugin.so'>
       <robotNamespace/>

--- a/models/cloudship/cloudship.sdf.jinja
+++ b/models/cloudship/cloudship.sdf.jinja
@@ -495,19 +495,15 @@
     </plugin>
 
     {# IMU #}
-    <plugin name='gazebo_imu_plugin' filename='libgazebo_imu_plugin.so'>
-      <robotNamespace/>
-      <linkName>hull</linkName>
-      <imuTopic>/imu</imuTopic>
-      <gyroscopeNoiseDensity>0.0003394</gyroscopeNoiseDensity>
-      <gyroscopeRandomWalk>3.8785e-05</gyroscopeRandomWalk>
-      <gyroscopeBiasCorrelationTime>1000.0</gyroscopeBiasCorrelationTime>
-      <gyroscopeTurnOnBiasSigma>0.0087</gyroscopeTurnOnBiasSigma>
-      <accelerometerNoiseDensity>0.004</accelerometerNoiseDensity>
-      <accelerometerRandomWalk>0.006</accelerometerRandomWalk>
-      <accelerometerBiasCorrelationTime>300.0</accelerometerBiasCorrelationTime>
-      <accelerometerTurnOnBiasSigma>0.196</accelerometerTurnOnBiasSigma>
-    </plugin>
+    <include>
+      <uri>model://imu</uri>
+      <pose>0 0 0 0 0 0</pose>
+      <name>imu</name>
+    </include>
+    <joint name='imu_joint' type='fixed'>
+      <child>imu::link</child>
+      <parent>hull</parent>
+    </joint>
 
     {# Magnetometer #}
     <plugin name='magnetometer_plugin' filename='libgazebo_magnetometer_plugin.so'>

--- a/models/cloudship/cloudship.sdf.jinja
+++ b/models/cloudship/cloudship.sdf.jinja
@@ -383,7 +383,7 @@
         </geometry>
       </collision>
     </link>
-    
+
     {# GPS joint which includes GPS plugin #}
     <include>
       <uri>model://gps</uri>
@@ -506,14 +506,15 @@
     </joint>
 
     {# Magnetometer #}
-    <plugin name='magnetometer_plugin' filename='libgazebo_magnetometer_plugin.so'>
-      <robotNamespace/>
-      <pubRate>20</pubRate>
-      <noiseDensity>0.0004</noiseDensity>
-      <randomWalk>6.4e-06</randomWalk>
-      <biasCorrelationTime>600</biasCorrelationTime>
-      <magTopic>/mag</magTopic>
-    </plugin>
+    <include>
+      <uri>model://magnetometer</uri>
+      <pose>0 0 0 0 0 0</pose>
+      <name>mag</name>
+    </include>
+    <joint name='mag_joint' type='fixed'>
+      <child>mag::link</child>
+      <parent>hull</parent>
+    </joint>
 
     {# Barometer #}
     <plugin name='barometer_plugin' filename='libgazebo_barometer_plugin.so'>

--- a/models/delta_wing/delta_wing.sdf
+++ b/models/delta_wing/delta_wing.sdf
@@ -236,16 +236,17 @@
       <child>gps::link</child>
       <parent>base_link</parent>
     </joint>
+    <include>
+      <uri>model://magnetometer</uri>
+      <pose>0 0 0 0 0 0</pose>
+      <name>mag</name>
+    </include>
+    <joint name='mag_joint' type='fixed'>
+      <child>mag::link</child>
+      <parent>base_link</parent>
+    </joint>
     <plugin name='groundtruth_plugin' filename='libgazebo_groundtruth_plugin.so'>
       <robotNamespace/>
-    </plugin>
-    <plugin name='magnetometer_plugin' filename='libgazebo_magnetometer_plugin.so'>
-      <robotNamespace/>
-      <pubRate>100</pubRate>
-      <noiseDensity>0.0004</noiseDensity>
-      <randomWalk>6.4e-06</randomWalk>
-      <biasCorrelationTime>600</biasCorrelationTime>
-      <magTopic>/mag</magTopic>
     </plugin>
     <plugin name='barometer_plugin' filename='libgazebo_barometer_plugin.so'>
       <robotNamespace/>

--- a/models/delta_wing/delta_wing.sdf
+++ b/models/delta_wing/delta_wing.sdf
@@ -126,23 +126,13 @@
       </axis>
     </joint>
 
-    <link name='delta_wing/imu_link'>
-      <pose>0 0 0.2 0 0 -1.5707</pose>
-      <inertial>
-        <pose>0 0 0 0 0 0</pose>
-        <mass>0.15</mass>
-        <inertia>
-          <ixx>1e-04</ixx>
-          <ixy>0</ixy>
-          <ixz>0</ixz>
-          <iyy>1e-04</iyy>
-          <iyz>0</iyz>
-          <izz>1e-04</izz>
-        </inertia>
-      </inertial>
-    </link>
-    <joint name='delta_wing/imu_joint' type='revolute'>
-      <child>delta_wing/imu_link</child>
+    <include>
+      <uri>model://imu</uri>
+      <pose>0 0 0 0 0 0</pose>
+      <name>imu</name>
+    </include>
+    <joint name='imu_joint' type='revolute'>
+      <child>imu::link</child>
       <parent>zephyr_delta_wing::wing</parent>
       <axis>
         <xyz>0 0 1</xyz>
@@ -246,19 +236,6 @@
       <child>gps::link</child>
       <parent>base_link</parent>
     </joint>
-    <plugin name='gazebo_imu_plugin' filename='libgazebo_imu_plugin.so'>
-      <robotNamespace>delta_wing</robotNamespace>
-      <linkName>delta_wing/imu_link</linkName>
-      <imuTopic>/imu</imuTopic>
-      <gyroscopeNoiseDensity>0.0003394</gyroscopeNoiseDensity>
-      <gyroscopeRandomWalk>3.8785e-05</gyroscopeRandomWalk>
-      <gyroscopeBiasCorrelationTime>1000.0</gyroscopeBiasCorrelationTime>
-      <gyroscopeTurnOnBiasSigma>0.0087</gyroscopeTurnOnBiasSigma>
-      <accelerometerNoiseDensity>0.004</accelerometerNoiseDensity>
-      <accelerometerRandomWalk>0.006</accelerometerRandomWalk>
-      <accelerometerBiasCorrelationTime>300.0</accelerometerBiasCorrelationTime>
-      <accelerometerTurnOnBiasSigma>0.196</accelerometerTurnOnBiasSigma>
-    </plugin>
     <plugin name='groundtruth_plugin' filename='libgazebo_groundtruth_plugin.so'>
       <robotNamespace/>
     </plugin>

--- a/models/glider/glider.sdf
+++ b/models/glider/glider.sdf
@@ -54,23 +54,13 @@
       <velocity_decay/>
       <self_collide>0</self_collide>
     </link>
-    <link name='plane/imu_link'>
+    <include>
+      <uri>model://imu</uri>
       <pose>0 0 0 0 0 0</pose>
-      <inertial>
-        <pose>0 0 0 0 0 0</pose>
-        <mass>0.015</mass>
-        <inertia>
-          <ixx>1e-05</ixx>
-          <ixy>0</ixy>
-          <ixz>0</ixz>
-          <iyy>1e-05</iyy>
-          <iyz>0</iyz>
-          <izz>1e-05</izz>
-        </inertia>
-      </inertial>
-    </link>
-    <joint name='plane/imu_joint' type='revolute'>
-      <child>plane/imu_link</child>
+      <name>imu</name>
+    </include>
+    <joint name='imu_joint' type='revolute'>
+      <child>imu::link</child>
       <parent>base_link</parent>
       <axis>
         <xyz>1 0 0</xyz>
@@ -546,19 +536,6 @@
       <control_joint_rad_to_cl>4.0</control_joint_rad_to_cl>
       <robotNamespace></robotNamespace>
       <windSubTopic>world_wind</windSubTopic>
-    </plugin>
-    <plugin name='gazebo_imu_plugin' filename='libgazebo_imu_plugin.so'>
-      <robotNamespace></robotNamespace>
-      <linkName>plane/imu_link</linkName>
-      <imuTopic>/imu</imuTopic>
-      <gyroscopeNoiseDensity>0.0003394</gyroscopeNoiseDensity>
-      <gyroscopeRandomWalk>3.8785e-05</gyroscopeRandomWalk>
-      <gyroscopeBiasCorrelationTime>1000.0</gyroscopeBiasCorrelationTime>
-      <gyroscopeTurnOnBiasSigma>0.0087</gyroscopeTurnOnBiasSigma>
-      <accelerometerNoiseDensity>0.004</accelerometerNoiseDensity>
-      <accelerometerRandomWalk>0.006</accelerometerRandomWalk>
-      <accelerometerBiasCorrelationTime>300.0</accelerometerBiasCorrelationTime>
-      <accelerometerTurnOnBiasSigma>0.196</accelerometerTurnOnBiasSigma>
     </plugin>
     <plugin name='groundtruth_plugin' filename='libgazebo_groundtruth_plugin.so'>
       <robotNamespace/>

--- a/models/glider/glider.sdf
+++ b/models/glider/glider.sdf
@@ -86,6 +86,15 @@
       <child>airspeed::link</child>
       <parent>base_link</parent>
     </joint>
+    <include>
+      <uri>model://magnetometer</uri>
+      <pose>0 0 0 0 0 0</pose>
+      <name>mag</name>
+    </include>
+    <joint name='mag_joint' type='fixed'>
+      <child>mag::link</child>
+      <parent>base_link</parent>
+    </joint>
     <link name="left_elevon">
       <inertial>
         <mass>0.00000001</mass>
@@ -530,23 +539,15 @@
       <forward>1 0 0</forward>
       <upward>0 1 0</upward>
       <link_name>base_link</link_name>
-      <control_joint_name> 
-         rudder_joint 
-      </control_joint_name> 
+      <control_joint_name>
+         rudder_joint
+      </control_joint_name>
       <control_joint_rad_to_cl>4.0</control_joint_rad_to_cl>
       <robotNamespace></robotNamespace>
       <windSubTopic>world_wind</windSubTopic>
     </plugin>
     <plugin name='groundtruth_plugin' filename='libgazebo_groundtruth_plugin.so'>
       <robotNamespace/>
-    </plugin>
-    <plugin name='magnetometer_plugin' filename='libgazebo_magnetometer_plugin.so'>
-      <robotNamespace/>
-      <pubRate>100</pubRate>
-      <noiseDensity>0.0004</noiseDensity>
-      <randomWalk>6.4e-06</randomWalk>
-      <biasCorrelationTime>600</biasCorrelationTime>
-      <magTopic>/mag</magTopic>
     </plugin>
     <plugin name='barometer_plugin' filename='libgazebo_barometer_plugin.so'>
       <robotNamespace/>

--- a/models/imu/imu.sdf
+++ b/models/imu/imu.sdf
@@ -1,0 +1,49 @@
+<?xml version="1.0" ?>
+<sdf version="1.7">
+  <model name="imu">
+    <pose>0 0 0 0 0 0</pose>
+    <link name="link">
+      <inertial>
+        <mass>0.015</mass>
+        <inertia>
+          <ixx>1e-05</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>1e-05</iyy>
+          <iyz>0</iyz>
+          <izz>1e-05</izz>
+        </inertia>
+      </inertial>
+      <visual name="visual">
+        <geometry>
+          <cylinder>
+            <radius>0.01</radius>
+            <length>0.1</length>
+          </cylinder>
+        </geometry>
+        <material>
+          <script>
+            <name>Gazebo/Black</name>
+          </script>
+        </material>
+      </visual>
+      <sensor name="imu" type="imu">
+        <pose>0 0 0 0 0 0</pose>
+        <always_on>true</always_on>
+        <visualize>false</visualize>
+        <plugin name='gazebo_imu_plugin' filename='libgazebo_imu_plugin.so'>
+          <robotNamespace></robotNamespace>
+          <linkName>standard_vtol/imu_link</linkName>
+          <gyroscopeNoiseDensity>0.0003394</gyroscopeNoiseDensity>
+          <gyroscopeRandomWalk>3.8785e-05</gyroscopeRandomWalk>
+          <gyroscopeBiasCorrelationTime>1000.0</gyroscopeBiasCorrelationTime>
+          <gyroscopeTurnOnBiasSigma>0.0087</gyroscopeTurnOnBiasSigma>
+          <accelerometerNoiseDensity>0.004</accelerometerNoiseDensity>
+          <accelerometerRandomWalk>0.006</accelerometerRandomWalk>
+          <accelerometerBiasCorrelationTime>300.0</accelerometerBiasCorrelationTime>
+          <accelerometerTurnOnBiasSigma>0.196</accelerometerTurnOnBiasSigma>
+        </plugin>
+      </sensor>
+    </link>
+  </model>
+</sdf>

--- a/models/imu/model.config
+++ b/models/imu/model.config
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+
+<model>
+  <name>IMU</name>
+  <version>1.0</version>
+  <sdf version='1.7'>imu.sdf</sdf>
+
+  <description>
+    Common IMU model.
+  </description>
+</model>

--- a/models/iris/iris.sdf.jinja
+++ b/models/iris/iris.sdf.jinja
@@ -52,23 +52,13 @@
       <gravity>1</gravity>
       <velocity_decay/>
     </link>
-    <link name='/imu_link'>
+    <include>
+      <uri>model://imu</uri>
       <pose>0 0 0 0 0 0</pose>
-      <inertial>
-        <pose>0 0 0 0 0 0</pose>
-        <mass>0.015</mass>
-        <inertia>
-          <ixx>1e-05</ixx>
-          <ixy>0</ixy>
-          <ixz>0</ixz>
-          <iyy>1e-05</iyy>
-          <iyz>0</iyz>
-          <izz>1e-05</izz>
-        </inertia>
-      </inertial>
-    </link>
-    <joint name='/imu_joint' type='revolute'>
-      <child>/imu_link</child>
+      <name>imu</name>
+    </include>
+    <joint name='imu_joint' type='revolute'>
+      <child>imu::link</child>
       <parent>base_link</parent>
       <axis>
         <xyz>1 0 0</xyz>
@@ -564,18 +554,5 @@
       </control_channels>
     </plugin>
     <static>0</static>
-    <plugin name='rotors_gazebo_imu_plugin' filename='libgazebo_imu_plugin.so'>
-      <robotNamespace/>
-      <linkName>/imu_link</linkName>
-      <imuTopic>/imu</imuTopic>
-      <gyroscopeNoiseDensity>0.00018665</gyroscopeNoiseDensity>
-      <gyroscopeRandomWalk>3.8785e-05</gyroscopeRandomWalk>
-      <gyroscopeBiasCorrelationTime>1000.0</gyroscopeBiasCorrelationTime>
-      <gyroscopeTurnOnBiasSigma>0.0087</gyroscopeTurnOnBiasSigma>
-      <accelerometerNoiseDensity>0.00186</accelerometerNoiseDensity>
-      <accelerometerRandomWalk>0.006</accelerometerRandomWalk>
-      <accelerometerBiasCorrelationTime>300.0</accelerometerBiasCorrelationTime>
-      <accelerometerTurnOnBiasSigma>0.196</accelerometerTurnOnBiasSigma>
-    </plugin>
   </model>
 </sdf>

--- a/models/iris/iris.sdf.jinja
+++ b/models/iris/iris.sdf.jinja
@@ -417,16 +417,17 @@
       <child>gps0::link</child>
       <parent>base_link</parent>
     </joint>
+    <include>
+      <uri>model://magnetometer</uri>
+      <pose>0 0 0 0 0 0</pose>
+      <name>mag</name>
+    </include>
+    <joint name='mag_joint' type='fixed'>
+      <child>mag::link</child>
+      <parent>base_link</parent>
+    </joint>
     <plugin name='groundtruth_plugin' filename='libgazebo_groundtruth_plugin.so'>
       <robotNamespace/>
-    </plugin>
-    <plugin name='magnetometer_plugin' filename='libgazebo_magnetometer_plugin.so'>
-      <robotNamespace/>
-      <pubRate>100</pubRate>
-      <noiseDensity>0.0004</noiseDensity>
-      <randomWalk>6.4e-06</randomWalk>
-      <biasCorrelationTime>600</biasCorrelationTime>
-      <magTopic>/mag</magTopic>
     </plugin>
     <plugin name='barometer_plugin' filename='libgazebo_barometer_plugin.so'>
       <robotNamespace/>

--- a/models/iris_hitl/iris_hitl.sdf
+++ b/models/iris_hitl/iris_hitl.sdf
@@ -456,16 +456,17 @@
       <parent>base_link</parent>
       <child>gps0::link</child>
     </joint>
+    <include>
+      <uri>model://magnetometer</uri>
+      <pose>0 0 0 0 0 0</pose>
+      <name>mag</name>
+    </include>
+    <joint name='mag_joint' type='fixed'>
+      <child>mag::link</child>
+      <parent>base_link</parent>
+    </joint>
     <plugin name='groundtruth_plugin' filename='libgazebo_groundtruth_plugin.so'>
       <robotNamespace/>
-    </plugin>
-    <plugin name='magnetometer_plugin' filename='libgazebo_magnetometer_plugin.so'>
-      <robotNamespace/>
-      <pubRate>100</pubRate>
-      <noiseDensity>0.0004</noiseDensity>
-      <randomWalk>6.4e-06</randomWalk>
-      <biasCorrelationTime>600</biasCorrelationTime>
-      <magTopic>/mag</magTopic>
     </plugin>
     <plugin name='barometer_plugin' filename='libgazebo_barometer_plugin.so'>
       <robotNamespace/>

--- a/models/iris_hitl/iris_hitl.sdf
+++ b/models/iris_hitl/iris_hitl.sdf
@@ -52,23 +52,13 @@
       <gravity>1</gravity>
       <velocity_decay/>
     </link>
-    <link name='/imu_link'>
+    <include>
+      <uri>model://imu</uri>
       <pose>0 0 0 0 0 0</pose>
-      <inertial>
-        <pose>0 0 0 0 0 0</pose>
-        <mass>0.015</mass>
-        <inertia>
-          <ixx>1e-05</ixx>
-          <ixy>0</ixy>
-          <ixz>0</ixz>
-          <iyy>1e-05</iyy>
-          <iyz>0</iyz>
-          <izz>1e-05</izz>
-        </inertia>
-      </inertial>
-    </link>
-    <joint name='/imu_joint' type='revolute'>
-      <child>/imu_link</child>
+      <name>imu</name>
+    </include>
+    <joint name='imu_joint' type='revolute'>
+      <child>imu::link</child>
       <parent>base_link</parent>
       <axis>
         <xyz>1 0 0</xyz>
@@ -603,18 +593,5 @@
       </control_channels>
     </plugin>
     <static>0</static>
-    <plugin name='rotors_gazebo_imu_plugin' filename='libgazebo_imu_plugin.so'>
-      <robotNamespace/>
-      <linkName>/imu_link</linkName>
-      <imuTopic>/imu</imuTopic>
-      <gyroscopeNoiseDensity>0.00018665</gyroscopeNoiseDensity>
-      <gyroscopeRandomWalk>3.8785e-05</gyroscopeRandomWalk>
-      <gyroscopeBiasCorrelationTime>1000.0</gyroscopeBiasCorrelationTime>
-      <gyroscopeTurnOnBiasSigma>0.0087</gyroscopeTurnOnBiasSigma>
-      <accelerometerNoiseDensity>0.00186</accelerometerNoiseDensity>
-      <accelerometerRandomWalk>0.006</accelerometerRandomWalk>
-      <accelerometerBiasCorrelationTime>300.0</accelerometerBiasCorrelationTime>
-      <accelerometerTurnOnBiasSigma>0.196</accelerometerTurnOnBiasSigma>
-    </plugin>
   </model>
 </sdf>

--- a/models/magnetometer/magnetometer.sdf
+++ b/models/magnetometer/magnetometer.sdf
@@ -1,0 +1,44 @@
+<?xml version="1.0" ?>
+<sdf version="1.5">
+  <model name="magnetometer">
+    <pose>0 0 0 0 0 0</pose>
+    <link name="link">
+      <inertial>
+        <mass>0.001</mass>
+        <inertia>
+          <ixx>1e-07</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>1e-07</iyy>
+          <iyz>0</iyz>
+          <izz>1e-07</izz>
+        </inertia>
+      </inertial>
+      <visual name="visual">
+        <geometry>
+          <cylinder>
+            <radius>0.01</radius>
+            <length>0.1</length>
+          </cylinder>
+        </geometry>
+        <material>
+          <script>
+            <name>Gazebo/Black</name>
+          </script>
+        </material>
+      </visual>
+      <sensor name="magnetometer" type="magnetometer">
+        <pose>0 0 0 0 0 0</pose>
+        <always_on>true</always_on>
+        <visualize>false</visualize>
+        <plugin name='magnetometer_plugin' filename='libgazebo_magnetometer_plugin.so'>
+          <robotNamespace/>
+          <pubRate>100</pubRate>
+          <noiseDensity>0.0004</noiseDensity>
+          <randomWalk>6.4e-06</randomWalk>
+          <biasCorrelationTime>600</biasCorrelationTime>
+        </plugin>
+      </sensor>
+    </link>
+  </model>
+</sdf>

--- a/models/magnetometer/model.config
+++ b/models/magnetometer/model.config
@@ -1,0 +1,9 @@
+<model>
+  <name>Magnetometer</name>
+  <version>1.0</version>
+  <sdf version="1.5">magnetometer.sdf</sdf>
+
+  <description>
+    Common magnetometer model.
+  </description>
+</model>

--- a/models/matrice_100/matrice_100.sdf.jinja
+++ b/models/matrice_100/matrice_100.sdf.jinja
@@ -277,14 +277,15 @@
       <robotNamespace/>
     </plugin>
 
-    <plugin name='magnetometer_plugin' filename='libgazebo_magnetometer_plugin.so'>
-        <robotNamespace/>
-        <pubRate>100</pubRate>
-        <noiseDensity>0.0004</noiseDensity>
-        <randomWalk>6.4e-06</randomWalk>
-        <biasCorrelationTime>600</biasCorrelationTime>
-        <magTopic>/mag</magTopic>
-    </plugin>
+    <include>
+      <uri>model://magnetometer</uri>
+      <pose>0 0 0 0 0 0</pose>
+      <name>mag</name>
+    </include>
+    <joint name='mag_joint' type='fixed'>
+      <child>mag::link</child>
+      <parent>fuselage</parent>
+    </joint>
 
     <plugin name='barometer_plugin' filename='libgazebo_barometer_plugin.so'>
       <robotNamespace/>

--- a/models/matrice_100/matrice_100.sdf.jinja
+++ b/models/matrice_100/matrice_100.sdf.jinja
@@ -312,19 +312,15 @@
       <motorSpeedCommandPubTopic>/gazebo/command/motor_speed</motorSpeedCommandPubTopic>
     </plugin>
 
-    <plugin name='gazebo_imu_plugin' filename='libgazebo_imu_plugin.so'>
-      <robotNamespace></robotNamespace>
-      <linkName>fuselage</linkName>
-      <imuTopic>/imu</imuTopic>
-      <gyroscopeNoiseDensity>0.0003394</gyroscopeNoiseDensity>
-      <gyroscopeRandomWalk>3.8785e-05</gyroscopeRandomWalk>
-      <gyroscopeBiasCorrelationTime>1000.0</gyroscopeBiasCorrelationTime>
-      <gyroscopeTurnOnBiasSigma>0.0087</gyroscopeTurnOnBiasSigma>
-      <accelerometerNoiseDensity>0.004</accelerometerNoiseDensity>
-      <accelerometerRandomWalk>0.006</accelerometerRandomWalk>
-      <accelerometerBiasCorrelationTime>300.0</accelerometerBiasCorrelationTime>
-      <accelerometerTurnOnBiasSigma>0.196</accelerometerTurnOnBiasSigma>
-    </plugin>
+    <include>
+      <uri>model://imu</uri>
+      <pose>0 0 0 0 0 0</pose>
+      <name>imu</name>
+    </include>
+    <joint name='imu_joint' type='fixed'>
+      <child>imu::link</child>
+      <parent>fuselage</parent>
+    </joint>
 
   </model>
 

--- a/models/omnicopter/omnicopter.sdf
+++ b/models/omnicopter/omnicopter.sdf
@@ -51,23 +51,13 @@
       <gravity>1</gravity>
       <velocity_decay/>
     </link>
-    <link name='/imu_link'>
-      <pose frame=''>0 0 0 0 -0 0</pose>
-      <inertial>
-        <pose frame=''>0 0 0 0 -0 0</pose>
-        <mass>0.015</mass>
-        <inertia>
-          <ixx>1e-05</ixx>
-          <ixy>0</ixy>
-          <ixz>0</ixz>
-          <iyy>1e-05</iyy>
-          <iyz>0</iyz>
-          <izz>1e-05</izz>
-        </inertia>
-      </inertial>
-    </link>
-    <joint name='/imu_joint' type='revolute'>
-      <child>/imu_link</child>
+    <include>
+      <uri>model://imu</uri>
+      <pose>0 0 0 0 0 0</pose>
+      <name>imu</name>
+    </include>
+    <joint name='imu_joint' type='revolute'>
+      <child>imu::link</child>
       <parent>base_link</parent>
       <axis>
         <xyz>1 0 0</xyz>
@@ -867,18 +857,5 @@
       </control_channels>
     </plugin>
     <static>0</static>
-    <plugin name='rotors_gazebo_imu_plugin' filename='libgazebo_imu_plugin.so'>
-      <robotNamespace/>
-      <linkName>/imu_link</linkName>
-      <imuTopic>/imu</imuTopic>
-      <gyroscopeNoiseDensity>0.00018665</gyroscopeNoiseDensity>
-      <gyroscopeRandomWalk>3.8785e-05</gyroscopeRandomWalk>
-      <gyroscopeBiasCorrelationTime>1000.0</gyroscopeBiasCorrelationTime>
-      <gyroscopeTurnOnBiasSigma>0.0087</gyroscopeTurnOnBiasSigma>
-      <accelerometerNoiseDensity>0.00186</accelerometerNoiseDensity>
-      <accelerometerRandomWalk>0.006</accelerometerRandomWalk>
-      <accelerometerBiasCorrelationTime>300.0</accelerometerBiasCorrelationTime>
-      <accelerometerTurnOnBiasSigma>0.196</accelerometerTurnOnBiasSigma>
-    </plugin>
   </model>
 </sdf>

--- a/models/omnicopter/omnicopter.sdf
+++ b/models/omnicopter/omnicopter.sdf
@@ -752,14 +752,15 @@
       <child>gps::link</child>
       <parent>base_link</parent>
     </joint>
-    <plugin name='magnetometer_plugin' filename='libgazebo_magnetometer_plugin.so'>
-      <robotNamespace/>
-      <pubRate>100</pubRate>
-      <noiseDensity>0.0004</noiseDensity>
-      <randomWalk>6.4e-06</randomWalk>
-      <biasCorrelationTime>600</biasCorrelationTime>
-      <magTopic>/mag</magTopic>
-    </plugin>
+    <include>
+      <uri>model://magnetometer</uri>
+      <pose>0 0 0 0 0 0</pose>
+      <name>mag</name>
+    </include>
+    <joint name='mag_joint' type='fixed'>
+      <child>mag::link</child>
+      <parent>base_link</parent>
+    </joint>
     <plugin name='barometer_plugin' filename='libgazebo_barometer_plugin.so'>
       <robotNamespace/>
       <pubRate>50</pubRate>

--- a/models/plane/plane.sdf.jinja
+++ b/models/plane/plane.sdf.jinja
@@ -470,6 +470,15 @@
       <child>gps::link</child>
       <parent>base_link</parent>
     </joint>
+    <include>
+      <uri>model://magnetometer</uri>
+      <pose>0 0 0 0 0 0</pose>
+      <name>mag</name>
+    </include>
+    <joint name='mag_joint' type='fixed'>
+      <child>mag::link</child>
+      <parent>base_link</parent>
+    </joint>
     <plugin name="left_wing" filename="libLiftDragPlugin.so">
       <a0>0.05984281113</a0>
       <cla>4.752798721</cla>
@@ -625,14 +634,6 @@
     </plugin>
     <plugin name='groundtruth_plugin' filename='libgazebo_groundtruth_plugin.so'>
       <robotNamespace/>
-    </plugin>
-    <plugin name='magnetometer_plugin' filename='libgazebo_magnetometer_plugin.so'>
-      <robotNamespace/>
-      <pubRate>100</pubRate>
-      <noiseDensity>0.0004</noiseDensity>
-      <randomWalk>6.4e-06</randomWalk>
-      <biasCorrelationTime>600</biasCorrelationTime>
-      <magTopic>/mag</magTopic>
     </plugin>
     <plugin name='barometer_plugin' filename='libgazebo_barometer_plugin.so'>
       <robotNamespace/>

--- a/models/plane/plane.sdf.jinja
+++ b/models/plane/plane.sdf.jinja
@@ -54,23 +54,13 @@
       <velocity_decay/>
       <self_collide>0</self_collide>
     </link>
-    <link name='plane/imu_link'>
+    <include>
+      <uri>model://imu</uri>
       <pose>0 0 0 0 0 0</pose>
-      <inertial>
-        <pose>0 0 0 0 0 0</pose>
-        <mass>0.015</mass>
-        <inertia>
-          <ixx>1e-05</ixx>
-          <ixy>0</ixy>
-          <ixz>0</ixz>
-          <iyy>1e-05</iyy>
-          <iyz>0</iyz>
-          <izz>1e-05</izz>
-        </inertia>
-      </inertial>
-    </link>
-    <joint name='plane/imu_joint' type='revolute'>
-      <child>plane/imu_link</child>
+      <name>imu</name>
+    </include>
+    <joint name='imu_joint' type='revolute'>
+      <child>imu::link</child>
       <parent>base_link</parent>
       <axis>
         <xyz>1 0 0</xyz>
@@ -736,18 +726,5 @@
       </control_channels>
     </plugin>
     <static>0</static>
-    <plugin name='gazebo_imu_plugin' filename='libgazebo_imu_plugin.so'>
-      <robotNamespace></robotNamespace>
-      <linkName>plane/imu_link</linkName>
-      <imuTopic>/imu</imuTopic>
-      <gyroscopeNoiseDensity>0.0003394</gyroscopeNoiseDensity>
-      <gyroscopeRandomWalk>3.8785e-05</gyroscopeRandomWalk>
-      <gyroscopeBiasCorrelationTime>1000.0</gyroscopeBiasCorrelationTime>
-      <gyroscopeTurnOnBiasSigma>0.0087</gyroscopeTurnOnBiasSigma>
-      <accelerometerNoiseDensity>0.004</accelerometerNoiseDensity>
-      <accelerometerRandomWalk>0.006</accelerometerRandomWalk>
-      <accelerometerBiasCorrelationTime>300.0</accelerometerBiasCorrelationTime>
-      <accelerometerTurnOnBiasSigma>0.196</accelerometerTurnOnBiasSigma>
-    </plugin>
   </model>
 </sdf>

--- a/models/px4vision/px4vision.sdf
+++ b/models/px4vision/px4vision.sdf
@@ -343,6 +343,15 @@
       <child>gps::link</child>
       <parent>base_link</parent>
     </joint>
+    <include>
+      <uri>model://magnetometer</uri>
+      <pose>0 0 0 0 0 0</pose>
+      <name>mag</name>
+    </include>
+    <joint name='mag_joint' type='fixed'>
+      <child>mag::link</child>
+      <parent>base_link</parent>
+    </joint>
     <plugin name='rosbag' filename='libgazebo_multirotor_base_plugin.so'>
       <robotNamespace/>
       <linkName>base_link</linkName>
@@ -418,14 +427,6 @@
     </plugin>
     <plugin name='groundtruth_plugin' filename='libgazebo_groundtruth_plugin.so'>
       <robotNamespace/>
-    </plugin>
-    <plugin name='magnetometer_plugin' filename='libgazebo_magnetometer_plugin.so'>
-      <robotNamespace/>
-      <pubRate>20</pubRate>
-      <noiseDensity>0.0004</noiseDensity>
-      <randomWalk>6.4e-06</randomWalk>
-      <biasCorrelationTime>600</biasCorrelationTime>
-      <magTopic>/mag</magTopic>
     </plugin>
     <plugin name='barometer_plugin' filename='libgazebo_barometer_plugin.so'>
       <robotNamespace/>

--- a/models/px4vision/px4vision.sdf
+++ b/models/px4vision/px4vision.sdf
@@ -51,23 +51,13 @@
       <gravity>1</gravity>
       <velocity_decay/>
     </link>
-    <link name='/imu_link'>
-      <pose>0 0 0 0 -0 0</pose>
-      <inertial>
-        <pose>0 0 0 0 -0 0</pose>
-        <mass>0.015</mass>
-        <inertia>
-          <ixx>1e-05</ixx>
-          <ixy>0</ixy>
-          <ixz>0</ixz>
-          <iyy>1e-05</iyy>
-          <iyz>0</iyz>
-          <izz>1e-05</izz>
-        </inertia>
-      </inertial>
-    </link>
-    <joint name='/imu_joint' type='revolute'>
-      <child>/imu_link</child>
+    <include>
+      <uri>model://imu</uri>
+      <pose>0 0 0 0 0 0</pose>
+      <name>imu</name>
+    </include>
+    <joint name='imu_joint' type='revolute'>
+      <child>imu::link</child>
       <parent>base_link</parent>
       <axis>
         <xyz>1 0 0</xyz>
@@ -563,19 +553,6 @@
       </control_channels>
     </plugin>
     <static>0</static>
-    <plugin name='rotors_gazebo_imu_plugin' filename='libgazebo_imu_plugin.so'>
-      <robotNamespace/>
-      <linkName>/imu_link</linkName>
-      <imuTopic>/imu</imuTopic>
-      <gyroscopeNoiseDensity>0.00018665</gyroscopeNoiseDensity>
-      <gyroscopeRandomWalk>3.8785e-05</gyroscopeRandomWalk>
-      <gyroscopeBiasCorrelationTime>1000.0</gyroscopeBiasCorrelationTime>
-      <gyroscopeTurnOnBiasSigma>0.0087</gyroscopeTurnOnBiasSigma>
-      <accelerometerNoiseDensity>0.00186</accelerometerNoiseDensity>
-      <accelerometerRandomWalk>0.006</accelerometerRandomWalk>
-      <accelerometerBiasCorrelationTime>300.0</accelerometerBiasCorrelationTime>
-      <accelerometerTurnOnBiasSigma>0.196</accelerometerTurnOnBiasSigma>
-    </plugin>
     <link name="depthcamera_link">
       <pose>0.08 0.0 -0.01 0 0 0</pose>
       <inertial>

--- a/models/r1_rover/r1_rover.sdf.jinja
+++ b/models/r1_rover/r1_rover.sdf.jinja
@@ -503,16 +503,17 @@
       <child>gps::link</child>
       <parent>base_link</parent>
     </joint>
+    <include>
+      <uri>model://magnetometer</uri>
+      <pose>0 0 0 0 0 0</pose>
+      <name>mag</name>
+    </include>
+    <joint name='mag_joint' type='fixed'>
+      <child>mag::link</child>
+      <parent>base_link</parent>
+    </joint>
     <plugin name='groundtruth_plugin' filename='libgazebo_groundtruth_plugin.so'>
       <robotNamespace/>
-    </plugin>
-    <plugin name='magnetometer_plugin' filename='libgazebo_magnetometer_plugin.so'>
-      <robotNamespace/>
-      <pubRate>20</pubRate>
-      <noiseDensity>0.0004</noiseDensity>
-      <randomWalk>6.4e-06</randomWalk>
-      <biasCorrelationTime>600</biasCorrelationTime>
-      <magTopic>/mag</magTopic>
     </plugin>
     <plugin name='barometer_plugin' filename='libgazebo_barometer_plugin.so'>
       <robotNamespace/>

--- a/models/r1_rover/r1_rover.sdf.jinja
+++ b/models/r1_rover/r1_rover.sdf.jinja
@@ -471,34 +471,13 @@
       </axis>
     </joint>
     <static>0</static>
-    <link name='rover/imu_link'>
-      <pose>0 0 .2 0 0 0</pose>
-      <inertial>
-        <pose>0 0 0 0 0 0</pose>
-        <mass>0.015</mass>
-        <inertia>
-          <ixx>1e-05</ixx>
-          <ixy>0</ixy>
-          <ixz>0</ixz>
-          <iyy>1e-05</iyy>
-          <iyz>0</iyz>
-          <izz>1e-05</izz>
-        </inertia>
-      </inertial>
-      <!--<visual name='imu_box'>
-        <pose>0 0 0 0 0 0</pose>
-        <geometry>
-          <box>
-            <size>.05 .05 .02</size>
-          </box>
-        </geometry>
-        <material>
-          <emissive>1.0 0.0 0.0 1</emissive>
-        </material>
-      </visual>--> <!--uncomment visual block to see IMU-->
-    </link>
-    <joint name='rover/imu_joint' type='revolute'>
-      <child>rover/imu_link</child>
+    <include>
+      <uri>model://imu</uri>
+      <pose>0 0 0 0 0 0</pose>
+      <name>imu</name>
+    </include>
+    <joint name='imu_joint' type='revolute'>
+      <child>imu::link</child>
       <parent>base_link</parent>
       <axis>
         <xyz>1 0 0</xyz>
@@ -524,19 +503,6 @@
       <child>gps::link</child>
       <parent>base_link</parent>
     </joint>
-    <plugin name='gazebo_imu_plugin' filename='libgazebo_imu_plugin.so'>
-      <robotNamespace></robotNamespace>
-      <linkName>rover/imu_link</linkName>
-      <imuTopic>/imu</imuTopic>
-      <gyroscopeNoiseDensity>0.0003394</gyroscopeNoiseDensity>
-      <gyroscopeRandomWalk>3.8785e-05</gyroscopeRandomWalk>
-      <gyroscopeBiasCorrelationTime>1000.0</gyroscopeBiasCorrelationTime>
-      <gyroscopeTurnOnBiasSigma>0.0087</gyroscopeTurnOnBiasSigma>
-      <accelerometerNoiseDensity>0.004</accelerometerNoiseDensity>
-      <accelerometerRandomWalk>0.006</accelerometerRandomWalk>
-      <accelerometerBiasCorrelationTime>300.0</accelerometerBiasCorrelationTime>
-      <accelerometerTurnOnBiasSigma>0.196</accelerometerTurnOnBiasSigma>
-    </plugin>
     <plugin name='groundtruth_plugin' filename='libgazebo_groundtruth_plugin.so'>
       <robotNamespace/>
     </plugin>

--- a/models/rover/rover.sdf.jinja
+++ b/models/rover/rover.sdf.jinja
@@ -431,23 +431,13 @@
         </material>
       </visual>
     </link>
-    <link name='rover/imu_link'>
+    <include>
+      <uri>model://imu</uri>
       <pose>0 0 0 0 0 0</pose>
-      <inertial>
-        <pose>0 0 0 0 0 0</pose>
-        <mass>0.015</mass>
-        <inertia>
-          <ixx>1e-05</ixx>
-          <ixy>0</ixy>
-          <ixz>0</ixz>
-          <iyy>1e-05</iyy>
-          <iyz>0</iyz>
-          <izz>1e-05</izz>
-        </inertia>
-      </inertial>
-    </link>
-    <joint name='rover/imu_joint' type='revolute'>
-      <child>rover/imu_link</child>
+      <name>imu</name>
+    </include>
+    <joint name='imu_joint' type='revolute'>
+      <child>imu::link</child>
       <parent>base_link</parent>
       <axis>
         <xyz>1 0 0</xyz>
@@ -993,19 +983,5 @@
         </channel>
       </control_channels>
     </plugin>
-    <plugin name='gazebo_imu_plugin' filename='libgazebo_imu_plugin.so'>
-      <robotNamespace></robotNamespace>
-      <linkName>rover/imu_link</linkName>
-      <imuTopic>/imu</imuTopic>
-      <gyroscopeNoiseDensity>0.0003394</gyroscopeNoiseDensity>
-      <gyroscopeRandomWalk>3.8785e-05</gyroscopeRandomWalk>
-      <gyroscopeBiasCorrelationTime>1000.0</gyroscopeBiasCorrelationTime>
-      <gyroscopeTurnOnBiasSigma>0.0087</gyroscopeTurnOnBiasSigma>
-      <accelerometerNoiseDensity>0.004</accelerometerNoiseDensity>
-      <accelerometerRandomWalk>0.006</accelerometerRandomWalk>
-      <accelerometerBiasCorrelationTime>300.0</accelerometerBiasCorrelationTime>
-      <accelerometerTurnOnBiasSigma>0.196</accelerometerTurnOnBiasSigma>
-    </plugin>
-
   </model>
 </sdf>

--- a/models/rover/rover.sdf.jinja
+++ b/models/rover/rover.sdf.jinja
@@ -850,6 +850,15 @@
       <child>gps::link</child>
       <parent>base_link</parent>
     </joint>
+    <include>
+      <uri>model://magnetometer</uri>
+      <pose>0 0 0 0 0 0</pose>
+      <name>mag</name>
+    </include>
+    <joint name='mag_joint' type='fixed'>
+      <child>mag::link</child>
+      <parent>base_link</parent>
+    </joint>
     <plugin name='barometer_plugin' filename='libgazebo_barometer_plugin.so'>
       <robotNamespace/>
       <pubRate>10</pubRate>
@@ -857,14 +866,6 @@
     </plugin>
     <plugin name='groundtruth_plugin' filename='libgazebo_groundtruth_plugin.so'>
       <robotNamespace/>
-    </plugin>
-    <plugin name='magnetometer_plugin' filename='libgazebo_magnetometer_plugin.so'>
-      <robotNamespace/>
-      <pubRate>100</pubRate>
-      <noiseDensity>0.0004</noiseDensity>
-      <randomWalk>6.4e-06</randomWalk>
-      <biasCorrelationTime>600</biasCorrelationTime>
-      <magTopic>/mag</magTopic>
     </plugin>
     <plugin name='mavlink_interface' filename='libgazebo_mavlink_interface.so'>
       <robotNamespace/>

--- a/models/standard_vtol/standard_vtol.sdf.jinja
+++ b/models/standard_vtol/standard_vtol.sdf.jinja
@@ -177,6 +177,15 @@
       <child>airspeed::link</child>
       <parent>base_link</parent>
     </joint>
+    <include>
+      <uri>model://magnetometer</uri>
+      <pose>0 0 0 0 0 0</pose>
+      <name>mag</name>
+    </include>
+    <joint name='mag_joint' type='fixed'>
+      <child>mag::link</child>
+      <parent>base_link</parent>
+    </joint>
     <link name='rotor_0'>
       <pose>0.35 -0.35 0.07 0 0 0</pose>
       <inertial>
@@ -860,14 +869,6 @@
     <plugin name='groundtruth_plugin' filename='libgazebo_groundtruth_plugin.so'>
       <robotNamespace/>
     </plugin>
-    <plugin name='magnetometer_plugin' filename='libgazebo_magnetometer_plugin.so'>
-      <robotNamespace/>
-      <pubRate>100</pubRate>
-      <noiseDensity>0.0004</noiseDensity>
-      <randomWalk>6.4e-06</randomWalk>
-      <biasCorrelationTime>600</biasCorrelationTime>
-      <magTopic>/mag</magTopic>
-    </plugin>
     <plugin name='barometer_plugin' filename='libgazebo_barometer_plugin.so'>
       <robotNamespace/>
       <pubRate>50</pubRate>
@@ -876,7 +877,6 @@
     <plugin name='mavlink_interface' filename='libgazebo_mavlink_interface.so'>
       <robotNamespace></robotNamespace>
       <imuSubTopic>/imu</imuSubTopic>
-      <magSubTopic>/mag</magSubTopic>
       <baroSubTopic>/baro</baroSubTopic>
       <mavlink_addr>INADDR_ANY</mavlink_addr>
       <mavlink_tcp_port>{{ mavlink_tcp_port }}</mavlink_tcp_port>

--- a/models/standard_vtol/standard_vtol.sdf.jinja
+++ b/models/standard_vtol/standard_vtol.sdf.jinja
@@ -145,23 +145,13 @@
       <velocity_decay/>
       <self_collide>0</self_collide>
     </link>
-    <link name='standard_vtol/imu_link'>
+    <include>
+      <uri>model://imu</uri>
       <pose>0 0 0 0 0 0</pose>
-      <inertial>
-        <pose>0 0 0 0 0 0</pose>
-        <mass>0.015</mass>
-        <inertia>
-          <ixx>1e-05</ixx>
-          <ixy>0</ixy>
-          <ixz>0</ixz>
-          <iyy>1e-05</iyy>
-          <iyz>0</iyz>
-          <izz>1e-05</izz>
-        </inertia>
-      </inertial>
-    </link>
-    <joint name='standard_vtol/imu_joint' type='revolute'>
-      <child>standard_vtol/imu_link</child>
+      <name>imu</name>
+    </include>
+    <joint name='imu_joint' type='revolute'>
+      <child>imu::link</child>
       <parent>base_link</parent>
       <axis>
         <xyz>1 0 0</xyz>
@@ -977,19 +967,6 @@
           <joint_name>elevator_joint</joint_name>
         </channel>
       </control_channels>
-    </plugin>
-    <plugin name='gazebo_imu_plugin' filename='libgazebo_imu_plugin.so'>
-      <robotNamespace></robotNamespace>
-      <linkName>standard_vtol/imu_link</linkName>
-      <imuTopic>/imu</imuTopic>
-      <gyroscopeNoiseDensity>0.0003394</gyroscopeNoiseDensity>
-      <gyroscopeRandomWalk>3.8785e-05</gyroscopeRandomWalk>
-      <gyroscopeBiasCorrelationTime>1000.0</gyroscopeBiasCorrelationTime>
-      <gyroscopeTurnOnBiasSigma>0.0087</gyroscopeTurnOnBiasSigma>
-      <accelerometerNoiseDensity>0.004</accelerometerNoiseDensity>
-      <accelerometerRandomWalk>0.006</accelerometerRandomWalk>
-      <accelerometerBiasCorrelationTime>300.0</accelerometerBiasCorrelationTime>
-      <accelerometerTurnOnBiasSigma>0.196</accelerometerTurnOnBiasSigma>
     </plugin>
     <static>0</static>
   </model>

--- a/models/standard_vtol_drop/standard_vtol_drop.sdf.jinja
+++ b/models/standard_vtol_drop/standard_vtol_drop.sdf.jinja
@@ -145,23 +145,13 @@
       <velocity_decay/>
       <self_collide>0</self_collide>
     </link>
-    <link name='standard_vtol/imu_link'>
+    <include>
+      <uri>model://imu</uri>
       <pose>0 0 0 0 0 0</pose>
-      <inertial>
-        <pose>0 0 0 0 0 0</pose>
-        <mass>0.015</mass>
-        <inertia>
-          <ixx>1e-05</ixx>
-          <ixy>0</ixy>
-          <ixz>0</ixz>
-          <iyy>1e-05</iyy>
-          <iyz>0</iyz>
-          <izz>1e-05</izz>
-        </inertia>
-      </inertial>
-    </link>
-    <joint name='standard_vtol/imu_joint' type='revolute'>
-      <child>standard_vtol/imu_link</child>
+      <name>imu</name>
+    </include>
+    <joint name='imu_joint' type='revolute'>
+      <child>imu::link</child>
       <parent>base_link</parent>
       <axis>
         <xyz>1 0 0</xyz>
@@ -890,19 +880,6 @@
       <rollingMomentCoefficient>1e-06</rollingMomentCoefficient>
       <motorSpeedPubTopic>/motor_speed/4</motorSpeedPubTopic>
       <rotorVelocitySlowdownSim>20</rotorVelocitySlowdownSim>
-    </plugin>
-    <plugin name='gazebo_imu_plugin' filename='libgazebo_imu_plugin.so'>
-      <robotNamespace></robotNamespace>
-      <linkName>standard_vtol/imu_link</linkName>
-      <imuTopic>/imu</imuTopic>
-      <gyroscopeNoiseDensity>0.0003394</gyroscopeNoiseDensity>
-      <gyroscopeRandomWalk>3.8785e-05</gyroscopeRandomWalk>
-      <gyroscopeBiasCorrelationTime>1000.0</gyroscopeBiasCorrelationTime>
-      <gyroscopeTurnOnBiasSigma>0.0087</gyroscopeTurnOnBiasSigma>
-      <accelerometerNoiseDensity>0.004</accelerometerNoiseDensity>
-      <accelerometerRandomWalk>0.006</accelerometerRandomWalk>
-      <accelerometerBiasCorrelationTime>300.0</accelerometerBiasCorrelationTime>
-      <accelerometerTurnOnBiasSigma>0.196</accelerometerTurnOnBiasSigma>
     </plugin>
     <plugin name='groundtruth_plugin' filename='libgazebo_groundtruth_plugin.so'>
       <robotNamespace/>

--- a/models/standard_vtol_drop/standard_vtol_drop.sdf.jinja
+++ b/models/standard_vtol_drop/standard_vtol_drop.sdf.jinja
@@ -712,6 +712,15 @@
       <child>gps::link</child>
       <parent>base_link</parent>
     </joint>
+    <include>
+      <uri>model://magnetometer</uri>
+      <pose>0 0 0 0 0 0</pose>
+      <name>mag</name>
+    </include>
+    <joint name='mag_joint' type='fixed'>
+      <child>mag::link</child>
+      <parent>base_link</parent>
+    </joint>
     <plugin name="left_wing_lift" filename="libLiftDragPlugin.so">
       <alpha0>0.05984281113</alpha0>
       <cla>4.752798721</cla>
@@ -883,14 +892,6 @@
     </plugin>
     <plugin name='groundtruth_plugin' filename='libgazebo_groundtruth_plugin.so'>
       <robotNamespace/>
-    </plugin>
-    <plugin name='magnetometer_plugin' filename='libgazebo_magnetometer_plugin.so'>
-      <robotNamespace/>
-      <pubRate>100</pubRate>
-      <noiseDensity>0.0004</noiseDensity>
-      <randomWalk>6.4e-06</randomWalk>
-      <biasCorrelationTime>600</biasCorrelationTime>
-      <magTopic>/mag</magTopic>
     </plugin>
     <plugin name='barometer_plugin' filename='libgazebo_barometer_plugin.so'>
       <robotNamespace/>

--- a/models/standard_vtol_hitl/standard_vtol_hitl.sdf
+++ b/models/standard_vtol_hitl/standard_vtol_hitl.sdf
@@ -144,23 +144,13 @@
       <velocity_decay/>
       <self_collide>0</self_collide>
     </link>
-    <link name='standard_vtol_hitl/imu_link'>
+    <include>
+      <uri>model://imu</uri>
       <pose>0 0 0 0 0 0</pose>
-      <inertial>
-        <pose>0 0 0 0 0 0</pose>
-        <mass>0.015</mass>
-        <inertia>
-          <ixx>1e-05</ixx>
-          <ixy>0</ixy>
-          <ixz>0</ixz>
-          <iyy>1e-05</iyy>
-          <iyz>0</iyz>
-          <izz>1e-05</izz>
-        </inertia>
-      </inertial>
-    </link>
-    <joint name='standard_vtol_hitl/imu_joint' type='revolute'>
-      <child>standard_vtol_hitl/imu_link</child>
+      <name>imu</name>
+    </include>
+    <joint name='imu_joint' type='revolute'>
+      <child>imu::link</child>
       <parent>base_link</parent>
       <axis>
         <xyz>1 0 0</xyz>
@@ -865,19 +855,6 @@
       <rollingMomentCoefficient>1e-06</rollingMomentCoefficient>
       <motorSpeedPubTopic>/motor_speed/4</motorSpeedPubTopic>
       <rotorVelocitySlowdownSim>20</rotorVelocitySlowdownSim>
-    </plugin>
-    <plugin name='gazebo_imu_plugin' filename='libgazebo_imu_plugin.so'>
-      <robotNamespace></robotNamespace>
-      <linkName>standard_vtol_hitl/imu_link</linkName>
-      <imuTopic>/imu</imuTopic>
-      <gyroscopeNoiseDensity>0.0003394</gyroscopeNoiseDensity>
-      <gyroscopeRandomWalk>3.8785e-05</gyroscopeRandomWalk>
-      <gyroscopeBiasCorrelationTime>1000.0</gyroscopeBiasCorrelationTime>
-      <gyroscopeTurnOnBiasSigma>0.0087</gyroscopeTurnOnBiasSigma>
-      <accelerometerNoiseDensity>0.004</accelerometerNoiseDensity>
-      <accelerometerRandomWalk>0.006</accelerometerRandomWalk>
-      <accelerometerBiasCorrelationTime>300.0</accelerometerBiasCorrelationTime>
-      <accelerometerTurnOnBiasSigma>0.196</accelerometerTurnOnBiasSigma>
     </plugin>
     <plugin name='groundtruth_plugin' filename='libgazebo_groundtruth_plugin.so'>
       <robotNamespace/>

--- a/models/standard_vtol_hitl/standard_vtol_hitl.sdf
+++ b/models/standard_vtol_hitl/standard_vtol_hitl.sdf
@@ -687,6 +687,15 @@
       <child>gps0::link</child>
       <parent>base_link</parent>
     </joint>
+    <include>
+      <uri>model://magnetometer</uri>
+      <pose>0 0 0 0 0 0</pose>
+      <name>mag</name>
+    </include>
+    <joint name='mag_joint' type='fixed'>
+      <child>mag::link</child>
+      <parent>base_link</parent>
+    </joint>
     <plugin name="left_wing_lift" filename="libLiftDragPlugin.so">
       <a0>0.05984281113</a0>
       <cla>4.752798721</cla>
@@ -858,14 +867,6 @@
     </plugin>
     <plugin name='groundtruth_plugin' filename='libgazebo_groundtruth_plugin.so'>
       <robotNamespace/>
-    </plugin>
-    <plugin name='magnetometer_plugin' filename='libgazebo_magnetometer_plugin.so'>
-      <robotNamespace/>
-      <pubRate>100</pubRate>
-      <noiseDensity>0.0004</noiseDensity>
-      <randomWalk>6.4e-06</randomWalk>
-      <biasCorrelationTime>600</biasCorrelationTime>
-      <magTopic>/mag</magTopic>
     </plugin>
     <plugin name='barometer_plugin' filename='libgazebo_barometer_plugin.so'>
       <robotNamespace/>

--- a/models/tailsitter/tailsitter.sdf.jinja
+++ b/models/tailsitter/tailsitter.sdf.jinja
@@ -464,6 +464,15 @@
       <child>gps::link</child>
       <parent>base_link</parent>
     </joint>
+    <include>
+      <uri>model://magnetometer</uri>
+      <pose>0 0 0 0 0 0</pose>
+      <name>mag</name>
+    </include>
+    <joint name='mag_joint' type='fixed'>
+      <child>mag::link</child>
+      <parent>base_link</parent>
+    </joint>
     <plugin name="left_wing" filename="libLiftDragPlugin.so">
       <a0>0.05984281113</a0>
       <cla>4.752798721</cla>
@@ -603,14 +612,6 @@
     </plugin>
     <plugin name='groundtruth_plugin' filename='libgazebo_groundtruth_plugin.so'>
       <robotNamespace/>
-    </plugin>
-    <plugin name='magnetometer_plugin' filename='libgazebo_magnetometer_plugin.so'>
-      <robotNamespace/>
-      <pubRate>100</pubRate>
-      <noiseDensity>0.0004</noiseDensity>
-      <randomWalk>6.4e-06</randomWalk>
-      <biasCorrelationTime>600</biasCorrelationTime>
-      <magTopic>/mag</magTopic>
     </plugin>
     <plugin name='barometer_plugin' filename='libgazebo_barometer_plugin.so'>
       <robotNamespace/>

--- a/models/tailsitter/tailsitter.sdf.jinja
+++ b/models/tailsitter/tailsitter.sdf.jinja
@@ -54,23 +54,13 @@
       <velocity_decay/>
       <self_collide>0</self_collide>
     </link>
-    <link name='tailsitter/imu_link'>
+    <include>
+      <uri>model://imu</uri>
       <pose>0 0 0 0 0 0</pose>
-      <inertial>
-        <pose>0 0 0 0 0 0</pose>
-        <mass>0.015</mass>
-        <inertia>
-          <ixx>1e-05</ixx>
-          <ixy>0</ixy>
-          <ixz>0</ixz>
-          <iyy>1e-05</iyy>
-          <iyz>0</iyz>
-          <izz>1e-05</izz>
-        </inertia>
-      </inertial>
-    </link>
-    <joint name='tailsitter/imu_joint' type='revolute'>
-      <child>tailsitter/imu_link</child>
+      <name>imu</name>
+    </include>
+    <joint name='imu_joint' type='revolute'>
+      <child>imu::link</child>
       <parent>base_link</parent>
       <axis>
         <xyz>1 0 0</xyz>
@@ -610,19 +600,6 @@
       <rollingMomentCoefficient>1e-06</rollingMomentCoefficient>
       <motorSpeedPubTopic>/motor_speed/3</motorSpeedPubTopic>
       <rotorVelocitySlowdownSim>10</rotorVelocitySlowdownSim>
-    </plugin>
-    <plugin name='gazebo_imu_plugin' filename='libgazebo_imu_plugin.so'>
-      <robotNamespace></robotNamespace>
-      <linkName>tailsitter/imu_link</linkName>
-      <imuTopic>/imu</imuTopic>
-      <gyroscopeNoiseDensity>0.0003394</gyroscopeNoiseDensity>
-      <gyroscopeRandomWalk>3.8785e-05</gyroscopeRandomWalk>
-      <gyroscopeBiasCorrelationTime>1000.0</gyroscopeBiasCorrelationTime>
-      <gyroscopeTurnOnBiasSigma>0.0087</gyroscopeTurnOnBiasSigma>
-      <accelerometerNoiseDensity>0.004</accelerometerNoiseDensity>
-      <accelerometerRandomWalk>0.006</accelerometerRandomWalk>
-      <accelerometerBiasCorrelationTime>300.0</accelerometerBiasCorrelationTime>
-      <accelerometerTurnOnBiasSigma>0.196</accelerometerTurnOnBiasSigma>
     </plugin>
     <plugin name='groundtruth_plugin' filename='libgazebo_groundtruth_plugin.so'>
       <robotNamespace/>

--- a/models/techpod/techpod.sdf
+++ b/models/techpod/techpod.sdf
@@ -50,23 +50,13 @@
       <velocity_decay/>
       <self_collide>0</self_collide>
     </link>
-    <link name='techpod/imu_link'>
+    <include>
+      <uri>model://imu</uri>
       <pose>0 0 0 0 0 0</pose>
-      <inertial>
-        <pose>0 0 0 0 0 0</pose>
-        <mass>0.015</mass>
-        <inertia>
-          <ixx>1e-05</ixx>
-          <ixy>0</ixy>
-          <ixz>0</ixz>
-          <iyy>1e-05</iyy>
-          <iyz>0</iyz>
-          <izz>1e-05</izz>
-        </inertia>
-      </inertial>
-    </link>
-    <joint name='techpod/imu_joint' type='revolute'>
-      <child>techpod/imu_link</child>
+      <name>imu</name>
+    </include>
+    <joint name='imu_joint' type='revolute'>
+      <child>imu::link</child>
       <parent>base_link</parent>
       <axis>
         <xyz>1 0 0</xyz>
@@ -623,19 +613,6 @@
       <rotorVelocitySlowdownSim>10</rotorVelocitySlowdownSim>
       <robotNamespace></robotNamespace>
       <windSubTopic>world_wind</windSubTopic>
-    </plugin>
-    <plugin name='gazebo_imu_plugin' filename='libgazebo_imu_plugin.so'>
-      <robotNamespace></robotNamespace>
-      <linkName>techpod/imu_link</linkName>
-      <imuTopic>/imu</imuTopic>
-      <gyroscopeNoiseDensity>0.0003394</gyroscopeNoiseDensity>
-      <gyroscopeRandomWalk>3.8785e-05</gyroscopeRandomWalk>
-      <gyroscopeBiasCorrelationTime>1000.0</gyroscopeBiasCorrelationTime>
-      <gyroscopeTurnOnBiasSigma>0.0087</gyroscopeTurnOnBiasSigma>
-      <accelerometerNoiseDensity>0.004</accelerometerNoiseDensity>
-      <accelerometerRandomWalk>0.006</accelerometerRandomWalk>
-      <accelerometerBiasCorrelationTime>300.0</accelerometerBiasCorrelationTime>
-      <accelerometerTurnOnBiasSigma>0.196</accelerometerTurnOnBiasSigma>
     </plugin>
     <plugin name='groundtruth_plugin' filename='libgazebo_groundtruth_plugin.so'>
       <robotNamespace/>

--- a/models/techpod/techpod.sdf
+++ b/models/techpod/techpod.sdf
@@ -463,6 +463,15 @@
       <child>airspeed::link</child>
       <parent>base_link</parent>
     </joint>
+    <include>
+      <uri>model://magnetometer</uri>
+      <pose>0 0 0 0 0 0</pose>
+      <name>mag</name>
+    </include>
+    <joint name='mag_joint' type='fixed'>
+      <child>mag::link</child>
+      <parent>base_link</parent>
+    </joint>
     <plugin name="left_wing" filename="libLiftDragPlugin.so">
       <a0>0.05984281113</a0>
       <cla>4.752798721</cla>
@@ -616,14 +625,6 @@
     </plugin>
     <plugin name='groundtruth_plugin' filename='libgazebo_groundtruth_plugin.so'>
       <robotNamespace/>
-    </plugin>
-    <plugin name='magnetometer_plugin' filename='libgazebo_magnetometer_plugin.so'>
-      <robotNamespace/>
-      <pubRate>100</pubRate>
-      <noiseDensity>0.0004</noiseDensity>
-      <randomWalk>6.4e-06</randomWalk>
-      <biasCorrelationTime>600</biasCorrelationTime>
-      <magTopic>/mag</magTopic>
     </plugin>
     <plugin name='barometer_plugin' filename='libgazebo_barometer_plugin.so'>
       <robotNamespace/>

--- a/models/tiltrotor/tiltrotor.sdf.jinja
+++ b/models/tiltrotor/tiltrotor.sdf.jinja
@@ -705,6 +705,15 @@
       <child>gps::link</child>
       <parent>base_link</parent>
     </joint>
+    <include>
+      <uri>model://magnetometer</uri>
+      <pose>0 0 0 0 0 0</pose>
+      <name>mag</name>
+    </include>
+    <joint name='mag_joint' type='fixed'>
+      <child>mag::link</child>
+      <parent>base_link</parent>
+    </joint>
     <plugin name="left_wing" filename="libLiftDragPlugin.so">
       <a0>0.05984281113</a0>
       <cla>4.752798721</cla>
@@ -859,14 +868,6 @@
     </plugin>
     <plugin name='groundtruth_plugin' filename='libgazebo_groundtruth_plugin.so'>
       <robotNamespace/>
-    </plugin>
-    <plugin name='magnetometer_plugin' filename='libgazebo_magnetometer_plugin.so'>
-      <robotNamespace/>
-      <pubRate>100</pubRate>
-      <noiseDensity>0.0004</noiseDensity>
-      <randomWalk>6.4e-06</randomWalk>
-      <biasCorrelationTime>600</biasCorrelationTime>
-      <magTopic>/mag</magTopic>
     </plugin>
     <plugin name='barometer_plugin' filename='libgazebo_barometer_plugin.so'>
       <robotNamespace/>

--- a/models/tiltrotor/tiltrotor.sdf.jinja
+++ b/models/tiltrotor/tiltrotor.sdf.jinja
@@ -84,23 +84,13 @@
       <velocity_decay/>
       <self_collide>0</self_collide>
     </link>
-    <link name='tiltrotor/imu_link'>
+    <include>
+      <uri>model://imu</uri>
       <pose>0 0 0 0 0 0</pose>
-      <inertial>
-        <pose>0 0 0 0 0 0</pose>
-        <mass>0.015</mass>
-        <inertia>
-          <ixx>1e-05</ixx>
-          <ixy>0</ixy>
-          <ixz>0</ixz>
-          <iyy>1e-05</iyy>
-          <iyz>0</iyz>
-          <izz>1e-05</izz>
-        </inertia>
-      </inertial>
-    </link>
-    <joint name='tiltrotor/imu_joint' type='revolute'>
-      <child>tiltrotor/imu_link</child>
+      <name>imu</name>
+    </include>
+    <joint name='imu_joint' type='revolute'>
+      <child>imu::link</child>
       <parent>base_link</parent>
       <axis>
         <xyz>1 0 0</xyz>
@@ -866,19 +856,6 @@
       <rollingMomentCoefficient>1e-06</rollingMomentCoefficient>
       <motorSpeedPubTopic>/motor_speed/3</motorSpeedPubTopic>
       <rotorVelocitySlowdownSim>20</rotorVelocitySlowdownSim>
-    </plugin>
-    <plugin name='gazebo_imu_plugin' filename='libgazebo_imu_plugin.so'>
-      <robotNamespace></robotNamespace>
-      <linkName>tiltrotor/imu_link</linkName>
-      <imuTopic>/imu</imuTopic>
-      <gyroscopeNoiseDensity>0.0003394</gyroscopeNoiseDensity>
-      <gyroscopeRandomWalk>3.8785e-05</gyroscopeRandomWalk>
-      <gyroscopeBiasCorrelationTime>1000.0</gyroscopeBiasCorrelationTime>
-      <gyroscopeTurnOnBiasSigma>0.0087</gyroscopeTurnOnBiasSigma>
-      <accelerometerNoiseDensity>0.004</accelerometerNoiseDensity>
-      <accelerometerRandomWalk>0.006</accelerometerRandomWalk>
-      <accelerometerBiasCorrelationTime>300.0</accelerometerBiasCorrelationTime>
-      <accelerometerTurnOnBiasSigma>0.196</accelerometerTurnOnBiasSigma>
     </plugin>
     <plugin name='groundtruth_plugin' filename='libgazebo_groundtruth_plugin.so'>
       <robotNamespace/>

--- a/models/typhoon_h480/typhoon_h480.sdf.jinja
+++ b/models/typhoon_h480/typhoon_h480.sdf.jinja
@@ -661,23 +661,13 @@
       </physics>
     </joint>
 
-    <link name='typhoon_h480/imu_link'>
+    <include>
+      <uri>model://imu</uri>
       <pose>0 0 0 0 0 0</pose>
-      <inertial>
-        <pose>0 0 0 0 0 0</pose>
-        <mass>0.015</mass>
-        <inertia>
-          <ixx>1e-05</ixx>
-          <ixy>0</ixy>
-          <ixz>0</ixz>
-          <iyy>1e-05</iyy>
-          <iyz>0</iyz>
-          <izz>1e-05</izz>
-        </inertia>
-      </inertial>
-    </link>
-    <joint name='typhoon_h480/imu_joint' type='revolute'>
-      <child>typhoon_h480/imu_link</child>
+      <name>imu</name>
+    </include>
+    <joint name='imu_joint' type='revolute'>
+      <child>imu::link</child>
       <parent>base_link</parent>
       <axis>
         <xyz>1 0 0</xyz>
@@ -1417,19 +1407,6 @@
       </control_channels>
     </plugin>
     <static>0</static>
-    <plugin name='gazebo_imu_plugin' filename='libgazebo_imu_plugin.so'>
-      <robotNamespace></robotNamespace>
-      <linkName>typhoon_h480/imu_link</linkName>
-      <imuTopic>/imu</imuTopic>
-      <gyroscopeNoiseDensity>0.0003394</gyroscopeNoiseDensity>
-      <gyroscopeRandomWalk>3.8785e-05</gyroscopeRandomWalk>
-      <gyroscopeBiasCorrelationTime>1000.0</gyroscopeBiasCorrelationTime>
-      <gyroscopeTurnOnBiasSigma>0.0087</gyroscopeTurnOnBiasSigma>
-      <accelerometerNoiseDensity>0.004</accelerometerNoiseDensity>
-      <accelerometerRandomWalk>0.006</accelerometerRandomWalk>
-      <accelerometerBiasCorrelationTime>300.0</accelerometerBiasCorrelationTime>
-      <accelerometerTurnOnBiasSigma>0.196</accelerometerTurnOnBiasSigma>
-    </plugin>
     <plugin name='gimbal_controller' filename='libgazebo_gimbal_controller_plugin.so'>
       <joint_yaw>typhoon_h480::cgo3_vertical_arm_joint</joint_yaw>
       <joint_roll>typhoon_h480::cgo3_horizontal_arm_joint</joint_roll>

--- a/models/typhoon_h480/typhoon_h480.sdf.jinja
+++ b/models/typhoon_h480/typhoon_h480.sdf.jinja
@@ -1144,7 +1144,15 @@
       <child>gps::link</child>
       <parent>base_link</parent>
     </joint>
-
+    <include>
+      <uri>model://magnetometer</uri>
+      <pose>0 0 0 0 0 0</pose>
+      <name>mag</name>
+    </include>
+    <joint name='mag_joint' type='fixed'>
+      <child>mag::link</child>
+      <parent>base_link</parent>
+    </joint>
 
     <plugin name='rosbag' filename='libgazebo_multirotor_base_plugin.so'>
       <robotNamespace></robotNamespace>
@@ -1255,14 +1263,6 @@
     </plugin>
     <plugin name='groundtruth_plugin' filename='libgazebo_groundtruth_plugin.so'>
       <robotNamespace/>
-    </plugin>
-    <plugin name='magnetometer_plugin' filename='libgazebo_magnetometer_plugin.so'>
-      <robotNamespace/>
-      <pubRate>100</pubRate>
-      <noiseDensity>0.0004</noiseDensity>
-      <randomWalk>6.4e-06</randomWalk>
-      <biasCorrelationTime>600</biasCorrelationTime>
-      <magTopic>/mag</magTopic>
     </plugin>
     <plugin name='barometer_plugin' filename='libgazebo_barometer_plugin.so'>
       <robotNamespace/>

--- a/models/uuv_bluerov2_heavy/uuv_bluerov2_heavy.sdf
+++ b/models/uuv_bluerov2_heavy/uuv_bluerov2_heavy.sdf
@@ -42,8 +42,17 @@
       <parent>base_link</parent>
       <child>gps::link</child>
     </joint>
-
-
+    
+    
+    <include>
+      <uri>model://imu</uri>
+      <pose>0 0 0 0 0 0</pose>
+      <name>imu</name>
+    </include>
+    <joint name='imu_joint' type='fixed'>
+      <child>imu::link</child>
+      <parent>base_link</parent>
+    </joint>
 
 <!-- Start of Thrusters  -->
         <link name="thruster1">
@@ -657,20 +666,6 @@
                     <joint_name>thruster8_joint</joint_name>
                 </channel>
             </control_channels>
-        </plugin>
-
-        <plugin name="gazebo_imu_plugin" filename="libgazebo_imu_plugin.so">
-            <robotNamespace />
-            <linkName>base_link</linkName>
-            <imuTopic>/imu</imuTopic>
-            <gyroscopeNoiseDensity>0.0003394</gyroscopeNoiseDensity>
-            <gyroscopeRandomWalk>3.8785e-05</gyroscopeRandomWalk>
-            <gyroscopeBiasCorrelationTime>1000.0</gyroscopeBiasCorrelationTime>
-            <gyroscopeTurnOnBiasSigma>0.0087</gyroscopeTurnOnBiasSigma>
-            <accelerometerNoiseDensity>0.004</accelerometerNoiseDensity>
-            <accelerometerRandomWalk>0.006</accelerometerRandomWalk>
-            <accelerometerBiasCorrelationTime>300.0</accelerometerBiasCorrelationTime>
-            <accelerometerTurnOnBiasSigma>0.196</accelerometerTurnOnBiasSigma>
         </plugin>
 
     </model>

--- a/models/uuv_bluerov2_heavy/uuv_bluerov2_heavy.sdf
+++ b/models/uuv_bluerov2_heavy/uuv_bluerov2_heavy.sdf
@@ -43,7 +43,6 @@
       <child>gps::link</child>
     </joint>
     
-    
     <include>
       <uri>model://imu</uri>
       <pose>0 0 0 0 0 0</pose>
@@ -51,6 +50,16 @@
     </include>
     <joint name='imu_joint' type='fixed'>
       <child>imu::link</child>
+      <parent>base_link</parent>
+    </joint>
+
+    <include>
+      <uri>model://magnetometer</uri>
+      <pose>0 0 0 0 0 0</pose>
+      <name>mag</name>
+    </include>
+    <joint name='mag_joint' type='fixed'>
+      <child>mag::link</child>
       <parent>base_link</parent>
     </joint>
 
@@ -534,15 +543,6 @@
             <motorNumber>7</motorNumber>
             <motorSpeedPubTopic>/motor_speed/7</motorSpeedPubTopic>
             <rotorVelocitySlowdownSim>0.025</rotorVelocitySlowdownSim>
-        </plugin>
-
-        <plugin name="magnetometer_plugin" filename="libgazebo_magnetometer_plugin.so">
-            <robotNamespace />
-            <pubRate>100</pubRate>
-            <noiseDensity>0.0004</noiseDensity>
-            <randomWalk>6.4e-06</randomWalk>
-            <biasCorrelationTime>600</biasCorrelationTime>
-            <magTopic>/mag</magTopic>
         </plugin>
 
         <plugin name="barometer_plugin" filename="libgazebo_barometer_plugin.so">

--- a/models/uuv_hippocampus/uuv_hippocampus.sdf
+++ b/models/uuv_hippocampus/uuv_hippocampus.sdf
@@ -397,6 +397,16 @@
       <parent>base_link</parent>
     </joint>
 
+    <include>
+      <uri>model://magnetometer</uri>
+      <pose>0 0 0 0 0 0</pose>
+      <name>mag</name>
+    </include>
+    <joint name='mag_joint' type='fixed'>
+      <child>mag::link</child>
+      <parent>base_link</parent>
+    </joint>
+
 <!-- Plugins -->
 
     <plugin name='groundtruth_plugin' filename='libgazebo_groundtruth_plugin.so'>
@@ -490,15 +500,6 @@
       <motorNumber>3</motorNumber>
       <motorSpeedPubTopic>/motor_speed/3</motorSpeedPubTopic>
       <rotorVelocitySlowdownSim>0.05</rotorVelocitySlowdownSim>
-    </plugin>
-
-    <plugin name='magnetometer_plugin' filename='libgazebo_magnetometer_plugin.so'>
-      <robotNamespace/>
-      <pubRate>100</pubRate>
-      <noiseDensity>0.0004</noiseDensity>
-      <randomWalk>6.4e-06</randomWalk>
-      <biasCorrelationTime>600</biasCorrelationTime>
-      <magTopic>/mag</magTopic>
     </plugin>
 
     <plugin name='barometer_plugin' filename='libgazebo_barometer_plugin.so'>

--- a/models/uuv_hippocampus/uuv_hippocampus.sdf
+++ b/models/uuv_hippocampus/uuv_hippocampus.sdf
@@ -80,25 +80,15 @@
         East-Down) coordinate frame whereas Gazebo uses a ENU (East-North-Up) coordinate frame.
     -->
 <!-- IMU link -->
-    <link name='uuv_hippocampus/imu_link'>
+    <include>
+      <uri>model://imu</uri>
       <pose>0 0 0 0 0 0</pose>
-      <inertial>
-        <pose>0 0 0 0 0 0</pose>
-        <mass>0.015</mass>
-        <inertia>
-          <ixx>1e-05</ixx>
-          <ixy>0</ixy>
-          <ixz>0</ixz>
-          <iyy>1e-05</iyy>
-          <iyz>0</iyz>
-          <izz>1e-05</izz>
-        </inertia>
-      </inertial>
-    </link>
+      <name>imu</name>
+    </include>
 
 <!-- IMU joint -->
-    <joint name='uuv_hippocampus/imu_joint' type='revolute'>
-      <child>uuv_hippocampus/imu_link</child>
+    <joint name='imu_joint' type='revolute'>
+      <child>imu::link</child>
       <parent>base_link</parent>
       <axis>
         <xyz>1 0 0</xyz>
@@ -579,20 +569,6 @@
           <joint_name>bottom_port_joint</joint_name>
         </channel>
       </control_channels>
-    </plugin>
-
-    <plugin name='gazebo_imu_plugin' filename='libgazebo_imu_plugin.so'>
-      <robotNamespace/>
-      <linkName>uuv_hippocampus/imu_link</linkName>
-      <imuTopic>/imu</imuTopic>
-      <gyroscopeNoiseDensity>0.0003394</gyroscopeNoiseDensity>
-      <gyroscopeRandomWalk>3.8785e-05</gyroscopeRandomWalk>
-      <gyroscopeBiasCorrelationTime>1000.0</gyroscopeBiasCorrelationTime>
-      <gyroscopeTurnOnBiasSigma>0.0087</gyroscopeTurnOnBiasSigma>
-      <accelerometerNoiseDensity>0.004</accelerometerNoiseDensity>
-      <accelerometerRandomWalk>0.006</accelerometerRandomWalk>
-      <accelerometerBiasCorrelationTime>300.0</accelerometerBiasCorrelationTime>
-      <accelerometerTurnOnBiasSigma>0.196</accelerometerTurnOnBiasSigma>
     </plugin>
   </model>
 </sdf>

--- a/src/gazebo_magnetometer_plugin.cpp
+++ b/src/gazebo_magnetometer_plugin.cpp
@@ -40,11 +40,13 @@
 
 #include <gazebo_magnetometer_plugin.h>
 
+#include <boost/algorithm/string.hpp>
+
 namespace gazebo
 {
-GZ_REGISTER_MODEL_PLUGIN(MagnetometerPlugin)
+GZ_REGISTER_SENSOR_PLUGIN(MagnetometerPlugin)
 
-MagnetometerPlugin::MagnetometerPlugin() : ModelPlugin(),
+MagnetometerPlugin::MagnetometerPlugin() : SensorPlugin(),
       groundtruth_lat_rad_(0.0),
       groundtruth_lon_rad_(0.0)
 {
@@ -92,22 +94,50 @@ void MagnetometerPlugin::getSdfParams(sdf::ElementPtr sdf)
     gzwarn << "[gazebo_magnetometer_plugin] Using default bias correlation time of " << random_walk_ << " s\n";
   }
 
-  if(sdf->HasElement("magTopic")) {
-    mag_topic_ = sdf->GetElement("magTopic")->Get<std::string>();
-  } else {
-    mag_topic_ = kDefaultMagnetometerTopic;
-    gzwarn << "[gazebo_magnetometer_plugin] Using default magnetometer topic " << mag_topic_ << "\n";
-  }
-
   gt_sub_topic_ = "/groundtruth";
 }
 
-void MagnetometerPlugin::Load(physics::ModelPtr model, sdf::ElementPtr sdf)
+void MagnetometerPlugin::Load(sensors::SensorPtr _parent, sdf::ElementPtr _sdf)
 {
-  getSdfParams(sdf);
+  // Get then name of the parent sensor
+  parentSensor_ = std::dynamic_pointer_cast<sensors::MagnetometerSensor>(_parent);
 
-  model_ = model;
-  world_ = model_->GetWorld();
+  if (!parentSensor_) {
+    gzthrow("MagnetometerPlugin requires a Magnetometer Sensor as its parent");
+  }
+
+  world_ = physics::get_world(_parent->WorldName());
+
+  link_ = boost::dynamic_pointer_cast<physics::Link>(
+            world_->EntityByName(_parent->ParentName()));
+  if (link_ == NULL) {
+    gzthrow("MagnetometerPlugin: could not find the link associated to the sensor");
+  }
+
+  model_ = link_->GetParentModel();
+  if (model_ == NULL) {
+    gzthrow("MagnetometerPlugin: could not find the model associated to the sensor");
+  }
+
+  // Get the root model name
+  const std::string scopedName = _parent->ParentName();
+  std::vector<std::string> names_splitted;
+  boost::split(names_splitted, scopedName, boost::is_any_of("::"));
+  names_splitted.erase(std::remove_if(begin(names_splitted), end(names_splitted),
+                            [](const std::string& name)
+                            { return name.size() == 0; }), end(names_splitted));
+
+  // the second to the last name is the model name
+  const std::string parentSensorModelName = names_splitted.rbegin()[1];
+
+  if(_sdf->HasElement("magTopic")) {
+    mag_topic_ = _sdf->GetElement("magTopic")->Get<std::string>();
+  } else {
+    mag_topic_ = parentSensorModelName;
+  }
+
+  getSdfParams(_sdf);
+
 #if GAZEBO_MAJOR_VERSION >= 9
   last_time_ = world_->SimTime();
   last_pub_time_ = world_->SimTime();
@@ -123,7 +153,8 @@ void MagnetometerPlugin::Load(physics::ModelPtr model, sdf::ElementPtr sdf)
   update_connection_ = event::Events::ConnectWorldUpdateBegin(
       boost::bind(&MagnetometerPlugin::OnUpdate, this, _1));
 
-  pub_mag_ = node_handle_->Advertise<sensor_msgs::msgs::MagneticField>("~/" + model_->GetName() + mag_topic_, 10);
+  pub_mag_ = node_handle_->Advertise<sensor_msgs::msgs::MagneticField>("~/" + model_->GetName() + "/link/" + mag_topic_, 10);
+
   gt_sub_ = node_handle_->Subscribe("~/" + model_->GetName() + gt_sub_topic_, &MagnetometerPlugin::GroundtruthCallback, this);
 
   standard_normal_distribution_ = std::normal_distribution<double>(0.0, 1.0);
@@ -197,9 +228,9 @@ void MagnetometerPlugin::OnUpdate(const common::UpdateInfo&)
     ignition::math::Vector3d magnetic_field_I(X, Y, Z);
 
 #if GAZEBO_MAJOR_VERSION >= 9
-    ignition::math::Pose3d T_W_I = model_->WorldPose();
+    ignition::math::Pose3d T_W_I = link_->WorldPose();
 #else
-    ignition::math::Pose3d T_W_I = ignitionFromGazeboMath(model_->GetWorldPose());
+    ignition::math::Pose3d T_W_I = ignitionFromGazeboMath(link_->GetWorldPose());
 #endif
     ignition::math::Quaterniond q_body_to_world = q_ENU_to_NED * T_W_I.Rot() * q_FLU_to_FRD.Inverse();
 

--- a/src/gazebo_mavlink_interface.cpp
+++ b/src/gazebo_mavlink_interface.cpp
@@ -210,7 +210,6 @@ void GazeboMavlinkInterface::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf
   getSdfParam<std::string>(_sdf, "opticalFlowSubTopic",
       opticalFlow_sub_topic_, opticalFlow_sub_topic_);
   getSdfParam<std::string>(_sdf, "irlockSubTopic", irlock_sub_topic_, irlock_sub_topic_);
-  getSdfParam<std::string>(_sdf, "magSubTopic", mag_sub_topic_, mag_sub_topic_);
   getSdfParam<std::string>(_sdf, "baroSubTopic", baro_sub_topic_, baro_sub_topic_);
   getSdfParam<std::string>(_sdf, "groundtruthSubTopic", groundtruth_sub_topic_, groundtruth_sub_topic_);
 
@@ -422,7 +421,6 @@ void GazeboMavlinkInterface::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf
   irlock_sub_ = node_handle_->Subscribe("~/" + model_->GetName() + irlock_sub_topic_, &GazeboMavlinkInterface::IRLockCallback, this);
   groundtruth_sub_ = node_handle_->Subscribe("~/" + model_->GetName() + groundtruth_sub_topic_, &GazeboMavlinkInterface::GroundtruthCallback, this);
   vision_sub_ = node_handle_->Subscribe("~/" + model_->GetName() + vision_sub_topic_, &GazeboMavlinkInterface::VisionCallback, this);
-  mag_sub_ = node_handle_->Subscribe("~/" + model_->GetName() + mag_sub_topic_, &GazeboMavlinkInterface::MagnetometerCallback, this);
   baro_sub_ = node_handle_->Subscribe("~/" + model_->GetName() + baro_sub_topic_, &GazeboMavlinkInterface::BarometerCallback, this);
   wind_sub_ = node_handle_->Subscribe("~/" + wind_sub_topic_, &GazeboMavlinkInterface::WindVelocityCallback, this);
 
@@ -446,6 +444,7 @@ void GazeboMavlinkInterface::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf
   CreateSensorSubscription(&GazeboMavlinkInterface::GpsCallback, this, joints, nested_model, kDefaultGPSModelNaming);
   CreateSensorSubscription(&GazeboMavlinkInterface::AirspeedCallback, this, joints, nested_model, kDefaultAirspeedModelJointNaming);
   CreateSensorSubscription(&GazeboMavlinkInterface::ImuCallback, this, joints, nested_model, kDefaultImuModelJointNaming);
+  CreateSensorSubscription(&GazeboMavlinkInterface::MagnetometerCallback, this, joints, nested_model, kDefaultMagModelJointNaming);
 
   // Publish gazebo's motor_speed message
   motor_velocity_reference_pub_ = node_handle_->Advertise<mav_msgs::msgs::CommandMotorSpeed>("~/" + model_->GetName() + motor_velocity_reference_pub_topic_, 1);
@@ -1079,11 +1078,12 @@ void GazeboMavlinkInterface::VisionCallback(OdomPtr& odom_message) {
   }
 }
 
-void GazeboMavlinkInterface::MagnetometerCallback(MagnetometerPtr& mag_msg) {
+void GazeboMavlinkInterface::MagnetometerCallback(MagnetometerPtr& mag_msg, const int& id) {
+
   SensorData::Magnetometer mag_data;
   mag_data.mag_b = Eigen::Vector3d(mag_msg->magnetic_field().x(),
     mag_msg->magnetic_field().y(), mag_msg->magnetic_field().z());
-  mavlink_interface_->UpdateMag(mag_data);
+  mavlink_interface_->UpdateMag(mag_data, id);
 }
 
 void GazeboMavlinkInterface::AirspeedCallback(AirspeedPtr& airspeed_msg, const int& id) {


### PR DESCRIPTION
Added support for multi mag and multi imu in a model.
Both sensors can have multiple instances, where each instance is published with a different id in mavlink.

PX4 side needs adaption to support multiple imus and magnetometer first, before this can be merged.