### PR TITLE
Fix local addr assignment for qgc and sdk sockets

### DIFF
--- a/src/mavlink_interface.cpp
+++ b/src/mavlink_interface.cpp
@@ -19,17 +19,18 @@ void MavlinkInterface::Load()
       abort();
     }
   }
-  local_qgc_addr_.sin_port = 0;
+  local_qgc_addr_.sin_addr.s_addr = htonl(INADDR_ANY);
   if (qgc_addr_ != "INADDR_ANY") {
-    local_qgc_addr_.sin_port = inet_addr(qgc_addr_.c_str());
-    if (local_qgc_addr_.sin_port == 0) {
+    local_qgc_addr_.sin_addr.s_addr = inet_addr(qgc_addr_.c_str());
+    if (local_qgc_addr_.sin_addr.s_addr == INADDR_NONE) {
       std::cerr << "Invalid qgc_addr: " << qgc_addr_ << ", aborting\n";
       abort();
     }
   }
+  local_sdk_addr_.sin_addr.s_addr = htonl(INADDR_ANY);
   if (sdk_addr_ != "INADDR_ANY") {
-    local_sdk_addr_.sin_port = inet_addr(sdk_addr_.c_str());
-    if (local_sdk_addr_.sin_port == 0) {
+    local_sdk_addr_.sin_addr.s_addr = inet_addr(sdk_addr_.c_str());
+    if (local_sdk_addr_.sin_addr.s_addr == INADDR_NONE) {
       std::cerr << "Invalid sdk_addr: " << sdk_addr_ << ", aborting\n";
       abort();
     }


### PR DESCRIPTION
We've used sitl_gazebo in a HITL setup, and in some of the runs we faced errors: "Creating QGC UDP socket failed" and "Creating SDK UDP socket failed".

After some investigation, I think I found a bug.

In the code, the result of IP address conversion (`inet_addr` call) is put somehow to the `sin_port` field of `local_qgc_addr_` and `local_sdk_addr_`, while `sin_addr` stays uninitilized, so some random bytes in memory was used as an address.

Also the `sin_port` was checked to detect invalid addr, while there obviously should be `sin_addr`.

Tested this fix and the errors are gone.