### PR TITLE
Fix standard_vtol_drop transition failure

### DIFF
--- a/models/standard_vtol_drop/standard_vtol_drop.sdf.jinja
+++ b/models/standard_vtol_drop/standard_vtol_drop.sdf.jinja
@@ -739,7 +739,7 @@
       <control_joint_name>
         left_elevon_joint
       </control_joint_name>
-      <cl_delta>-1.0</cl_delta>
+      <control_joint_rad_to_cl>-1.0</control_joint_rad_to_cl>
       <robotNamespace></robotNamespace>
       <windSubTopic>world_wind</windSubTopic>
     </plugin>
@@ -761,7 +761,7 @@
       <control_joint_name>
         right_elevon_joint
       </control_joint_name>
-      <cl_delta>-1.0</cl_delta>
+      <control_joint_rad_to_cl>-1.0</control_joint_rad_to_cl>
       <robotNamespace></robotNamespace>
       <windSubTopic>world_wind</windSubTopic>
     </plugin>
@@ -783,7 +783,7 @@
       <control_joint_name>
         elevator_joint
       </control_joint_name>
-      <cl_delta>-12.0</cl_delta>
+      <control_joint_rad_to_cl>-12.0</control_joint_rad_to_cl>
       <robotNamespace></robotNamespace>
       <windSubTopic>world_wind</windSubTopic>
     </plugin>

--- a/models/standard_vtol_drop/standard_vtol_drop.sdf.jinja
+++ b/models/standard_vtol_drop/standard_vtol_drop.sdf.jinja
@@ -722,7 +722,7 @@
       <parent>base_link</parent>
     </joint>
     <plugin name="left_wing_lift" filename="libLiftDragPlugin.so">
-      <alpha0>0.05984281113</alpha0>
+      <a0>0.05984281113</a0>
       <cla>4.752798721</cla>
       <cda>0.6417112299</cda>
       <cma>0.0</cma>
@@ -744,7 +744,7 @@
       <windSubTopic>world_wind</windSubTopic>
     </plugin>
     <plugin name="right_wing_lift" filename="libLiftDragPlugin.so">
-      <alpha0>0.05984281113</alpha0>
+      <a0>0.05984281113</a0>
       <cla>4.752798721</cla>
       <cda>0.6417112299</cda>
       <cma>0.0</cma>
@@ -766,7 +766,7 @@
       <windSubTopic>world_wind</windSubTopic>
     </plugin>
     <plugin name="elevator_lift" filename="libLiftDragPlugin.so">
-      <alpha0>-0.2</alpha0>
+      <a0>-0.2</a0>
       <cla>4.752798721</cla>
       <cda>0.6417112299</cda>
       <cma>0.0</cma>
@@ -788,7 +788,7 @@
       <windSubTopic>world_wind</windSubTopic>
     </plugin>
     <plugin name="rudder_lift" filename="libLiftDragPlugin.so">
-      <alpha0>0.0</alpha0>
+      <a0>0.0</a0>
       <cla>4.752798721</cla>
       <cda>0.6417112299</cda>
       <cma>0.0.</cma>


### PR DESCRIPTION
## About
Running the `make px4_sitl gazebo_standard_vtol_drop` and flying a mission with VTOL transition in upstream PX4 results in the vehicle going out of control. Which seems to be related to https://github.com/PX4/PX4-SITL_gazebo/pull/730

This was found while developing https://github.com/PX4/PX4-Autopilot/pull/20230

## Fix
Doing `diff /home/junwoo/PX4-Autopilot/Tools/simulation/gazebo/sitl_gazebo/models/standard_vtol/standard_vtol.sdf.jinja /home/junwoo/PX4-Autopilot/Tools/simulation/gazebo/sitl_gazebo/models/standard_vtol_drop/standard_vtol_drop.sdf.jinja` clearly pointed out the fact that `cl_delta` and `alpha0` elements in the `standard_vtol_drop.sdf.jinja` were outdated naming convention.

This PR includes 2 commits that updates these 2 variables. And it seems like renaming `cl_delta` alone fixed the crash, but renaming `alpha0` also doesn't hurt so I included it in the PR.

## Discussion
![image](https://user-images.githubusercontent.com/23277211/192332371-7971c9b0-5aa2-49f5-871b-a01ccef94878.png)

Currently, still the `.sdf.jinja`files have some diff and I am suspecting that the airspeed sensor not working in the `standard_vtol_drop` SITL is related to this. @Jaeyoung-Lim according to the screenshot above, could you spot if airspeed plug-in is wrongly implemented in `standard_vtol_drop`?

I'm also not sure how the `standard_vtol` itself has airspeed coming in, as I can't find the airspeed keyword in it's .sdf.jinja file :thinking: 