### PR TITLE
set lidar measurements to 0.0 if out of range

### DIFF
--- a/src/gazebo_lidar_plugin.cpp
+++ b/src/gazebo_lidar_plugin.cpp
@@ -160,10 +160,10 @@ void LidarPlugin::OnNewLaserScans()
   if (simulate_fog_ && current_distance > 2.0f) {
     double whiteNoise = ignition::math::Rand::DblNormal(0.0f, 0.1f);
     current_distance = 2.0f + whiteNoise;
-  } else if (current_distance < min_distance_ || std::isinf(current_distance)) {
+  } else if (current_distance < min_distance_) {
     current_distance = min_distance_;
-  } else if (current_distance > max_distance_) {
-    current_distance = max_distance_;
+  } else if (current_distance > max_distance_ || std::isinf(current_distance)) {
+    current_distance = 0.0f;
   }
 
 


### PR DESCRIPTION
I have observed that there is a discrepancy between how the simulated lidar reports values out of range compared to real sensors. In any case on the two Lidar models that I have access to (TFmini and LidarLite) when out of range they report 0.0 and not an (artificial) minimum value of 0.19m. 

This PR makes that the behaviour is the same on the simulated drone. 

Flight log on current PX4 main with these changes: https://logs.px4.io/plot_app?log=5b4f0efd-58e6-4ef8-a770-7c3ce63761c9

For reference, a flight log of a drone with a LidarLite: https://logs.px4.io/plot_app?log=0bf8f091-6c3d-461b-a67f-5d6658ca4c32
