### PR TITLE
Add quaternion to irlock message

### DIFF
--- a/msgs/IRLock.proto
+++ b/msgs/IRLock.proto
@@ -9,4 +9,8 @@ message IRLock
   required float pos_y		= 4;
   required float size_x		= 5;
   required float size_y		= 6;
+  optional double q_w = 7;
+  optional double q_x = 8;
+  optional double q_y = 9;
+  optional double q_z = 10;
 }

--- a/src/gazebo_irlock_plugin.cpp
+++ b/src/gazebo_irlock_plugin.cpp
@@ -119,6 +119,16 @@ void IRLockPlugin::OnUpdated()
         irlock_message.set_size_x(0); // unused by beacon estimator
         irlock_message.set_size_y(0); // unused by beacon estimator
 
+        // Use ignition to send orientation quaternion
+        ignition::math::Pose3d modelRelativePose = gazebo::msgs::ConvertIgn(model.pose());
+        ignition::math::Quaterniond q_enu_to_ned(3.141f, 0.0f, 0.0f);
+        ignition::math::Quaterniond modelRelativeRotNed = q_enu_to_ned * modelRelativePose.Rot();
+
+        irlock_message.set_q_w(modelRelativeRotNed.W());
+        irlock_message.set_q_x(modelRelativeRotNed.X());
+        irlock_message.set_q_y(modelRelativeRotNed.Y());
+        irlock_message.set_q_z(modelRelativeRotNed.Z());
+
         // send message
         irlock_pub_->Publish(irlock_message);
 

--- a/src/gazebo_mavlink_interface.cpp
+++ b/src/gazebo_mavlink_interface.cpp
@@ -949,6 +949,10 @@ void GazeboMavlinkInterface::IRLockCallback(IRLockPtr& irlock_message) {
   sensor_msg.angle_y = irlock_message->pos_y();
   sensor_msg.size_x = irlock_message->size_x();
   sensor_msg.size_y = irlock_message->size_y();
+  sensor_msg.q[0] = irlock_message->q_w();
+  sensor_msg.q[1] = irlock_message->q_x();
+  sensor_msg.q[2] = irlock_message->q_y();
+  sensor_msg.q[3] = irlock_message->q_z();
   sensor_msg.position_valid = false;
   sensor_msg.type = LANDING_TARGET_TYPE_LIGHT_BEACON;
 


### PR DESCRIPTION
The landing_target mavlink message supports sending a quaternion for the orientation. So far this was not done for two reasons:
- PX4's onboard LandingTargetEstimator.cpp does not evaluate the orientation
- The setup was created with IR beacons in mind, which have no orientation

I want to add orientation to the landing_target message, also in PX4, and move away from the concept of IR beacons. They will of course still be supported, but so should April Tags, ArucoTags and other vision based markers be.