### PR TITLE
Fix user camera plugin

### DIFF
--- a/.github/workflows/firmware_build_test.yml
+++ b/.github/workflows/firmware_build_test.yml
@@ -71,7 +71,7 @@ jobs:
       env:
         DONT_RUN: 1
         GIT_SUBMODULES_ARE_EVIL: 1
-      run: make px4_sitl_default gazebo
+      run: make px4_sitl_default gazebo_iris
     - name: ccache post-run px4/firmware
       run: ccache -s
     - name: Build MAVSDK tests
@@ -79,7 +79,7 @@ jobs:
       env:
         DONT_RUN: 1
         GIT_SUBMODULES_ARE_EVIL: 1
-      run: make px4_sitl_default gazebo mavsdk_tests
+      run: make px4_sitl_default gazebo_iris mavsdk_tests
     - name: ccache post-run mavsdk_tests
       run: ccache -s
     - name: Run SITL tests

--- a/src/gazebo_user_camera_plugin.cpp
+++ b/src/gazebo_user_camera_plugin.cpp
@@ -61,10 +61,19 @@ UserCameraPlugin::UserCameraPlugin()
   update_connection_ =
       event::Events::ConnectPreRender(
           boost::bind(&UserCameraPlugin::OnUpdate, this));
-  
+
   const char *model = std::getenv("PX4_SIM_MODEL");
   if (model) {
     model_name_ = std::string(model);
+
+    // Remove gazebo_ substring
+    // Model name in `PX4_SIM_MODEL` includes the gazebo substring after
+    // https://github.com/PX4/PX4-Autopilot/pull/20867
+    std:: string prefix = "gazebo_";
+    std::size_t ind = model_name_.find(prefix);
+    if(ind !=std::string::npos){
+        model_name_.erase(ind,prefix.length());
+    }
   }
 }
 


### PR DESCRIPTION
 **Problem Description**
The user camera plugin, which takes care of camera tracking on the model have been broken. This is because the model naming in the environment variable `PX4_SIM_MODEL` changed in https://github.com/PX4/PX4-Autopilot/pull/20867 to include a `gazebo_` prefix for the gazebo SITL simulation.

**Solution**
This commit removes the gazebo_ substring from PX4_SIM_MODEL to find the model name in gazebo

![ezgif com-gif-maker (34)](https://user-images.githubusercontent.com/5248102/211595657-60366f75-8a8e-41a6-b6d3-9b6f97e48c51.gif)

**Additional Context**
- This was written on top of https://github.com/PX4/PX4-SITL_gazebo-classic/pull/946 to get the github actions working
