### PR TITLE
Fix model prefix for user camera plugin

### DIFF
--- a/src/gazebo_user_camera_plugin.cpp
+++ b/src/gazebo_user_camera_plugin.cpp
@@ -69,7 +69,7 @@ UserCameraPlugin::UserCameraPlugin()
     // Remove gazebo_ substring
     // Model name in `PX4_SIM_MODEL` includes the gazebo substring after
     // https://github.com/PX4/PX4-Autopilot/pull/20867
-    std:: string prefix = "gazebo_";
+    std:: string prefix = "gazebo-classic_";
     std::size_t ind = model_name_.find(prefix);
     if(ind !=std::string::npos){
         model_name_.erase(ind,prefix.length());


### PR DESCRIPTION
**Problem Description**
This fixes the model prefix the `user_camera_plugin` looks for to `gazebo-classic_`, as to be aligned with https://github.com/PX4/PX4-Autopilot/pull/20936

- Tested in SITL
```
make px4_sitl gazebo-classic_plane
```