### PR TITLE
removing macos 1015 github actions

### DIFF
--- a/.github/workflows/build_test_macos.yml
+++ b/.github/workflows/build_test_macos.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-10.15, macos-11.0]
+        os: [macos-11.0]
     steps:
     - uses: actions/checkout@v1
     - name: submodule update


### PR DESCRIPTION
MacOs 10.15 seemed to have very very strange behaviours.
So as per this article
https://github.com/actions/runner-images/issues/5583
it seems like github officially declared it as deprecated.
so, this is an attempt to remove it to speed up the current flow