### PR TITLE
fix typhoon broken link

### DIFF
--- a/models/typhoon_h480/typhoon_h480.sdf.jinja
+++ b/models/typhoon_h480/typhoon_h480.sdf.jinja
@@ -1134,7 +1134,7 @@
     </include>
     <joint name="sonar_joint" type="revolute">
       <child>sonar::link</child>
-      <parent>typhoon_h480::base_link</parent>
+      <parent>base_link</parent>
       <axis>
         <xyz>0 0 1</xyz>
         <limit>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5926779/224132647-b99a46c0-3a0f-40d0-b74f-142cd92637e2.png)

It was probably harmless but there was an error spamming the logs when running this vehicle. 
Not sure how this sonar was supposed to work, but maybe we can simply remove it from the vehicle 