### PR TITLE
Update jinja_gen.py

### DIFF
--- a/resources/px4_gazebo_jinja_parameters.json
+++ b/resources/px4_gazebo_jinja_parameters.json
@@ -1,0 +1,10 @@
+{
+    "serial_enabled": 0,
+    "serial_device": "/dev/ttyACM0",
+    "serial_baudrate": 921600,
+    "hil_mode": 0,
+    "cam_component_id": 100,
+    "gst_udp_host": "127.0.0.1",
+    "udp_onboard_gimbal_host_ip": "127.0.0.1",
+    "generate_ros_models": false
+}

--- a/scripts/jinja_gen.py
+++ b/scripts/jinja_gen.py
@@ -55,7 +55,7 @@ if __name__ == "__main__":
     parser.add_argument('--udp_onboard_gimbal_port_remote', default=13030, help="Mavlink Gimbal UDP for SITL")
     parser.add_argument('--generate_ros_models', default=False, dest='generate_ros_models', type=str2bool,
                     help="required if generating the agent for usage with ROS nodes, by default false")
-    parser.add_argument('--override_parameters_json_path', default='/tmp/px4_gazebo_jinja_parameters_0.json', help="json file with variables to override jinja parameters")
+    parser.add_argument('--override_parameters_json_path', default='', help="json file with variables to override jinja parameters")
     args = parser.parse_args()
     env = jinja2.Environment(loader=jinja2.FileSystemLoader(args.env_dir))
     template = env.get_template(os.path.relpath(args.filename, args.env_dir))
@@ -91,7 +91,11 @@ if __name__ == "__main__":
          'hil_mode': args.hil_mode, \
          'ros_version': ros_version}
 
-    parameters_from_json_file = read_jinja_parameters_from_file(args.override_parameters_json_path)
+    override_params_path = args.override_parameters_json_path
+    if not override_params_path:
+        override_params_path = args.env_dir + "/resources/px4_gazebo_jinja_parameters.json"
+
+    parameters_from_json_file = read_jinja_parameters_from_file(override_params_path)
     d.update(parameters_from_json_file)
     result = template.render(d)
 

--- a/scripts/jinja_gen.py
+++ b/scripts/jinja_gen.py
@@ -53,7 +53,7 @@ if __name__ == "__main__":
     parser.add_argument('--udp_onboard_gimbal_port_remote', default=13030, help="Mavlink Gimbal UDP for SITL")
     parser.add_argument('--generate_ros_models', default=False, dest='generate_ros_models', type=str2bool,
                     help="required if generating the agent for usage with ROS nodes, by default false")
-    parser.add_argument('--override_parameters_json_path', default='', help="json file with varaibles to override jinja parameters")
+    parser.add_argument('--override_parameters_json_path', default='/tmp/px4_gazebo_jinja_parameters_0.json', help="json file with variables to override jinja parameters")
     args = parser.parse_args()
     env = jinja2.Environment(loader=jinja2.FileSystemLoader(args.env_dir))
     template = env.get_template(os.path.relpath(args.filename, args.env_dir))

--- a/scripts/jinja_gen.py
+++ b/scripts/jinja_gen.py
@@ -25,6 +25,8 @@ def str2bool(v):
 def read_jinja_parameters_from_file(filepath):
     if not filepath:
         return {}
+    if not os.path.exists(filepath):
+        return {}
     with open(filepath) as f:
         data = json.load(f)
         return data


### PR DESCRIPTION
Setting a default location for the jinja override file location. 
It would be actually good to have an existing one 
{repository_path}/resources/px4_gazebo_jinja_parameters.json is the location I'm already using, but maybe if we are making it available to the public another location that doesn't get flushed would be better. 
