### PR TITLE
iris: move IMU and GPS where they are

### DIFF
--- a/models/iris/iris.sdf.jinja
+++ b/models/iris/iris.sdf.jinja
@@ -53,7 +53,7 @@
       <velocity_decay/>
     </link>
     <link name='/imu_link'>
-      <pose>0 0 0 0 0 0</pose>
+      <pose>0 0 0.02 0 0 0</pose>
       <inertial>
         <pose>0 0 0 0 0 0</pose>
         <mass>0.015</mass>
@@ -420,7 +420,7 @@
     </plugin>
     <include>
       <uri>model://gps</uri>
-      <pose>0.1 0 0 0 0 0</pose>
+      <pose>0.05 0 0.04 0 0 0</pose>
       <name>gps0</name>
     </include>
     <joint name='gps0_joint' type='fixed'>


### PR DESCRIPTION
What about actually having the IMU and GPS locations as they were in reality, once upon a time.

Before with GPS in front:
![2023-05-04_12-16_1](https://user-images.githubusercontent.com/1419688/236078134-f600cde0-0fd4-4c46-abd4-5bb71e6db3cd.png)

After:
![2023-05-04_12-16](https://user-images.githubusercontent.com/1419688/236078190-c64852c4-89b2-4ce3-ade0-b7ba9951fb1b.png)


Just something I found while learning about how to move these things around.