### PR TITLE
Fix: deleted <robotNamespace> in depth_camera.sdf.jinja

### DIFF
--- a/models/depth_camera/depth_camera.sdf.jinja
+++ b/models/depth_camera/depth_camera.sdf.jinja
@@ -71,7 +71,6 @@
         </camera>
         <plugin filename="libgazebo_ros_openni_kinect.so" name="camera_controller">
           <cameraName>camera</cameraName>
-          <robotNamespace></robotNamespace>
           <alwaysOn>true</alwaysOn>
           <updateRate>10</updateRate>
           <pointCloudCutoff>0.2</pointCloudCutoff>


### PR DESCRIPTION
In previous commit, @Cavalletta98 added <robotNamespace> tag in this model.

> e5836d3a5b28b670e8e94aa5fea7b767bb33a745

but this had a serious impact on PX4-Avoidance and other use case of depth camera in custom UAV model.
The difference in the presence of this tag is as follows:

`$ roslaunch local_planner local_planner-depth_camera.launch`

if <robotNamespace> exists:
`$rostopic list` 
```bash
# copied only related topics
/iris_obs_avoid/camera/depth/camera_info
/iris_obs_avoid/camera/depth/image_raw
/iris_obs_avoid/camera/depth/points
/iris_obs_avoid/camera/parameter_descriptions
/iris_obs_avoid/camera/parameter_updates
/iris_obs_avoid/camera/rgb/camera_info
/iris_obs_avoid/camera/rgb/image_raw
/iris_obs_avoid/camera/rgb/image_raw/compressed
/iris_obs_avoid/camera/rgb/image_raw/compressed/parameter_descriptions
/iris_obs_avoid/camera/rgb/image_raw/compressed/parameter_updates
/iris_obs_avoid/camera/rgb/image_raw/compressedDepth
/iris_obs_avoid/camera/rgb/image_raw/compressedDepth/parameter_descriptions
/iris_obs_avoid/camera/rgb/image_raw/compressedDepth/parameter_updates
/iris_obs_avoid/camera/rgb/image_raw/theora
/iris_obs_avoid/camera/rgb/image_raw/theora/parameter_descriptions
/iris_obs_avoid/camera/rgb/image_raw/theora/parameter_updates
```
else (this commit version or before  e5836d3a5b28b670e8e94aa5fea7b767bb33a745)
```bash
# copied only related topics
/camera/depth/camera_info
/camera/depth/image_raw
/camera/depth/points
/camera/parameter_descriptions
/camera/parameter_updates
/camera/rgb/camera_info
/camera/rgb/image_raw
/camera/rgb/image_raw/compressed
/camera/rgb/image_raw/compressed/parameter_descriptions
/camera/rgb/image_raw/compressed/parameter_updates
/camera/rgb/image_raw/compressedDepth
/camera/rgb/image_raw/compressedDepth/parameter_descriptions
/camera/rgb/image_raw/compressedDepth/parameter_updates
/camera/rgb/image_raw/theora
/camera/rgb/image_raw/theora/parameter_descriptions
/camera/rgb/image_raw/theora/parameter_updates
```
Since PX4-Avoidance utilizes the "/camera/depth/points" topic in their launch file, it might be more logical or appropriate to exclude this tag.
[`<arg name="pointcloud_topics" default="[/camera/depth/points]"/>`](https://github.com/PX4/PX4-Avoidance/blob/master/local_planner/launch/local_planner_depth-camera.launch#L5)

I know that using a specific robot namespace is easier for users to customize and utilize for models, but this ultimately depends on the user's needs.

