### PR TITLE
Fix force visualization feature

### DIFF
--- a/models/advanced_plane/advanced_plane.sdf.jinja
+++ b/models/advanced_plane/advanced_plane.sdf.jinja
@@ -49,6 +49,10 @@
             <uri>__default__</uri>
           </script>
         </material>
+        <plugin name="left_elevon_lift_visual" filename="libForceVisual.so">
+          <topic_name>lift_force/lumped_force</topic_name>
+          <color>Gazebo/Green</color>
+        </plugin>
       </visual>
       <gravity>1</gravity>
       <velocity_decay/>
@@ -190,10 +194,6 @@
             <uri>__default__</uri>
           </script>
         </material>
-        <plugin name="left_elevon_lift_visual" filename="libForceVisual.so">
-          <topic_name>lift_force/left_elevon</topic_name>
-          <color>Gazebo/Red</color>
-        </plugin>
       </visual>
     </link>
     <link name="right_elevon">
@@ -223,10 +223,6 @@
             <uri>__default__</uri>
           </script>
         </material>
-        <plugin name="right_elevon_lift_visual" filename="libForceVisual.so">
-          <topic_name>lift_force/right_elevon</topic_name>
-          <color>Gazebo/Green</color>
-        </plugin>
       </visual>
     </link>
     <link name="left_flap">
@@ -521,7 +517,7 @@
       <forward>1 0 0</forward>
       <upward>0 0 1</upward>
       <link_name>base_link</link_name>
-      <!--<topic_name>lift_force/left_elevon</topic_name> Uncomment to draw the force -->
+      <topic_name>lift_force/lumped_force</topic_name> <!--Uncomment to draw the force-->
       <num_ctrl_surfaces>4</num_ctrl_surfaces>
       <control_surface>
         <name>left_elevon_joint</name>

--- a/models/plane/plane.sdf.jinja
+++ b/models/plane/plane.sdf.jinja
@@ -192,7 +192,7 @@
         </material>
         <plugin name="left_elevon_lift_visual" filename="libForceVisual.so">
           <topic_name>lift_force/left_elevon</topic_name>
-          <color>Gazebo/Red</color>
+          <color>Gazebo/Green</color>
         </plugin>
       </visual>
     </link>
@@ -256,6 +256,10 @@
             <uri>__default__</uri>
           </script>
         </material>
+        <plugin name="left_flap_lift_visual" filename="libForceVisual.so">
+          <topic_name>lift_force/left_flap</topic_name>
+          <color>Gazebo/Green</color>
+        </plugin>
       </visual>
     </link>
     <link name="right_flap">
@@ -285,6 +289,10 @@
             <uri>__default__</uri>
           </script>
         </material>
+        <plugin name="right_elevon_lift_visual" filename="libForceVisual.so">
+          <topic_name>lift_force/right_flap</topic_name>
+          <color>Gazebo/Green</color>
+        </plugin>
       </visual>
     </link>
     <link name="elevator">
@@ -314,6 +322,10 @@
             <uri>__default__</uri>
           </script>
         </material>
+        <plugin name="elevator_lift_visual" filename="libForceVisual.so">
+          <topic_name>lift_force/elevator</topic_name>
+          <color>Gazebo/Green</color>
+        </plugin>
       </visual>
     </link>
     <link name="rudder">
@@ -343,6 +355,10 @@
             <uri>__default__</uri>
           </script>
         </material>
+        <plugin name="rudder_lift_visual" filename="libForceVisual.so">
+          <topic_name>lift_force/rudder</topic_name>
+          <color>Gazebo/Green</color>
+        </plugin>
       </visual>
     </link>
     <joint name='left_elevon_joint' type='revolute'>
@@ -495,7 +511,7 @@
       <forward>1 0 0</forward>
       <upward>0 0 1</upward>
       <link_name>base_link</link_name>
-      <!--<topic_name>lift_force/left_elevon</topic_name> Uncomment to draw the force -->
+      <topic_name>lift_force/left_elevon</topic_name> <!--Uncomment to draw the force-->
       <control_joint_name>
         left_elevon_joint
       </control_joint_name>
@@ -518,7 +534,7 @@
       <forward>1 0 0</forward>
       <upward>0 0 1</upward>
       <link_name>base_link</link_name>
-      <!--<topic_name>lift_force/right_elevon</topic_name> Uncomment to draw the force -->
+      <topic_name>lift_force/right_elevon</topic_name> <!--Uncomment to draw the force-->
       <control_joint_name>
         right_elevon_joint
       </control_joint_name>
@@ -541,6 +557,7 @@
       <forward>1 0 0</forward>
       <upward>0 0 1</upward>
       <link_name>base_link</link_name>
+      <topic_name>lift_force/left_flap</topic_name> <!--Uncomment to draw the force-->
       <control_joint_name>
         left_flap_joint
       </control_joint_name>
@@ -563,6 +580,7 @@
       <forward>1 0 0</forward>
       <upward>0 0 1</upward>
       <link_name>base_link</link_name>
+      <topic_name>lift_force/right_flap</topic_name> <!--Uncomment to draw the force-->
       <control_joint_name>
         right_flap_joint
       </control_joint_name>
@@ -585,6 +603,7 @@
       <forward>1 0 0</forward>
       <upward>0 0 1</upward>
       <link_name>base_link</link_name>
+      <topic_name>lift_force/elevator</topic_name> <!--Uncomment to draw the force-->
       <control_joint_name>
         elevator_joint
       </control_joint_name>
@@ -607,6 +626,7 @@
       <forward>1 0 0</forward>
       <upward>0 1 0</upward>
       <link_name>base_link</link_name>
+      <topic_name>lift_force/rudder</topic_name> <!--Uncomment to draw the force-->
       <control_joint_name>
          rudder_joint
       </control_joint_name>

--- a/src/liftdrag_plugin/advanced_liftdrag_plugin.cpp
+++ b/src/liftdrag_plugin/advanced_liftdrag_plugin.cpp
@@ -574,9 +574,11 @@ CL_poststall = 2*(this->alpha/abs(this->alpha))*pow(sinAlpha,2.0)*cosAlpha
       force_center_msg->set_z(relative_center.Z());
 
       msgs::Vector3d* force_vector_msg = new msgs::Vector3d;
-      force_vector_msg->set_x(force.X());
-      force_vector_msg->set_y(force.Y());
-      force_vector_msg->set_z(force.Z());
+      ignition::math::Quaterniond veh_q_world_to_body = pose.Rot();
+      auto force_in_body = veh_q_world_to_body.RotateVectorReverse(force);
+      force_vector_msg->set_x(force_in_body.X());
+      force_vector_msg->set_y(force_in_body.Y());
+      force_vector_msg->set_z(force_in_body.Z());
 
       physics_msgs::msgs::Force force_msg;
       force_msg.set_allocated_center(force_center_msg);

--- a/src/liftdrag_plugin/liftdrag_plugin.cpp
+++ b/src/liftdrag_plugin/liftdrag_plugin.cpp
@@ -447,9 +447,12 @@ void LiftDragPlugin::OnUpdate()
       force_center_msg->set_z(relative_center.Z());
 
       msgs::Vector3d* force_vector_msg = new msgs::Vector3d;
-      force_vector_msg->set_x(force.X());
-      force_vector_msg->set_y(force.Y());
-      force_vector_msg->set_z(force.Z());
+      ignition::math::Quaterniond veh_q_world_to_body = pose.Rot();
+      auto force_in_body = veh_q_world_to_body.RotateVectorReverse(force);
+      // Transform force to link coordinates
+      force_vector_msg->set_x(force_in_body.X());
+      force_vector_msg->set_y(force_in_body.Y());
+      force_vector_msg->set_z(force_in_body.Z());
 
       physics_msgs::msgs::Force force_msg;
       force_msg.set_allocated_center(force_center_msg);


### PR DESCRIPTION
**Problem Description**
While the liftdrag plugin is publishing calculated forces in the world frame coordinates, the force_visual plugin visualizes the forces in the link relative frame.

**Proposed Solution**
This PR fixes the force visualization feature to use the correct frames. This is done by converting the force into link relative frame before publishing the message

Somehow I can't assign @JonasVautherin as a reviewer...

To test:
```
make px4_sitl gazebo-classic_plane
```

- Liftdrag plugin
![ezgif com-video-to-gif (1)](https://github.com/PX4/PX4-SITL_gazebo-classic/assets/5248102/969f06de-7ff3-47d1-a06a-7af452d8d47a)

- Advanced Liftdrag plugin
![ezgif com-video-to-gif (2)](https://github.com/PX4/PX4-SITL_gazebo-classic/assets/5248102/2b1070b9-8177-43a3-9778-a5121c911e8b)
