### PR TITLE
Add gimbal device id to mavlink messages DeviceAttitudeStatus and DeviceInformation

### DIFF
--- a/src/gazebo_camera_manager_plugin.cpp
+++ b/src/gazebo_camera_manager_plugin.cpp
@@ -585,7 +585,8 @@ void CameraManagerPlugin::_handle_camera_info(const mavlink_message_t *pMsg, str
         0,                         // lens_id
         camera_capabilities,       // CAP_FLAGS
         0,                         // Camera Definition Version
-        uri                        // URI
+        uri,                       // URI
+        0                          // uint8_t gimbal_device_id
     );
     _send_mavlink_message(&msg, srcaddr);
 }

--- a/src/gazebo_gimbal_controller_plugin.cpp
+++ b/src/gazebo_gimbal_controller_plugin.cpp
@@ -682,7 +682,8 @@ void GimbalControllerPlugin::SendGimbalDeviceInformation()
     pitchMin,
     pitchMax,
     yawMin,
-    yawMax);
+    yawMax,
+    0 /*gimbal_device_id*/);
   SendMavlinkMessage(msg);
 }
 
@@ -736,7 +737,8 @@ void GimbalControllerPlugin::SendGimbalDeviceAttitudeStatus()
     angularVelocity.Z(),
     failureFlags,
     NAN, // per mavlink spec - NAN if unknown
-    NAN); // per mavlink spec - NAN if unknown
+    NAN, // per mavlink spec - NAN if unknown
+    0 /*gimbal_device_id*/);
   SendMavlinkMessage(msg);
 }
 


### PR DESCRIPTION
Added field `gimbal_device_id` to mavlink messages GIMBAL_DEVICE_INFORMATION ([ GIMBAL_DEVICE_INFORMATION ](https://mavlink.io/en/messages/common.html#GIMBAL_DEVICE_INFORMATION)) and   ([ GIMBAL_DEVICE_ATTITUDE_STATUS ](https://mavlink.io/en/messages/common.html#GIMBAL_DEVICE_ATTITUDE_STATUS))