### PR TITLE
wind plugin: add option to simulate a constant wind change with ramp up

### DIFF
--- a/include/gazebo_wind_plugin.h
+++ b/include/gazebo_wind_plugin.h
@@ -52,6 +52,10 @@ static const ignition::math::Vector3d kDefaultWindGustDirectionMean = ignition::
 static constexpr double kDefaultWindDirectionVariance = 0.0;
 static constexpr double kDefaultWindGustDirectionVariance = 0.0;
 
+static constexpr double kDefaultWindRampStart = 0.;
+static constexpr double kDefaultWindRampDuration = 0.;
+static const ignition::math::Vector3d kDefaultRampedWindVector = ignition::math::Vector3d(0, 0, 0);
+
 /// \brief This gazebo plugin simulates wind acting on a model.
 class GazeboWindPlugin : public WorldPlugin {
  public:
@@ -69,6 +73,7 @@ class GazeboWindPlugin : public WorldPlugin {
         wind_direction_variance_(kDefaultWindDirectionVariance),
         wind_gust_direction_mean_(kDefaultWindGustDirectionMean),
         wind_gust_direction_variance_(kDefaultWindGustDirectionVariance),
+        ramped_wind_vector(kDefaultRampedWindVector),
         frame_id_(kDefaultFrameId),
         pub_interval_(0.5),
         node_handle_(NULL) {}
@@ -124,6 +129,10 @@ class GazeboWindPlugin : public WorldPlugin {
   common::Time wind_gust_end_;
   common::Time wind_gust_start_;
   common::Time last_time_;
+
+  ignition::math::Vector3d ramped_wind_vector;
+  common::Time wind_ramp_start_;
+  common::Time wind_ramp_duration_;
 
   transport::NodePtr node_handle_;
   transport::PublisherPtr wind_pub_;

--- a/src/gazebo_wind_plugin.cpp
+++ b/src/gazebo_wind_plugin.cpp
@@ -34,6 +34,9 @@ void GazeboWindPlugin::Load(physics::WorldPtr world, sdf::ElementPtr sdf) {
   double wind_gust_start = kDefaultWindGustStart;
   double wind_gust_duration = kDefaultWindGustDuration;
 
+  double wind_ramp_start = kDefaultWindRampStart;
+  double wind_ramp_duration = kDefaultWindRampDuration;
+
   if (sdf->HasElement("robotNamespace")) {
     namespace_ = sdf->GetElement("robotNamespace")->Get<std::string>();
   } else {
@@ -80,6 +83,14 @@ void GazeboWindPlugin::Load(physics::WorldPtr world, sdf::ElementPtr sdf) {
   wind_gust_direction_distribution_X_.param(std::normal_distribution<double>::param_type(wind_gust_direction_mean_.X(), sqrt(wind_gust_direction_variance_)));
   wind_gust_direction_distribution_Y_.param(std::normal_distribution<double>::param_type(wind_gust_direction_mean_.Y(), sqrt(wind_gust_direction_variance_)));
   wind_gust_direction_distribution_Z_.param(std::normal_distribution<double>::param_type(wind_gust_direction_mean_.Z(), sqrt(wind_gust_direction_variance_)));
+
+  // Get the ramped wind params from SDF.
+  getSdfParam<double>(sdf, "windRampStart", wind_ramp_start, wind_ramp_start);
+  getSdfParam<double>(sdf, "windChangeRampDuration", wind_ramp_duration, wind_ramp_duration);
+  getSdfParam<ignition::math::Vector3d>(sdf, "windRampWindVectorComponents", ramped_wind_vector, ramped_wind_vector);
+
+  wind_ramp_start_ = common::Time(wind_ramp_start);
+  wind_ramp_duration_ = common::Time(wind_ramp_duration);
 
   // Listen to the update event. This event is broadcast every
   // simulation iteration.
@@ -133,6 +144,15 @@ void GazeboWindPlugin::OnUpdate(const common::UpdateInfo& _info) {
     wind_gust_direction.Z() = wind_gust_direction_distribution_Z_(wind_gust_direction_generator_);
     wind_gust = wind_gust_strength * wind_gust_direction;
   }
+
+  // Calculate the wind with the added ramped up wind component
+  const double denominator = wind_ramp_start_.Double() + wind_ramp_duration_.Double();
+  double ramp_factor = 0.;
+  if (denominator > 0) {
+    ramp_factor = constrain((now - wind_ramp_start_).Double() / denominator, 0., 1.);
+  }
+
+  wind += ramp_factor * ramped_wind_vector;
 
   gazebo::msgs::Vector3d* wind_v = new gazebo::msgs::Vector3d();
   wind_v->set_x(wind.X() + wind_gust.X());

--- a/worlds/ramped_up_wind.world
+++ b/worlds/ramped_up_wind.world
@@ -1,0 +1,57 @@
+<?xml version="1.0" ?>
+<sdf version="1.5">
+  <world name="default">
+    <!-- A global light source -->
+    <include>
+      <uri>model://sun</uri>
+    </include>
+    <!-- A ground plane -->
+    <include>
+      <uri>model://ground_plane</uri>
+    </include>
+    <include>
+      <uri>model://asphalt_plane</uri>
+    </include>
+    <plugin name='wind_plugin' filename='libgazebo_wind_plugin.so'>
+      <frameId>base_link</frameId>
+      <robotNamespace/>
+      <windVelocityMean>5.0</windVelocityMean>
+      <windVelocityMax>20.0</windVelocityMax>
+      <windVelocityVariance>0</windVelocityVariance>
+      <windDirectionMean>0 1 0</windDirectionMean>
+      <windDirectionVariance>0</windDirectionVariance>
+      <windRampStart>60</windRampStart>
+      <windRampWindVectorComponents>0 15 0</windRampWindVectorComponents>
+      <windChangeRampDuration>30</windChangeRampDuration>
+      <windGustStart>0</windGustStart>
+      <windGustDuration>0</windGustDuration>
+      <windGustVelocityMean>0</windGustVelocityMean>
+      <windGustVelocityMax>20.0</windGustVelocityMax>
+      <windGustVelocityVariance>0</windGustVelocityVariance>
+      <windGustDirectionMean>1 0 0</windGustDirectionMean>
+      <windGustDirectionVariance>0</windGustDirectionVariance>
+      <windPubTopic>world_wind</windPubTopic>
+    </plugin>
+    <physics name='default_physics' default='0' type='ode'>
+      <gravity>0 0 -9.8066</gravity>
+      <ode>
+        <solver>
+          <type>quick</type>
+          <iters>10</iters>
+          <sor>1.3</sor>
+          <use_dynamic_moi_rescaling>0</use_dynamic_moi_rescaling>
+        </solver>
+        <constraints>
+          <cfm>0</cfm>
+          <erp>0.2</erp>
+          <contact_max_correcting_vel>100</contact_max_correcting_vel>
+          <contact_surface_layer>0.001</contact_surface_layer>
+        </constraints>
+      </ode>
+      <max_step_size>0.004</max_step_size>
+      <real_time_factor>1</real_time_factor>
+      <real_time_update_rate>250</real_time_update_rate>
+      <magnetic_field>6.0e-6 2.3e-5 -4.2e-5</magnetic_field>
+    </physics>
+  </world>
+</sdf>


### PR DESCRIPTION
-add option to add a custom 3D wind vector starting at time X with ramp up time Y
-add new world that has it enabled (ramped_up_wind.world). It starts with a constant wind in direction North (5m/s), then at t=180s ramps in a wind component in North direction over 30s to a magnitude of 15m/s (to a total of 20m/s wind in direction N)

Required for https://github.com/PX4/PX4-Autopilot/pull/21764