### PR TITLE
Add Iris model with a depth camera and downward-facing lidar

### DIFF
--- a/models/iris_depth_camera_downward_lidar/iris_depth_camera_downward_lidar.sdf
+++ b/models/iris_depth_camera_downward_lidar/iris_depth_camera_downward_lidar.sdf
@@ -1,0 +1,19 @@
+<?xml version="1.0" ?>
+<sdf version="1.5">
+  <model name='iris_depth_camera_downward_lidar'>
+    <include>
+      <uri>model://iris_depth_camera</uri>
+    </include>
+
+    <!--downward-facing lidar-->
+    <include>
+      <uri>model://lidar</uri>
+      <pose>-0.1 0 -0.01 0 0 0</pose>
+    </include>
+    <joint name="lidar_joint" type="fixed">
+      <parent>iris_depth_camera::iris::base_link</parent>
+      <child>lidar::link</child>
+    </joint>
+
+  </model>
+</sdf>

--- a/models/iris_depth_camera_downward_lidar/model.config
+++ b/models/iris_depth_camera_downward_lidar/model.config
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<model>
+  <name>3DR Iris with depth camera and downward-facing Lidar</name>
+  <version>1.0</version>
+  <sdf version='1.0'>iris_depth_camera_downward_lidar.sdf</sdf>
+
+  <author>
+   <name>Daniel Mesham</name>
+   <email>daniel@auterion.com</email>
+  </author>
+
+  <description>
+    A model of the 3DR Iris Quadrotor with a forward-facing depth camera and a downward-facing Lidar.
+  </description>
+</model>


### PR DESCRIPTION
This extends the model with a forward-facing depth camera to also have a downward-facing Lidar range finder. The Lidar is mounted at the rear of the vehicle (see image).

This model is useful in applications that require perception in multiple directions.

![depth_cam_with_lidar](https://github.com/PX4/PX4-SITL_gazebo-classic/assets/12900114/dcb49ca1-8a0a-45ce-854f-a96cc8f41e25)