### PR TITLE
ramped up wind.world: increase windRampStart to 90s

### DIFF
--- a/worlds/ramped_up_wind.world
+++ b/worlds/ramped_up_wind.world
@@ -20,7 +20,7 @@
       <windVelocityVariance>0</windVelocityVariance>
       <windDirectionMean>0 1 0</windDirectionMean>
       <windDirectionVariance>0</windDirectionVariance>
-      <windRampStart>60</windRampStart>
+      <windRampStart>90</windRampStart>
       <windRampWindVectorComponents>0 15 0</windRampWindVectorComponents>
       <windChangeRampDuration>30</windChangeRampDuration>
       <windGustStart>0</windGustStart>


### PR DESCRIPTION
To give simulated vehicles more time to establish in air before the wind is ramped up.