### PR TITLE
Parameterize maximum relative air velocity for generating thrust on the motors

### DIFF
--- a/include/gazebo_motor_model.h
+++ b/include/gazebo_motor_model.h
@@ -71,6 +71,7 @@ static constexpr double kDefaulMaxRotVelocity = 838.0;
 static constexpr double kDefaultRotorDragCoefficient = 1.0e-4;
 static constexpr double kDefaultRollingMomentCoefficient = 1.0e-6;
 static constexpr double kDefaultRotorVelocitySlowdownSim = 10.0;
+static constexpr double kDefaultMaxRelativeAirspeed = 25.0;
 
 class GazeboMotorModel : public MotorModel, public ModelPlugin {
  public:
@@ -118,6 +119,7 @@ class GazeboMotorModel : public MotorModel, public ModelPlugin {
   double rotor_velocity_slowdown_sim_{kDefaultRotorVelocitySlowdownSim};
   double time_constant_down_{kDefaultTimeConstantDown};
   double time_constant_up_{kDefaultTimeConstantUp};
+  double max_relative_airspeed_{kDefaultMaxRelativeAirspeed};
 
   bool reversible_{false};
 

--- a/src/gazebo_motor_model.cpp
+++ b/src/gazebo_motor_model.cpp
@@ -129,6 +129,7 @@ void GazeboMotorModel::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf) {
   getSdfParam<double>(_sdf, "rollingMomentCoefficient", rolling_moment_coefficient_,
                       rolling_moment_coefficient_);
   getSdfParam<double>(_sdf, "maxRotVelocity", max_rot_velocity_, max_rot_velocity_);
+  getSdfParam<double>(_sdf, "maxRelativeAirspeed", max_relative_airspeed_, max_relative_airspeed_);
   getSdfParam<double>(_sdf, "motorConstant", motor_constant_, motor_constant_);
   getSdfParam<double>(_sdf, "momentConstant", moment_constant_, moment_constant_);
 

--- a/src/gazebo_motor_model.cpp
+++ b/src/gazebo_motor_model.cpp
@@ -217,8 +217,7 @@ void GazeboMotorModel::UpdateForcesAndMoments() {
 
   ignition::math::Vector3d relative_wind_velocity = body_velocity - wind_vel_;
   ignition::math::Vector3d velocity_parallel_to_rotor_axis = (relative_wind_velocity.Dot(joint_axis)) * joint_axis;
-  double vel = velocity_parallel_to_rotor_axis.Length();
-  double scalar = 1 - vel / 25.0; // at 25 m/s the rotor will not produce any force anymore
+  double scalar = 1 - velocity_parallel_to_rotor_axis.Length() / max_relative_airspeed_; // at 25 m/s the rotor will not produce any force anymore
   scalar = ignition::math::clamp(scalar, 0.0, 1.0);
   // Apply a force to the link.
   link_->AddRelativeForce(ignition::math::Vector3d(0, 0, force * scalar));


### PR DESCRIPTION
**Problem Description**
This PR parameterizes the maximum air relative velocity that the motor model generates, which was defined as 25m/s previously. 