### PR TITLE
standard_vtol.sdf: increase max airspeed for thrust model to 30m/s

### DIFF
--- a/models/standard_vtol/standard_vtol.sdf.jinja
+++ b/models/standard_vtol/standard_vtol.sdf.jinja
@@ -859,6 +859,7 @@
       <timeConstantDown>0.025</timeConstantDown>
       <maxRotVelocity>3500</maxRotVelocity>
       <motorConstant>8.54858e-06</motorConstant>
+      <maxRelativeAirspeed>30</maxRelativeAirspeed>
       <momentConstant>0.01</momentConstant>
       <commandSubTopic>/gazebo/command/motor_speed</commandSubTopic>
       <motorNumber>4</motorNumber>


### PR DESCRIPTION
Change possible after https://github.com/PX4/PX4-SITL_gazebo-classic/pull/1045