### PR TITLE
camera_manager_plugin: fix mavlink messages for camera info and video stream information

### DIFF
--- a/src/gazebo_camera_manager_plugin.cpp
+++ b/src/gazebo_camera_manager_plugin.cpp
@@ -720,7 +720,6 @@ void CameraManagerPlugin::_handle_request_video_stream_information(const mavlink
     video_stream_information.hfov = 90; // made up
     std::strncpy(video_stream_information.name, "Visual Spectrum", sizeof(video_stream_information.name));
     std::strncpy(video_stream_information.uri, _videoURI.c_str(), sizeof(video_stream_information.uri));
-    video_stream_information.encoding = VIDEO_STREAM_ENCODING_H264;
 
     mavlink_message_t msg;
     mavlink_msg_video_stream_information_encode_chan(_systemID, _componentID, MAVLINK_COMM_1, &msg, &video_stream_information);

--- a/src/gazebo_camera_manager_plugin.cpp
+++ b/src/gazebo_camera_manager_plugin.cpp
@@ -631,7 +631,7 @@ void CameraManagerPlugin::_handle_camera_info(const mavlink_message_t *pMsg, str
                                 | CAMERA_CAP_FLAGS_HAS_VIDEO_STREAM;;
 
     mavlink_message_t msg;
-    mavlink_msg_camera_information_encode(_systemID, _componentID, &msg, &camera_information);
+    mavlink_msg_camera_information_encode_chan(_systemID, _componentID, MAVLINK_COMM_1, &msg, &camera_information);
     _send_mavlink_message(&msg, srcaddr);
 }
 
@@ -723,7 +723,7 @@ void CameraManagerPlugin::_handle_request_video_stream_information(const mavlink
     video_stream_information.encoding = VIDEO_STREAM_ENCODING_H264;
 
     mavlink_message_t msg;
-    mavlink_msg_video_stream_information_encode(_systemID, _componentID, &msg, &video_stream_information);
+    mavlink_msg_video_stream_information_encode_chan(_systemID, _componentID, MAVLINK_COMM_1, &msg, &video_stream_information);
     _send_mavlink_message(&msg, srcaddr);
 }
 

--- a/src/gazebo_camera_manager_plugin.cpp
+++ b/src/gazebo_camera_manager_plugin.cpp
@@ -616,25 +616,19 @@ void CameraManagerPlugin::_handle_camera_info(const mavlink_message_t *pMsg, str
     _send_cmd_ack(pMsg->sysid, pMsg->compid, MAV_CMD_REQUEST_CAMERA_INFORMATION, MAV_RESULT_ACCEPTED, srcaddr);
 
     mavlink_camera_information_t camera_information{};
-    camera_information.time_boot_ms = 0;
-    std::strcpy((char *)camera_information.vendor_name, "PX4.io");
-    std::strcpy((char *)camera_information.model_name, "Gazebo");
+    std::strncpy((char *)camera_information.vendor_name, "PX4.io", sizeof(camera_information.vendor_name));
+    std::strncpy((char *)camera_information.model_name, "Gazebo", sizeof(camera_information.model_name));
     camera_information.firmware_version = 0x01;
     camera_information.focal_length = 50.f;
     camera_information.sensor_size_h = 35.f;
     camera_information.sensor_size_v = 24.f;
     camera_information.resolution_h = _width;
     camera_information.resolution_v = _height;
-    camera_information.lens_id = 0;
     camera_information.flags = CAMERA_CAP_FLAGS_CAPTURE_IMAGE
                                 | CAMERA_CAP_FLAGS_CAPTURE_VIDEO
                                 | CAMERA_CAP_FLAGS_HAS_MODES
                                 | CAMERA_CAP_FLAGS_HAS_BASIC_ZOOM
                                 | CAMERA_CAP_FLAGS_HAS_VIDEO_STREAM;;
-    camera_information.cam_definition_version = 0;
-    std::strcpy(camera_information.cam_definition_uri, "");
-    camera_information.gimbal_device_id = 0;
-    camera_information.camera_device_id = 0;
 
     mavlink_message_t msg;
     mavlink_msg_camera_information_encode(_systemID, _componentID, &msg, &camera_information);
@@ -723,10 +717,10 @@ void CameraManagerPlugin::_handle_request_video_stream_information(const mavlink
     video_stream_information.resolution_h = _width;
     video_stream_information.resolution_v = _height;
     video_stream_information.bitrate = 2048;
-    video_stream_information.rotation = 0; // none
     video_stream_information.hfov = 90; // made up
-    std::strcpy(video_stream_information.name, "Visual Spectrum");
-    std::strcpy(video_stream_information.uri, _videoURI.c_str());
+    std::strncpy(video_stream_information.name, "Visual Spectrum", sizeof(video_stream_information.name));
+    std::strncpy(video_stream_information.uri, _videoURI.c_str(), sizeof(video_stream_information.uri));
+    video_stream_information.encoding = VIDEO_STREAM_ENCODING_H264;
 
     mavlink_message_t msg;
     mavlink_msg_video_stream_information_encode(_systemID, _componentID, &msg, &video_stream_information);


### PR DESCRIPTION
### Problem

Can't update MAVLink in PX4 anymore because of
https://github.com/mavlink/mavlink/pull/2121
https://github.com/mavlink/mavlink/pull/2127
which are not breaking changes but because of the way they are invoked here end up breaking the build
which makes CI in https://github.com/PX4/PX4-Autopilot/pull/23490 fail.

### Solution
Like proposed by @dagar this time I fix it with the struct call instead of the direct pack_chan() calls. So it should hold longer.

Please check if I did any mistake with these string, component ID and MAVLink channel things. What was `MAVLINK_COMM_1` used for?