### PR TITLE
Report positive value for h480 yawMax and negative value for yawMin

### DIFF
--- a/src/gazebo_gimbal_controller_plugin.cpp
+++ b/src/gazebo_gimbal_controller_plugin.cpp
@@ -659,8 +659,8 @@ void GimbalControllerPlugin::SendGimbalDeviceInformation()
   const float rollMin = this->rollJoint->LowerLimit(0);
   const float pitchMax = this->pitchJoint->UpperLimit(0);
   const float pitchMin = this->pitchJoint->LowerLimit(0);
-  const float yawMax = this->yawJoint->LowerLimit(0);
-  const float yawMin = this->yawJoint->UpperLimit(0);
+  const float yawMax = this->yawJoint->UpperLimit(0);
+  const float yawMin = this->yawJoint->LowerLimit(0);
 
   mavlink_message_t msg;
   mavlink_msg_gimbal_device_information_pack_chan(


### PR DESCRIPTION
The h480 sim gimbal has no limit on its yaw axis. Before, it was reporting its yawMax as -1e+16 (value came from typhoon_h480.sdf.jinja:247) and its yawMin as 1e+16 (value came from typhoon_h480.sdf.jinja:248). The sign of these 2 needed to be switched, which is the fix made by this commit.

The MAVLink GIMBAL_DEVICE_INFORMATION message does not specify how to represent infinity, but it does specify "positive: to the right, negative: to the left". Gazebo already considers the right the positive direction, and handles commands as expected. This commit just fixes the yawMin/yawMax limit reporting.

## Sponsor
This contribution was sponsored by [Firestorm](https://www.launchfirestorm.com/)
![654d4f9476ff2a38f37e9ab9_firestorm-homepage-share-img-2](https://github.com/user-attachments/assets/bc1a2c95-b33d-4a2d-af35-4d2d8651d0a2)