### PR TITLE
<direction> Element in Catapult Plugin Overwrites commandSubTopic

### DIFF
--- a/include/gazebo_catapult_plugin.h
+++ b/include/gazebo_catapult_plugin.h
@@ -99,7 +99,7 @@ private:
   double launch_duration_ = 0.01;
   double force_magnitude_ = 1.0;
   int motor_number_;
-  ignition::math::Vector3d direction_;
+  ignition::math::Vector3d direction_ = ignition::math::Vector3d(1.0, 0.0, 2.0);
 
   std::string trigger_sub_topic_ = "/gazebo/command/motor_speed";
 

--- a/include/gazebo_catapult_plugin.h
+++ b/include/gazebo_catapult_plugin.h
@@ -99,6 +99,7 @@ private:
   double launch_duration_ = 0.01;
   double force_magnitude_ = 1.0;
   int motor_number_;
+  ignition::math::Vector3d direction_;
 
   std::string trigger_sub_topic_ = "/gazebo/command/motor_speed";
 

--- a/include/gazebo_catapult_plugin.h
+++ b/include/gazebo_catapult_plugin.h
@@ -99,7 +99,7 @@ private:
   double launch_duration_ = 0.01;
   double force_magnitude_ = 1.0;
   int motor_number_;
-  ignition::math::Vector3d direction_ = ignition::math::Vector3d(1.0, 0.0, 2.0);
+  ignition::math::Vector3d direction_ {ignition::math::Vector3d(1.0, 0.0, 2.0)};
 
   std::string trigger_sub_topic_ = "/gazebo/command/motor_speed";
 

--- a/src/gazebo_catapult_plugin.cpp
+++ b/src/gazebo_catapult_plugin.cpp
@@ -77,6 +77,13 @@ void CatapultPlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf)
     gzerr << "[gazebo_catapult_plugin] link_name needs to be provided";
   }
 
+  if (_sdf->HasElement("direction")) {
+    direction_ = _sdf->Get<ignition::math::Vector3d>("direction");
+  } else {
+    direction_ = ignition::math::Vector3d(1.0, 0.0, 2.0);
+  }
+  direction_.Normalize();
+
   if (_sdf->HasElement("motorNumber"))
     motor_number_ = _sdf->GetElement("motorNumber")->Get<int>();
   else
@@ -84,7 +91,6 @@ void CatapultPlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf)
 
   getSdfParam<std::string>(_sdf, "commandSubTopic", trigger_sub_topic_, trigger_sub_topic_);
   getSdfParam<double>(_sdf, "force", force_magnitude_, force_magnitude_);
-  getSdfParam<std::string>(_sdf, "direction", trigger_sub_topic_, trigger_sub_topic_);
   getSdfParam<double>(_sdf, "duration", launch_duration_, launch_duration_);
 
   // Listen to the update event. This event is broadcast every simulation iteration.
@@ -110,12 +116,8 @@ void CatapultPlugin::OnUpdate(const common::UpdateInfo&){
         std::cout << "[gazebo_catapult_plugin] Catapult armed " << std::endl;
       
       } else { // launch_status = VEHICLE_INLAUNCH
-        //Define launch direction
-        ignition::math::Vector3d direction(1.0, 0.0, 2.0);
-        direction.Normalize();
-
         //Apply force to the vehicle
-        ignition::math::Vector3d force = force_magnitude_ * direction;
+        ignition::math::Vector3d force = force_magnitude_ * direction_;
         this->link_->AddForce(force);     
         #if GAZEBO_MAJOR_VERSION >= 9
           common::Time curr_time = world_->SimTime();

--- a/src/gazebo_catapult_plugin.cpp
+++ b/src/gazebo_catapult_plugin.cpp
@@ -77,13 +77,6 @@ void CatapultPlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf)
     gzerr << "[gazebo_catapult_plugin] link_name needs to be provided";
   }
 
-  if (_sdf->HasElement("direction")) {
-    direction_ = _sdf->Get<ignition::math::Vector3d>("direction");
-  } else {
-    direction_ = ignition::math::Vector3d(1.0, 0.0, 2.0);
-  }
-  direction_.Normalize();
-
   if (_sdf->HasElement("motorNumber"))
     motor_number_ = _sdf->GetElement("motorNumber")->Get<int>();
   else
@@ -92,6 +85,7 @@ void CatapultPlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf)
   getSdfParam<std::string>(_sdf, "commandSubTopic", trigger_sub_topic_, trigger_sub_topic_);
   getSdfParam<double>(_sdf, "force", force_magnitude_, force_magnitude_);
   getSdfParam<double>(_sdf, "duration", launch_duration_, launch_duration_);
+  getSdfParam<ignition::math::Vector3d>(_sdf, "direction", direction_, direction_);
 
   // Listen to the update event. This event is broadcast every simulation iteration.
   _updateConnection = event::Events::ConnectWorldUpdateBegin(boost::bind(&CatapultPlugin::OnUpdate, this, _1));
@@ -116,6 +110,8 @@ void CatapultPlugin::OnUpdate(const common::UpdateInfo&){
         std::cout << "[gazebo_catapult_plugin] Catapult armed " << std::endl;
       
       } else { // launch_status = VEHICLE_INLAUNCH
+        direction_.Normalize();
+        
         //Apply force to the vehicle
         ignition::math::Vector3d force = force_magnitude_ * direction_;
         this->link_->AddForce(force);     


### PR DESCRIPTION
When using the catapult plugin, adding the \<direction> element (e.g., <direction>1.0 0.0 1.0</direction>) causes the original commandSubTopic to be overwritten.

# Steps to Reproduce
1. Configure the catapult plugin in your project.
2. Insert the following line into the plugin configuration:
```xml
<direction>1.0 0.0 1.0</direction>
```
3. Observe that the existing commandSubTopic is overwritten by this addition.
![image](https://github.com/user-attachments/assets/65fd724a-4f6e-4679-9326-e09805233315)
4. Verify that the expected direction value is no longer in effect.
