### PR TITLE
Remove random walk from IMU noise model 

### DIFF
--- a/include/gazebo_imu_plugin.h
+++ b/include/gazebo_imu_plugin.h
@@ -35,23 +35,23 @@
 namespace gazebo {
 //typedef const boost::shared_ptr<const sensor_msgs::msgs::Imu> ImuPtr;
 
-// Default values for use with ADIS16448 IMU
-static constexpr double kDefaultAdisGyroscopeNoiseDensity =
-    2.0 * 35.0 / 3600.0 / 180.0 * M_PI;
-static constexpr double kDefaultAdisGyroscopeRandomWalk =
-    2.0 * 4.0 / 3600.0 / 180.0 * M_PI;
-static constexpr double kDefaultAdisGyroscopeBiasCorrelationTime =
-    1.0e+3;
-static constexpr double kDefaultAdisGyroscopeTurnOnBiasSigma =
-    0.5 / 180.0 * M_PI;
-static constexpr double kDefaultAdisAccelerometerNoiseDensity =
-    2.0 * 2.0e-3;
-static constexpr double kDefaultAdisAccelerometerRandomWalk =
-    2.0 * 3.0e-3;
-static constexpr double kDefaultAdisAccelerometerBiasCorrelationTime =
-    300.0;
-static constexpr double kDefaultAdisAccelerometerTurnOnBiasSigma =
-    20.0e-3 * 9.8;
+// Default values for use with IIM42653 IMU
+static constexpr double kDefaultGyroscopeNoiseDensity =
+    0.0008726646;  // [rad/s/sqrt(Hz)] (0.05 deg/s converted to rad/s)
+static constexpr double kDefaultGyroscopeRandomWalk =
+    0.0;  // [rad/s/s/sqrt(Hz)]
+static constexpr double kDefaultGyroscopeBiasCorrelationTime =
+    1000.0;  // [s]
+static constexpr double kDefaultGyroscopeTurnOnBiasSigma =
+    0.0;  // [rad/s]
+static constexpr double kDefaultAccelerometerNoiseDensity =
+    0.00637;  // [m/s^2/sqrt(Hz)] (0.65 mg-rms converted to m/s^2)
+static constexpr double kDefaultAccelerometerRandomWalk =
+    0.0;  // [m/s^2/s/sqrt(Hz)]
+static constexpr double kDefaultAccelerometerBiasCorrelationTime =
+    300.0;  // [s]
+static constexpr double kDefaultAccelerometerTurnOnBiasSigma =
+    0.0;  // [m/s^2]
 // Earth's gravity in Zurich (lat=+47.3667degN, lon=+8.5500degE, h=+500m, WGS84)
 static constexpr double kDefaultGravityMagnitude = 9.8068;
 
@@ -81,17 +81,17 @@ struct ImuParameters {
   double gravity_magnitude;
 
   ImuParameters()
-      : gyroscope_noise_density(kDefaultAdisGyroscopeNoiseDensity),
-        gyroscope_random_walk(kDefaultAdisGyroscopeRandomWalk),
+      : gyroscope_noise_density(kDefaultGyroscopeNoiseDensity),
+        gyroscope_random_walk(kDefaultGyroscopeRandomWalk),
         gyroscope_bias_correlation_time(
-            kDefaultAdisGyroscopeBiasCorrelationTime),
-        gyroscope_turn_on_bias_sigma(kDefaultAdisGyroscopeTurnOnBiasSigma),
-        accelerometer_noise_density(kDefaultAdisAccelerometerNoiseDensity),
-        accelerometer_random_walk(kDefaultAdisAccelerometerRandomWalk),
+            kDefaultGyroscopeBiasCorrelationTime),
+        gyroscope_turn_on_bias_sigma(kDefaultGyroscopeTurnOnBiasSigma),
+        accelerometer_noise_density(kDefaultAccelerometerNoiseDensity),
+        accelerometer_random_walk(kDefaultAccelerometerRandomWalk),
         accelerometer_bias_correlation_time(
-            kDefaultAdisAccelerometerBiasCorrelationTime),
+            kDefaultAccelerometerBiasCorrelationTime),
         accelerometer_turn_on_bias_sigma(
-            kDefaultAdisAccelerometerTurnOnBiasSigma),
+            kDefaultAccelerometerTurnOnBiasSigma),
         gravity_magnitude(kDefaultGravityMagnitude) {}
 };
 

--- a/models/advanced_plane/advanced_plane.sdf.jinja
+++ b/models/advanced_plane/advanced_plane.sdf.jinja
@@ -692,14 +692,6 @@
       <robotNamespace></robotNamespace>
       <linkName>plane/imu_link</linkName>
       <imuTopic>/imu</imuTopic>
-      <gyroscopeNoiseDensity>0.0003394</gyroscopeNoiseDensity>
-      <gyroscopeRandomWalk>3.8785e-05</gyroscopeRandomWalk>
-      <gyroscopeBiasCorrelationTime>1000.0</gyroscopeBiasCorrelationTime>
-      <gyroscopeTurnOnBiasSigma>0.0087</gyroscopeTurnOnBiasSigma>
-      <accelerometerNoiseDensity>0.004</accelerometerNoiseDensity>
-      <accelerometerRandomWalk>0.006</accelerometerRandomWalk>
-      <accelerometerBiasCorrelationTime>300.0</accelerometerBiasCorrelationTime>
-      <accelerometerTurnOnBiasSigma>0.196</accelerometerTurnOnBiasSigma>
     </plugin>
   </model>
 </sdf>

--- a/models/believer/believer.sdf
+++ b/models/believer/believer.sdf
@@ -567,14 +567,6 @@
       <robotNamespace></robotNamespace>
       <linkName>imu_link</linkName>
       <imuTopic>/imu</imuTopic>
-      <gyroscopeNoiseDensity>0.0003394</gyroscopeNoiseDensity>
-      <gyroscopeRandomWalk>3.8785e-05</gyroscopeRandomWalk>
-      <gyroscopeBiasCorrelationTime>1000.0</gyroscopeBiasCorrelationTime>
-      <gyroscopeTurnOnBiasSigma>0.0087</gyroscopeTurnOnBiasSigma>
-      <accelerometerNoiseDensity>0.004</accelerometerNoiseDensity>
-      <accelerometerRandomWalk>0.006</accelerometerRandomWalk>
-      <accelerometerBiasCorrelationTime>300.0</accelerometerBiasCorrelationTime>
-      <accelerometerTurnOnBiasSigma>0.196</accelerometerTurnOnBiasSigma>
     </plugin>
     <plugin name='groundtruth_plugin' filename='libgazebo_groundtruth_plugin.so'>
       <robotNamespace/>

--- a/models/boat/boat.sdf.jinja
+++ b/models/boat/boat.sdf.jinja
@@ -458,14 +458,6 @@
       <robotNamespace></robotNamespace>
       <linkName>boat/imu_link</linkName>
       <imuTopic>/imu</imuTopic>
-      <gyroscopeNoiseDensity>0.0003394</gyroscopeNoiseDensity>
-      <gyroscopeRandomWalk>3.8785e-05</gyroscopeRandomWalk>
-      <gyroscopeBiasCorrelationTime>1000.0</gyroscopeBiasCorrelationTime>
-      <gyroscopeTurnOnBiasSigma>0.0087</gyroscopeTurnOnBiasSigma>
-      <accelerometerNoiseDensity>0.004</accelerometerNoiseDensity>
-      <accelerometerRandomWalk>0.006</accelerometerRandomWalk>
-      <accelerometerBiasCorrelationTime>300.0</accelerometerBiasCorrelationTime>
-      <accelerometerTurnOnBiasSigma>0.196</accelerometerTurnOnBiasSigma>
     </plugin>
     <plugin name='magnetometer_plugin' filename='libgazebo_magnetometer_plugin.so'>
       <robotNamespace/>

--- a/models/cloudship/cloudship.sdf.jinja
+++ b/models/cloudship/cloudship.sdf.jinja
@@ -499,14 +499,6 @@
       <robotNamespace/>
       <linkName>hull</linkName>
       <imuTopic>/imu</imuTopic>
-      <gyroscopeNoiseDensity>0.0003394</gyroscopeNoiseDensity>
-      <gyroscopeRandomWalk>3.8785e-05</gyroscopeRandomWalk>
-      <gyroscopeBiasCorrelationTime>1000.0</gyroscopeBiasCorrelationTime>
-      <gyroscopeTurnOnBiasSigma>0.0087</gyroscopeTurnOnBiasSigma>
-      <accelerometerNoiseDensity>0.004</accelerometerNoiseDensity>
-      <accelerometerRandomWalk>0.006</accelerometerRandomWalk>
-      <accelerometerBiasCorrelationTime>300.0</accelerometerBiasCorrelationTime>
-      <accelerometerTurnOnBiasSigma>0.196</accelerometerTurnOnBiasSigma>
     </plugin>
 
     {# Magnetometer #}

--- a/models/delta_wing/delta_wing.sdf
+++ b/models/delta_wing/delta_wing.sdf
@@ -250,14 +250,6 @@
       <robotNamespace>delta_wing</robotNamespace>
       <linkName>delta_wing/imu_link</linkName>
       <imuTopic>/imu</imuTopic>
-      <gyroscopeNoiseDensity>0.0003394</gyroscopeNoiseDensity>
-      <gyroscopeRandomWalk>3.8785e-05</gyroscopeRandomWalk>
-      <gyroscopeBiasCorrelationTime>1000.0</gyroscopeBiasCorrelationTime>
-      <gyroscopeTurnOnBiasSigma>0.0087</gyroscopeTurnOnBiasSigma>
-      <accelerometerNoiseDensity>0.004</accelerometerNoiseDensity>
-      <accelerometerRandomWalk>0.006</accelerometerRandomWalk>
-      <accelerometerBiasCorrelationTime>300.0</accelerometerBiasCorrelationTime>
-      <accelerometerTurnOnBiasSigma>0.196</accelerometerTurnOnBiasSigma>
     </plugin>
     <plugin name='groundtruth_plugin' filename='libgazebo_groundtruth_plugin.so'>
       <robotNamespace/>

--- a/models/glider/glider.sdf
+++ b/models/glider/glider.sdf
@@ -551,14 +551,6 @@
       <robotNamespace></robotNamespace>
       <linkName>plane/imu_link</linkName>
       <imuTopic>/imu</imuTopic>
-      <gyroscopeNoiseDensity>0.0003394</gyroscopeNoiseDensity>
-      <gyroscopeRandomWalk>3.8785e-05</gyroscopeRandomWalk>
-      <gyroscopeBiasCorrelationTime>1000.0</gyroscopeBiasCorrelationTime>
-      <gyroscopeTurnOnBiasSigma>0.0087</gyroscopeTurnOnBiasSigma>
-      <accelerometerNoiseDensity>0.004</accelerometerNoiseDensity>
-      <accelerometerRandomWalk>0.006</accelerometerRandomWalk>
-      <accelerometerBiasCorrelationTime>300.0</accelerometerBiasCorrelationTime>
-      <accelerometerTurnOnBiasSigma>0.196</accelerometerTurnOnBiasSigma>
     </plugin>
     <plugin name='groundtruth_plugin' filename='libgazebo_groundtruth_plugin.so'>
       <robotNamespace/>

--- a/models/iris/iris.sdf.jinja
+++ b/models/iris/iris.sdf.jinja
@@ -568,14 +568,8 @@
       <robotNamespace/>
       <linkName>/imu_link</linkName>
       <imuTopic>/imu</imuTopic>
-      <gyroscopeNoiseDensity>0.00018665</gyroscopeNoiseDensity>
-      <gyroscopeRandomWalk>3.8785e-05</gyroscopeRandomWalk>
-      <gyroscopeBiasCorrelationTime>1000.0</gyroscopeBiasCorrelationTime>
-      <gyroscopeTurnOnBiasSigma>0.0087</gyroscopeTurnOnBiasSigma>
-      <accelerometerNoiseDensity>0.00186</accelerometerNoiseDensity>
-      <accelerometerRandomWalk>0.006</accelerometerRandomWalk>
-      <accelerometerBiasCorrelationTime>300.0</accelerometerBiasCorrelationTime>
-      <accelerometerTurnOnBiasSigma>0.196</accelerometerTurnOnBiasSigma>
+      <gyroscopeNoiseDensity>0.0008726646</gyroscopeNoiseDensity>
+      <accelerometerNoiseDensity>0.00637</accelerometerNoiseDensity>
     </plugin>
   </model>
 </sdf>

--- a/models/iris/iris.sdf.jinja
+++ b/models/iris/iris.sdf.jinja
@@ -568,8 +568,6 @@
       <robotNamespace/>
       <linkName>/imu_link</linkName>
       <imuTopic>/imu</imuTopic>
-      <gyroscopeNoiseDensity>0.0008726646</gyroscopeNoiseDensity>
-      <accelerometerNoiseDensity>0.00637</accelerometerNoiseDensity>
     </plugin>
   </model>
 </sdf>

--- a/models/iris_hitl/iris_hitl.sdf
+++ b/models/iris_hitl/iris_hitl.sdf
@@ -607,14 +607,6 @@
       <robotNamespace/>
       <linkName>/imu_link</linkName>
       <imuTopic>/imu</imuTopic>
-      <gyroscopeNoiseDensity>0.00018665</gyroscopeNoiseDensity>
-      <gyroscopeRandomWalk>3.8785e-05</gyroscopeRandomWalk>
-      <gyroscopeBiasCorrelationTime>1000.0</gyroscopeBiasCorrelationTime>
-      <gyroscopeTurnOnBiasSigma>0.0087</gyroscopeTurnOnBiasSigma>
-      <accelerometerNoiseDensity>0.00186</accelerometerNoiseDensity>
-      <accelerometerRandomWalk>0.006</accelerometerRandomWalk>
-      <accelerometerBiasCorrelationTime>300.0</accelerometerBiasCorrelationTime>
-      <accelerometerTurnOnBiasSigma>0.196</accelerometerTurnOnBiasSigma>
     </plugin>
   </model>
 </sdf>

--- a/models/matrice_100/matrice_100.sdf.jinja
+++ b/models/matrice_100/matrice_100.sdf.jinja
@@ -316,14 +316,6 @@
       <robotNamespace></robotNamespace>
       <linkName>fuselage</linkName>
       <imuTopic>/imu</imuTopic>
-      <gyroscopeNoiseDensity>0.0003394</gyroscopeNoiseDensity>
-      <gyroscopeRandomWalk>3.8785e-05</gyroscopeRandomWalk>
-      <gyroscopeBiasCorrelationTime>1000.0</gyroscopeBiasCorrelationTime>
-      <gyroscopeTurnOnBiasSigma>0.0087</gyroscopeTurnOnBiasSigma>
-      <accelerometerNoiseDensity>0.004</accelerometerNoiseDensity>
-      <accelerometerRandomWalk>0.006</accelerometerRandomWalk>
-      <accelerometerBiasCorrelationTime>300.0</accelerometerBiasCorrelationTime>
-      <accelerometerTurnOnBiasSigma>0.196</accelerometerTurnOnBiasSigma>
     </plugin>
 
   </model>

--- a/models/omnicopter/omnicopter.sdf
+++ b/models/omnicopter/omnicopter.sdf
@@ -871,14 +871,6 @@
       <robotNamespace/>
       <linkName>/imu_link</linkName>
       <imuTopic>/imu</imuTopic>
-      <gyroscopeNoiseDensity>0.00018665</gyroscopeNoiseDensity>
-      <gyroscopeRandomWalk>3.8785e-05</gyroscopeRandomWalk>
-      <gyroscopeBiasCorrelationTime>1000.0</gyroscopeBiasCorrelationTime>
-      <gyroscopeTurnOnBiasSigma>0.0087</gyroscopeTurnOnBiasSigma>
-      <accelerometerNoiseDensity>0.00186</accelerometerNoiseDensity>
-      <accelerometerRandomWalk>0.006</accelerometerRandomWalk>
-      <accelerometerBiasCorrelationTime>300.0</accelerometerBiasCorrelationTime>
-      <accelerometerTurnOnBiasSigma>0.196</accelerometerTurnOnBiasSigma>
     </plugin>
   </model>
 </sdf>

--- a/models/plane/plane.sdf.jinja
+++ b/models/plane/plane.sdf.jinja
@@ -760,14 +760,6 @@
       <robotNamespace></robotNamespace>
       <linkName>plane/imu_link</linkName>
       <imuTopic>/imu</imuTopic>
-      <gyroscopeNoiseDensity>0.0003394</gyroscopeNoiseDensity>
-      <gyroscopeRandomWalk>3.8785e-05</gyroscopeRandomWalk>
-      <gyroscopeBiasCorrelationTime>1000.0</gyroscopeBiasCorrelationTime>
-      <gyroscopeTurnOnBiasSigma>0.0087</gyroscopeTurnOnBiasSigma>
-      <accelerometerNoiseDensity>0.004</accelerometerNoiseDensity>
-      <accelerometerRandomWalk>0.006</accelerometerRandomWalk>
-      <accelerometerBiasCorrelationTime>300.0</accelerometerBiasCorrelationTime>
-      <accelerometerTurnOnBiasSigma>0.196</accelerometerTurnOnBiasSigma>
     </plugin>
   </model>
 </sdf>

--- a/models/px4vision/px4vision.sdf
+++ b/models/px4vision/px4vision.sdf
@@ -567,14 +567,6 @@
       <robotNamespace/>
       <linkName>/imu_link</linkName>
       <imuTopic>/imu</imuTopic>
-      <gyroscopeNoiseDensity>0.00018665</gyroscopeNoiseDensity>
-      <gyroscopeRandomWalk>3.8785e-05</gyroscopeRandomWalk>
-      <gyroscopeBiasCorrelationTime>1000.0</gyroscopeBiasCorrelationTime>
-      <gyroscopeTurnOnBiasSigma>0.0087</gyroscopeTurnOnBiasSigma>
-      <accelerometerNoiseDensity>0.00186</accelerometerNoiseDensity>
-      <accelerometerRandomWalk>0.006</accelerometerRandomWalk>
-      <accelerometerBiasCorrelationTime>300.0</accelerometerBiasCorrelationTime>
-      <accelerometerTurnOnBiasSigma>0.196</accelerometerTurnOnBiasSigma>
     </plugin>
     <link name="depthcamera_link">
       <pose>0.08 0.0 -0.01 0 0 0</pose>

--- a/models/quadtailsitter/quadtailsitter.sdf.jinja
+++ b/models/quadtailsitter/quadtailsitter.sdf.jinja
@@ -497,14 +497,6 @@
       <robotNamespace></robotNamespace>
       <linkName>quadtailsitter/imu_link</linkName>
       <imuTopic>/imu</imuTopic>
-      <gyroscopeNoiseDensity>0.0003394</gyroscopeNoiseDensity>
-      <gyroscopeRandomWalk>3.8785e-05</gyroscopeRandomWalk>
-      <gyroscopeBiasCorrelationTime>1000.0</gyroscopeBiasCorrelationTime>
-      <gyroscopeTurnOnBiasSigma>0.0087</gyroscopeTurnOnBiasSigma>
-      <accelerometerNoiseDensity>0.004</accelerometerNoiseDensity>
-      <accelerometerRandomWalk>0.006</accelerometerRandomWalk>
-      <accelerometerBiasCorrelationTime>300.0</accelerometerBiasCorrelationTime>
-      <accelerometerTurnOnBiasSigma>0.196</accelerometerTurnOnBiasSigma>
     </plugin>
     <plugin name='groundtruth_plugin' filename='libgazebo_groundtruth_plugin.so'>
       <robotNamespace/>

--- a/models/r1_rover/r1_rover.sdf.jinja
+++ b/models/r1_rover/r1_rover.sdf.jinja
@@ -528,14 +528,6 @@
       <robotNamespace></robotNamespace>
       <linkName>rover/imu_link</linkName>
       <imuTopic>/imu</imuTopic>
-      <gyroscopeNoiseDensity>0.0003394</gyroscopeNoiseDensity>
-      <gyroscopeRandomWalk>3.8785e-05</gyroscopeRandomWalk>
-      <gyroscopeBiasCorrelationTime>1000.0</gyroscopeBiasCorrelationTime>
-      <gyroscopeTurnOnBiasSigma>0.0087</gyroscopeTurnOnBiasSigma>
-      <accelerometerNoiseDensity>0.004</accelerometerNoiseDensity>
-      <accelerometerRandomWalk>0.006</accelerometerRandomWalk>
-      <accelerometerBiasCorrelationTime>300.0</accelerometerBiasCorrelationTime>
-      <accelerometerTurnOnBiasSigma>0.196</accelerometerTurnOnBiasSigma>
     </plugin>
     <plugin name='groundtruth_plugin' filename='libgazebo_groundtruth_plugin.so'>
       <robotNamespace/>

--- a/models/rover/rover.sdf.jinja
+++ b/models/rover/rover.sdf.jinja
@@ -997,14 +997,6 @@
       <robotNamespace></robotNamespace>
       <linkName>rover/imu_link</linkName>
       <imuTopic>/imu</imuTopic>
-      <gyroscopeNoiseDensity>0.0003394</gyroscopeNoiseDensity>
-      <gyroscopeRandomWalk>3.8785e-05</gyroscopeRandomWalk>
-      <gyroscopeBiasCorrelationTime>1000.0</gyroscopeBiasCorrelationTime>
-      <gyroscopeTurnOnBiasSigma>0.0087</gyroscopeTurnOnBiasSigma>
-      <accelerometerNoiseDensity>0.004</accelerometerNoiseDensity>
-      <accelerometerRandomWalk>0.006</accelerometerRandomWalk>
-      <accelerometerBiasCorrelationTime>300.0</accelerometerBiasCorrelationTime>
-      <accelerometerTurnOnBiasSigma>0.196</accelerometerTurnOnBiasSigma>
     </plugin>
 
   </model>

--- a/models/standard_vtol/standard_vtol.sdf.jinja
+++ b/models/standard_vtol/standard_vtol.sdf.jinja
@@ -983,8 +983,6 @@
       <robotNamespace></robotNamespace>
       <linkName>standard_vtol/imu_link</linkName>
       <imuTopic>/imu</imuTopic>
-      <gyroscopeNoiseDensity>0.0008726646</gyroscopeNoiseDensity>
-      <accelerometerNoiseDensity>0.00637</accelerometerNoiseDensity>
     </plugin>
     <static>0</static>
   </model>

--- a/models/standard_vtol/standard_vtol.sdf.jinja
+++ b/models/standard_vtol/standard_vtol.sdf.jinja
@@ -983,14 +983,8 @@
       <robotNamespace></robotNamespace>
       <linkName>standard_vtol/imu_link</linkName>
       <imuTopic>/imu</imuTopic>
-      <gyroscopeNoiseDensity>0.0003394</gyroscopeNoiseDensity>
-      <gyroscopeRandomWalk>3.8785e-05</gyroscopeRandomWalk>
-      <gyroscopeBiasCorrelationTime>1000.0</gyroscopeBiasCorrelationTime>
-      <gyroscopeTurnOnBiasSigma>0.0087</gyroscopeTurnOnBiasSigma>
-      <accelerometerNoiseDensity>0.004</accelerometerNoiseDensity>
-      <accelerometerRandomWalk>0.006</accelerometerRandomWalk>
-      <accelerometerBiasCorrelationTime>300.0</accelerometerBiasCorrelationTime>
-      <accelerometerTurnOnBiasSigma>0.196</accelerometerTurnOnBiasSigma>
+      <gyroscopeNoiseDensity>0.0008726646</gyroscopeNoiseDensity>
+      <accelerometerNoiseDensity>0.00637</accelerometerNoiseDensity>
     </plugin>
     <static>0</static>
   </model>

--- a/models/standard_vtol_drop/standard_vtol_drop.sdf.jinja
+++ b/models/standard_vtol_drop/standard_vtol_drop.sdf.jinja
@@ -895,14 +895,6 @@
       <robotNamespace></robotNamespace>
       <linkName>standard_vtol/imu_link</linkName>
       <imuTopic>/imu</imuTopic>
-      <gyroscopeNoiseDensity>0.0003394</gyroscopeNoiseDensity>
-      <gyroscopeRandomWalk>3.8785e-05</gyroscopeRandomWalk>
-      <gyroscopeBiasCorrelationTime>1000.0</gyroscopeBiasCorrelationTime>
-      <gyroscopeTurnOnBiasSigma>0.0087</gyroscopeTurnOnBiasSigma>
-      <accelerometerNoiseDensity>0.004</accelerometerNoiseDensity>
-      <accelerometerRandomWalk>0.006</accelerometerRandomWalk>
-      <accelerometerBiasCorrelationTime>300.0</accelerometerBiasCorrelationTime>
-      <accelerometerTurnOnBiasSigma>0.196</accelerometerTurnOnBiasSigma>
     </plugin>
     <plugin name='groundtruth_plugin' filename='libgazebo_groundtruth_plugin.so'>
       <robotNamespace/>

--- a/models/standard_vtol_hitl/standard_vtol_hitl.sdf
+++ b/models/standard_vtol_hitl/standard_vtol_hitl.sdf
@@ -870,14 +870,6 @@
       <robotNamespace></robotNamespace>
       <linkName>standard_vtol_hitl/imu_link</linkName>
       <imuTopic>/imu</imuTopic>
-      <gyroscopeNoiseDensity>0.0003394</gyroscopeNoiseDensity>
-      <gyroscopeRandomWalk>3.8785e-05</gyroscopeRandomWalk>
-      <gyroscopeBiasCorrelationTime>1000.0</gyroscopeBiasCorrelationTime>
-      <gyroscopeTurnOnBiasSigma>0.0087</gyroscopeTurnOnBiasSigma>
-      <accelerometerNoiseDensity>0.004</accelerometerNoiseDensity>
-      <accelerometerRandomWalk>0.006</accelerometerRandomWalk>
-      <accelerometerBiasCorrelationTime>300.0</accelerometerBiasCorrelationTime>
-      <accelerometerTurnOnBiasSigma>0.196</accelerometerTurnOnBiasSigma>
     </plugin>
     <plugin name='groundtruth_plugin' filename='libgazebo_groundtruth_plugin.so'>
       <robotNamespace/>

--- a/models/tailsitter/tailsitter.sdf.jinja
+++ b/models/tailsitter/tailsitter.sdf.jinja
@@ -620,14 +620,8 @@
       <robotNamespace></robotNamespace>
       <linkName>tailsitter/imu_link</linkName>
       <imuTopic>/imu</imuTopic>
-      <gyroscopeNoiseDensity>0.0003394</gyroscopeNoiseDensity>
-      <gyroscopeRandomWalk>3.8785e-05</gyroscopeRandomWalk>
-      <gyroscopeBiasCorrelationTime>1000.0</gyroscopeBiasCorrelationTime>
-      <gyroscopeTurnOnBiasSigma>0.0087</gyroscopeTurnOnBiasSigma>
-      <accelerometerNoiseDensity>0.004</accelerometerNoiseDensity>
-      <accelerometerRandomWalk>0.006</accelerometerRandomWalk>
-      <accelerometerBiasCorrelationTime>300.0</accelerometerBiasCorrelationTime>
-      <accelerometerTurnOnBiasSigma>0.196</accelerometerTurnOnBiasSigma>
+      <gyroscopeNoiseDensity>0.0008726646</gyroscopeNoiseDensity>
+      <accelerometerNoiseDensity>0.00637</accelerometerNoiseDensity>
     </plugin>
     <plugin name='groundtruth_plugin' filename='libgazebo_groundtruth_plugin.so'>
       <robotNamespace/>

--- a/models/tailsitter/tailsitter.sdf.jinja
+++ b/models/tailsitter/tailsitter.sdf.jinja
@@ -620,8 +620,6 @@
       <robotNamespace></robotNamespace>
       <linkName>tailsitter/imu_link</linkName>
       <imuTopic>/imu</imuTopic>
-      <gyroscopeNoiseDensity>0.0008726646</gyroscopeNoiseDensity>
-      <accelerometerNoiseDensity>0.00637</accelerometerNoiseDensity>
     </plugin>
     <plugin name='groundtruth_plugin' filename='libgazebo_groundtruth_plugin.so'>
       <robotNamespace/>

--- a/models/techpod/techpod.sdf
+++ b/models/techpod/techpod.sdf
@@ -628,14 +628,6 @@
       <robotNamespace></robotNamespace>
       <linkName>techpod/imu_link</linkName>
       <imuTopic>/imu</imuTopic>
-      <gyroscopeNoiseDensity>0.0003394</gyroscopeNoiseDensity>
-      <gyroscopeRandomWalk>3.8785e-05</gyroscopeRandomWalk>
-      <gyroscopeBiasCorrelationTime>1000.0</gyroscopeBiasCorrelationTime>
-      <gyroscopeTurnOnBiasSigma>0.0087</gyroscopeTurnOnBiasSigma>
-      <accelerometerNoiseDensity>0.004</accelerometerNoiseDensity>
-      <accelerometerRandomWalk>0.006</accelerometerRandomWalk>
-      <accelerometerBiasCorrelationTime>300.0</accelerometerBiasCorrelationTime>
-      <accelerometerTurnOnBiasSigma>0.196</accelerometerTurnOnBiasSigma>
     </plugin>
     <plugin name='groundtruth_plugin' filename='libgazebo_groundtruth_plugin.so'>
       <robotNamespace/>

--- a/models/tiltrotor/tiltrotor.sdf.jinja
+++ b/models/tiltrotor/tiltrotor.sdf.jinja
@@ -871,14 +871,6 @@
       <robotNamespace></robotNamespace>
       <linkName>tiltrotor/imu_link</linkName>
       <imuTopic>/imu</imuTopic>
-      <gyroscopeNoiseDensity>0.0003394</gyroscopeNoiseDensity>
-      <gyroscopeRandomWalk>3.8785e-05</gyroscopeRandomWalk>
-      <gyroscopeBiasCorrelationTime>1000.0</gyroscopeBiasCorrelationTime>
-      <gyroscopeTurnOnBiasSigma>0.0087</gyroscopeTurnOnBiasSigma>
-      <accelerometerNoiseDensity>0.004</accelerometerNoiseDensity>
-      <accelerometerRandomWalk>0.006</accelerometerRandomWalk>
-      <accelerometerBiasCorrelationTime>300.0</accelerometerBiasCorrelationTime>
-      <accelerometerTurnOnBiasSigma>0.196</accelerometerTurnOnBiasSigma>
     </plugin>
     <plugin name='groundtruth_plugin' filename='libgazebo_groundtruth_plugin.so'>
       <robotNamespace/>

--- a/models/typhoon_h480/typhoon_h480.sdf.jinja
+++ b/models/typhoon_h480/typhoon_h480.sdf.jinja
@@ -1421,14 +1421,6 @@
       <robotNamespace></robotNamespace>
       <linkName>typhoon_h480/imu_link</linkName>
       <imuTopic>/imu</imuTopic>
-      <gyroscopeNoiseDensity>0.0003394</gyroscopeNoiseDensity>
-      <gyroscopeRandomWalk>3.8785e-05</gyroscopeRandomWalk>
-      <gyroscopeBiasCorrelationTime>1000.0</gyroscopeBiasCorrelationTime>
-      <gyroscopeTurnOnBiasSigma>0.0087</gyroscopeTurnOnBiasSigma>
-      <accelerometerNoiseDensity>0.004</accelerometerNoiseDensity>
-      <accelerometerRandomWalk>0.006</accelerometerRandomWalk>
-      <accelerometerBiasCorrelationTime>300.0</accelerometerBiasCorrelationTime>
-      <accelerometerTurnOnBiasSigma>0.196</accelerometerTurnOnBiasSigma>
     </plugin>
     <plugin name='gimbal_controller' filename='libgazebo_gimbal_controller_plugin.so'>
       <joint_yaw>typhoon_h480::cgo3_vertical_arm_joint</joint_yaw>

--- a/models/uuv_bluerov2_heavy/uuv_bluerov2_heavy.sdf.jinja
+++ b/models/uuv_bluerov2_heavy/uuv_bluerov2_heavy.sdf.jinja
@@ -704,14 +704,6 @@
             <robotNamespace/>
             <linkName>uuv_bluerov2_heavy/imu_link</linkName>
             <imuTopic>/imu</imuTopic>
-            <gyroscopeNoiseDensity>0.0003394</gyroscopeNoiseDensity>
-            <gyroscopeRandomWalk>3.8785e-05</gyroscopeRandomWalk>
-            <gyroscopeBiasCorrelationTime>1000.0</gyroscopeBiasCorrelationTime>
-            <gyroscopeTurnOnBiasSigma>0.0087</gyroscopeTurnOnBiasSigma>
-            <accelerometerNoiseDensity>0.004</accelerometerNoiseDensity>
-            <accelerometerRandomWalk>0.006</accelerometerRandomWalk>
-            <accelerometerBiasCorrelationTime>300.0</accelerometerBiasCorrelationTime>
-            <accelerometerTurnOnBiasSigma>0.196</accelerometerTurnOnBiasSigma>
         </plugin>
 
     </model>

--- a/models/uuv_hippocampus/uuv_hippocampus.sdf
+++ b/models/uuv_hippocampus/uuv_hippocampus.sdf
@@ -585,14 +585,6 @@
       <robotNamespace/>
       <linkName>uuv_hippocampus/imu_link</linkName>
       <imuTopic>/imu</imuTopic>
-      <gyroscopeNoiseDensity>0.0003394</gyroscopeNoiseDensity>
-      <gyroscopeRandomWalk>3.8785e-05</gyroscopeRandomWalk>
-      <gyroscopeBiasCorrelationTime>1000.0</gyroscopeBiasCorrelationTime>
-      <gyroscopeTurnOnBiasSigma>0.0087</gyroscopeTurnOnBiasSigma>
-      <accelerometerNoiseDensity>0.004</accelerometerNoiseDensity>
-      <accelerometerRandomWalk>0.006</accelerometerRandomWalk>
-      <accelerometerBiasCorrelationTime>300.0</accelerometerBiasCorrelationTime>
-      <accelerometerTurnOnBiasSigma>0.196</accelerometerTurnOnBiasSigma>
     </plugin>
   </model>
 </sdf>


### PR DESCRIPTION
As discussed on the dev call and discord, the random walk causes very poor altitude hold. I've updated the IMU plugin to disable random walk by setting the default value to 0. Also updated the noise density to match the IIM42653. I removed the noise params from the IMU plugin in all of the sdf files (use defaults in plugin). If a model needs a different IMU noise model we should handle that on a case by case basis.