### PR TITLE
gazebo_mavlink_interface: remove support for MAVLink v1

### DIFF
--- a/include/gazebo_mavlink_interface.h
+++ b/include/gazebo_mavlink_interface.h
@@ -148,8 +148,6 @@ private:
   bool received_first_actuator_{false};
   Eigen::VectorXd input_reference_;
 
-  float protocol_version_{2.0};
-
   std::unique_ptr<MavlinkInterface> mavlink_interface_;
 
   std::string namespace_{kDefaultNamespace};

--- a/src/gazebo_mavlink_interface.cpp
+++ b/src/gazebo_mavlink_interface.cpp
@@ -196,10 +196,6 @@ void GazeboMavlinkInterface::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf
     gzerr << "[gazebo_mavlink_interface] Please specify a robotNamespace.\n";
   }
 
-  if (_sdf->HasElement("protocol_version")) {
-    protocol_version_ = _sdf->GetElement("protocol_version")->Get<float>();
-  }
-
   node_handle_ = transport::NodePtr(new transport::Node());
   node_handle_->Init(namespace_);
 
@@ -539,18 +535,8 @@ void GazeboMavlinkInterface::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf
 
   mavlink_status_t* chan_state = mavlink_get_channel_status(MAVLINK_COMM_0);
 
-  // set the Mavlink protocol version to use on the link
-  if (protocol_version_ == 2.0) {
-    chan_state->flags &= ~(MAVLINK_STATUS_FLAG_OUT_MAVLINK1);
-    gzmsg << "Using MAVLink protocol v2.0\n";
-  }
-  else if (protocol_version_ == 1.0) {
-    chan_state->flags |= MAVLINK_STATUS_FLAG_OUT_MAVLINK1;
-    gzmsg << "Using MAVLink protocol v1.0\n";
-  }
-  else {
-    gzerr << "Unkown protocol version! Using v" << protocol_version_ << "by default \n";
-  }
+  chan_state->flags &= ~(MAVLINK_STATUS_FLAG_OUT_MAVLINK1);
+  gzmsg << "Using MAVLink protocol v2.0\n";
 
   mavlink_interface_->Load();
 }
@@ -963,7 +949,7 @@ void GazeboMavlinkInterface::IRLockCallback(IRLockPtr& irlock_message) {
 }
 
 void GazeboMavlinkInterface::targetReleativeCallback(TargetRelativePtr& targetRelative_message) {
-  
+
   mavlink_target_relative_t sensor_msg;
   sensor_msg.timestamp = targetRelative_message->time_usec();
   sensor_msg.x = targetRelative_message->pos_x();
@@ -1056,7 +1042,7 @@ void GazeboMavlinkInterface::VisionCallback(OdomPtr& odom_message) {
     odom_message->angular_velocity().z()));
 
   // Only sends ODOMETRY msgs if send_odometry is set and the protocol version is 2.0
-  if (send_odometry_ && protocol_version_ == 2.0) {
+  if (send_odometry_) {
     // send ODOMETRY Mavlink msg
     mavlink_odometry_t odom;
 


### PR DESCRIPTION
I thought I'd remove some clutter by only using MAVLink v2. It was default already before and I couldn't find any model that still uses MAVLink v1.

I can't test this pr with my Ubuntu 25.04 setup, sorry for that.

Mildly related to https://github.com/PX4/PX4-Autopilot/pull/25583 but for the simulation use case I don't have any concerns.