### PR TITLE
Use common mavlink, not development

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,6 +115,12 @@ endif()
 # find MAVLink
 find_package(MAVLink)
 
+# Check if MAVLINK_DEVELOPMENT should be defined
+if(MAVLINK_DEVELOPMENT)
+  message(STATUS "MAVLink development dialect enabled")
+  add_definitions(-DMAVLINK_DEVELOPMENT)
+endif()
+
 # see if catkin was invoked to build this
 if (CATKIN_DEVEL_PREFIX)
   message(STATUS "catkin ENABLED")

--- a/include/gazebo_camera_manager_plugin.h
+++ b/include/gazebo_camera_manager_plugin.h
@@ -18,7 +18,6 @@
 
 #include <string>
 #include <opencv2/opencv.hpp>
-#include <development/mavlink.h>
 #include <gazebo/common/Plugin.hh>
 #include <gazebo/sensors/CameraSensor.hh>
 #include <gazebo/gazebo.hh>
@@ -32,6 +31,8 @@
 #include <SITLGps.pb.h>
 #include <ignition/math.hh>
 #include <chrono>
+
+#include "mavlink_include.h"
 
 namespace gazebo
 {

--- a/include/gazebo_gimbal_controller_plugin.hh
+++ b/include/gazebo_gimbal_controller_plugin.hh
@@ -36,7 +36,8 @@
 #include <gazebo/util/system.hh>
 #include <gazebo/sensors/sensors.hh>
 #include <ignition/math.hh>
-#include <development/mavlink.h>
+
+#include "mavlink_include.h"
 
 namespace gazebo
 {

--- a/include/gazebo_mavlink_interface.h
+++ b/include/gazebo_mavlink_interface.h
@@ -71,6 +71,7 @@
 #include <Pressure.pb.h>
 #include <Wind.pb.h>
 
+#include "mavlink_include.h"
 #include "mavlink_interface.h"
 #include "msgbuffer.h"
 
@@ -230,8 +231,11 @@ private:
   transport::SubscriberPtr imu_sub_{nullptr};
   transport::SubscriberPtr opticalFlow_sub_{nullptr};
   transport::SubscriberPtr irlock_sub_{nullptr};
+
+#ifdef MAVLINK_DEVELOPMENT
   transport::SubscriberPtr target_gps_sub_{nullptr};
   transport::SubscriberPtr arucoMarker_sub_{nullptr};
+#endif // MAVLINK_DEVELOPMENT
   transport::SubscriberPtr groundtruth_sub_{nullptr};
   transport::SubscriberPtr vision_sub_{nullptr};
   transport::SubscriberPtr mag_sub_{nullptr};

--- a/include/mavlink_include.h
+++ b/include/mavlink_include.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#ifdef MAVLINK_DEVELOPMENT
+#include <development/mavlink.h>
+#else // MAVLINK_DEVELOPMENT
+#include <common/mavlink.h>
+#endif // MAVLINK_DEVELOPMENT

--- a/include/mavlink_interface.h
+++ b/include/mavlink_interface.h
@@ -49,9 +49,9 @@
 #include <netinet/in.h>
 
 #include <Eigen/Eigen>
-#include<Eigen/StdVector>
+#include <Eigen/StdVector>
 
-#include <development/mavlink.h>
+#include "mavlink_include.h"
 #include "msgbuffer.h"
 
 static const uint32_t kDefaultMavlinkUdpPort = 14560;

--- a/include/msgbuffer.h
+++ b/include/msgbuffer.h
@@ -23,7 +23,7 @@
 #pragma once
 
 #include <cassert>
-#include <development/mavlink.h>
+#include "mavlink_include.h"
 
 namespace gazebo {
 /**

--- a/src/gazebo_camera_manager_plugin.cpp
+++ b/src/gazebo_camera_manager_plugin.cpp
@@ -24,8 +24,6 @@
 #include <boost/algorithm/string.hpp>
 #include <opencv2/opencv.hpp>
 
-#include <development/mavlink.h>
-
 using namespace std;
 using namespace gazebo;
 using namespace cv;

--- a/src/gazebo_mavlink_interface.cpp
+++ b/src/gazebo_mavlink_interface.cpp
@@ -419,8 +419,11 @@ void GazeboMavlinkInterface::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf
   imu_sub_ = node_handle_->Subscribe("~/" + model_->GetName() + imu_sub_topic_, &GazeboMavlinkInterface::ImuCallback, this);
   opticalFlow_sub_ = node_handle_->Subscribe("~/" + model_->GetName() + opticalFlow_sub_topic_, &GazeboMavlinkInterface::OpticalFlowCallback, this);
   irlock_sub_ = node_handle_->Subscribe("~/" + model_->GetName() + irlock_sub_topic_, &GazeboMavlinkInterface::IRLockCallback, this);
+
+#ifdef MAVLINK_DEVELOPMENT
   target_gps_sub_ = node_handle_->Subscribe("~/" + target_gps_sub_topic_, &GazeboMavlinkInterface::TargetGpsCallback, this);
   arucoMarker_sub_ = node_handle_->Subscribe("~/" + model_->GetName() + arucoMarker_sub_topic_, &GazeboMavlinkInterface::targetReleativeCallback, this);
+#endif // MAVLINK_DEVELOPMENT
   groundtruth_sub_ = node_handle_->Subscribe("~/" + model_->GetName() + groundtruth_sub_topic_, &GazeboMavlinkInterface::GroundtruthCallback, this);
   vision_sub_ = node_handle_->Subscribe("~/" + model_->GetName() + vision_sub_topic_, &GazeboMavlinkInterface::VisionCallback, this);
   mag_sub_ = node_handle_->Subscribe("~/" + model_->GetName() + mag_sub_topic_, &GazeboMavlinkInterface::MagnetometerCallback, this);
@@ -948,6 +951,7 @@ void GazeboMavlinkInterface::IRLockCallback(IRLockPtr& irlock_message) {
   mavlink_interface_->send_mavlink_message(&msg);
 }
 
+#ifdef MAVLINK_DEVELOPMENT
 void GazeboMavlinkInterface::targetReleativeCallback(TargetRelativePtr& targetRelative_message) {
 
   mavlink_target_relative_t sensor_msg;
@@ -1005,6 +1009,7 @@ void GazeboMavlinkInterface::TargetGpsCallback(GpsPtr& gps_msg) {
   mavlink_msg_target_absolute_encode_chan(1, 200, MAVLINK_COMM_0, &msg, &gps_data);
   mavlink_interface_->send_mavlink_message(&msg);
 }
+#endif // MAVLINK_DEVELOPMENT
 
 void GazeboMavlinkInterface::VisionCallback(OdomPtr& odom_message) {
   mavlink_message_t msg;


### PR DESCRIPTION
I don't think we should require anything from the development dialect.

Related to https://github.com/PX4/PX4-Autopilot/pull/25834.