### PR TITLE
Camera plugin: Use sequence number to ignore repeat commands

### DIFF
--- a/include/gazebo_camera_manager_plugin.h
+++ b/include/gazebo_camera_manager_plugin.h
@@ -122,6 +122,9 @@ private:
     int                         _componentID{MAV_COMP_ID_CAMERA};
     int                         _mavlinkCamPort{14530};
 
+    double                      _last_single_capture_cmd_seq_num{NAN};
+    std::chrono::time_point<std::chrono::high_resolution_clock> _last_single_capture_cmd_time;
+
     std::chrono::time_point<std::chrono::high_resolution_clock> _start_video_capture_time;
 };
 


### PR DESCRIPTION
## Issue
If I plan/run a survey mission with QGC and PX4's `make px4_sitl gazebo-classic_typhoon_h480` sim, I noticed that sometimes multiple trigger commands for the same photo (aka trigger commands with the same sequence number) were being processed by the gazebo camera plugin.

This is evident because I put a print statement in `CameraManagerPlugin::_handle_take_photo()` and I could see sometimes (occurance is random/intermittent) a command would be received with the same sequence number as the previous command

Other evidence was that there would be more images taken then expected and in QGC I would see unexpected photo-taken-indicators (black circles would sometimes be in unexpected quick succession)
<img width="371" height="479" alt="doubleShots" src="https://github.com/user-attachments/assets/776ba35a-dec6-4c4d-81b9-6f55a05d6592" />
