### PR TITLE
Adjust the position of the force point for the visualization plugin

### DIFF
--- a/models/advanced_plane/advanced_plane.sdf.jinja
+++ b/models/advanced_plane/advanced_plane.sdf.jinja
@@ -50,8 +50,10 @@
           </script>
         </material>
         <plugin name="left_elevon_lift_visual" filename="libForceVisual.so">
+          <link_name>base_link</link_name>
           <topic_name>lift_force/lumped_force</topic_name>
           <color>Gazebo/Green</color>
+          <scale>0.2</scale>
         </plugin>
       </visual>
       <gravity>1</gravity>

--- a/models/glider/glider.sdf
+++ b/models/glider/glider.sdf
@@ -124,8 +124,10 @@
           </script>
         </material>
         <plugin name="left_elevon_lift_visual" filename="libForceVisual.so">
+          <link_name>base_link</link_name>
           <topic_name>lift_force/left_elevon</topic_name>
           <color>Gazebo/Red</color>
+          <scale>0.2</scale>
         </plugin>
       </visual>
     </link>
@@ -157,8 +159,10 @@
           </script>
         </material>
         <plugin name="right_elevon_lift_visual" filename="libForceVisual.so">
+          <link_name>base_link</link_name>
           <topic_name>lift_force/right_elevon</topic_name>
           <color>Gazebo/Green</color>
+          <scale>0.2</scale>
         </plugin>
       </visual>
     </link>
@@ -540,9 +544,9 @@
       <forward>1 0 0</forward>
       <upward>0 1 0</upward>
       <link_name>base_link</link_name>
-      <control_joint_name> 
-         rudder_joint 
-      </control_joint_name> 
+      <control_joint_name>
+         rudder_joint
+      </control_joint_name>
       <control_joint_rad_to_cl>4.0</control_joint_rad_to_cl>
       <robotNamespace></robotNamespace>
       <windSubTopic>world_wind</windSubTopic>

--- a/src/liftdrag_plugin/advanced_liftdrag_plugin.cpp
+++ b/src/liftdrag_plugin/advanced_liftdrag_plugin.cpp
@@ -562,7 +562,7 @@ CL_poststall = 2*(this->alpha/abs(this->alpha))*pow(sinAlpha,2.0)*cosAlpha
   this->link->AddForceAtRelativePosition(force, this->ref_pt);
   this->link->AddTorque(moment);
 
-  auto relative_center = this->link->RelativePose().Pos() + this->ref_pt;
+  auto relative_center = this->link->GetInertial()->Pose().Pos() + this->ref_pt;
 
   // Publish force and center of pressure for potential visual plugin.
   // - dt is used to control the rate at which the force is published

--- a/src/liftdrag_plugin/liftdrag_plugin.cpp
+++ b/src/liftdrag_plugin/liftdrag_plugin.cpp
@@ -435,7 +435,7 @@ void LiftDragPlugin::OnUpdate()
   this->link->AddForceAtRelativePosition(force, this->cp);
   this->link->AddTorque(moment);
 
-  auto relative_center = this->cp;
+  auto relative_center = this->link->GetInertial()->Pose().Pos() + this->cp;
 
   // Publish force and center of pressure for potential visual plugin.
   // - dt is used to control the rate at which the force is published


### PR DESCRIPTION
Adjust the point of force application to the position relative to the center of mass, as we are using the `AddForceAtRelativePosition` function.

Modification:
 - Modify the calculation of relative_center in the lift drag plugin (advanced_liftdrag_plugin and advanced_liftdrag_plugin), adding the offset of the center of mass relative to the origin of the link frame. 
 - Modify the sdf file used with the force_visual plugin to adapt to the current plugin parameters.

Please note that the existing sdf files using the force_visual plugin have the base_link set as follows. Since the `<pose>` tag in `<inertial>` is set to `<pose>0 0 0 0 0 0</pose>`, they are not affected by this change. In more general cases, such as `<pose>0.1 0 0 0 0 0</pose>`, this PR will take effect.
```xml
<link name='base_link'>
      <pose>0 0 0 0 0 0</pose>
      <inertial>
        <pose>0 0 0 0 0 0</pose>
        <mass>1.5</mass>
        <inertia>
          <ixx>0.197563</ixx>
          <ixy>0</ixy>
          <ixz>0</ixz>
          <iyy>0.1458929</iyy>
          <iyz>0</iyz>
          <izz>0.1477</izz>
        </inertia>
      </inertial>
```
