### PR TITLE
fix(mavlink): bound lockstep actuator wait and clean TCP shutdown

### DIFF
--- a/include/mavlink_interface.h
+++ b/include/mavlink_interface.h
@@ -185,7 +185,7 @@ public:
 private:
     bool received_actuator_{false};
     bool received_first_actuator_{false};
-    bool armed_;
+    bool armed_{false};
     Eigen::VectorXd input_reference_;
 
     void handle_message(mavlink_message_t *msg);

--- a/src/mavlink_interface.cpp
+++ b/src/mavlink_interface.cpp
@@ -431,9 +431,9 @@ void MavlinkInterface::pollForMAVLinkMessages()
 
         // client closed the connection orderly, only makes sense on tcp
         if (use_tcp_ && ret == 0) {
-          std::cerr << "Connection closed by client." << "\n";
-          close_conn_ = true;
-          continue;
+          this->close();
+          close_conn_ = false;
+          return;
         }
 
         // data received

--- a/src/mavlink_interface.cpp
+++ b/src/mavlink_interface.cpp
@@ -388,8 +388,11 @@ void MavlinkInterface::pollForMAVLinkMessages()
   received_actuator_ = false;
 
   do {
-    const bool needs_to_wait_for_actuator = received_first_actuator_ && enable_lockstep_;
-    int timeout_ms = needs_to_wait_for_actuator ? 1000 : 0;
+    const bool needs_to_wait_for_actuator = received_first_actuator_ && enable_lockstep_ && armed_;
+    // Keep this below PX4's simulator_mavlink receive timeout. If Gazebo waits
+    // a full second here while PX4 is waiting for the next sensor tick, arming
+    // can turn lockstep into a two-sided timeout loop, especially with gzclient.
+    const int timeout_ms = needs_to_wait_for_actuator ? 10 : 0;
     int ret = ::poll(&fds_[0], N_FDS, timeout_ms);
 
     if (ret < 0) {
@@ -398,9 +401,10 @@ void MavlinkInterface::pollForMAVLinkMessages()
     }
 
     if (ret == 0) {
-      if (needs_to_wait_for_actuator) {
-        std::cerr << "poll timeout\n";
-      }
+      // Missing an actuator packet inside this short wait is expected during
+      // arming mode changes and under gzclient load. Continue the update so
+      // PX4 receives the next sensor tick instead of turning this into a
+      // two-sided lockstep timeout.
       return;
     }
 


### PR DESCRIPTION
﻿### Solved Problem
Submodule changes required by [PX4/PX4-Autopilot#27297](https://github.com/PX4/PX4-Autopilot/pull/27297) (native Windows SITL with lockstep timing).

The current MAVLink interface in `sitl_gazebo-classic` exhibits three lockstep-related issues that surface when running SITL on Windows (and intermittently on other platforms) with strict lockstep timing:

1. The actuator `armed` flag is read by the lockstep receive path before any actuator controls message has arrived, so its initial value is undefined.
2. While waiting for a lockstep actuator packet, the simulator update loop blocks for the full receive timeout. This holds back the next sensor update and produces a two-sided timeout loop during arming.
3. An orderly TCP peer close is not handled as a normal disconnect, so the same closed descriptor is repeatedly processed on subsequent update iterations.

### Solution
- `fix(mavlink): initialize actuator armed state` - start the actuator armed flag in a known disarmed state so the lockstep receive path has defined behavior during simulator startup.
- `fix(mavlink): bound lockstep actuator wait` - keep the simulator update loop moving when a lockstep actuator packet is briefly unavailable. Use a short wait only while armed, then continue with the current actuator state.
- `fix(mavlink): close TCP connection on client shutdown` - handle an orderly TCP peer close as a normal disconnect. Closing the connection immediately resets the MAVLink interface state and avoids repeatedly processing the same closed descriptor.

### Test coverage
Tested in conjunction with [PX4-Autopilot#27297](https://github.com/PX4/PX4-Autopilot/pull/27297). Flight Review log: https://logs.px4.io/plot_app?log=82e5b500-878b-43d2-acde-c587a95ceb90

### Context
Companion PR: PX4/PX4-Autopilot#27297. Both must be merged together; this submodule update first, then the parent PR.